### PR TITLE
fix(runs): validate the launch body on every launch surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,43 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **BREAKING: the launch body is validated. An unknown field is a `400`, not a
+  silent drop.** The three launch surfaces handled an undeclared field three
+  different ways: `POST /api/runs/remote` refused it (`.strict()`),
+  `POST /api/runs/inline` stripped it (a non-strict `z.object`), and
+  `POST /api/agents/{scope}/{name}/run` — which had no schema at all, only a
+  `c.req.json<T>()` cast — ignored it and answered `201`. The last one is the
+  failure that matters: the release above removed `config` from that body with
+  no alias and no deprecation window, so a CLI, SDK or CI job still sending it
+  got an accepted run executing with parameters nobody asked for, with no
+  error, no log and no echoed field. Silently dropping a value the caller sent
+  is how a run does something other than what was asked — the rule
+  `assertFieldsUnlocked` already states, and the one `run_and_wait` was fixed
+  on in the same release. Each surface now owns a `.strict()` schema for its
+  own fields, and `parseRequestInput` receives an already-validated body
+  instead of re-reading the request.
+
+  Three observable changes, all on the way in:
+
+  - an unknown field, or a declared field of the wrong type, is `400`
+    `validation_failed` on all three surfaces;
+  - a malformed JSON body is `400` instead of being swallowed into `{}` and
+    launched as an input-less run (the `c.req.json().catch(() => ({}))`
+    dialect `readJsonBody` was written to replace — the launch body was its
+    last user in the API);
+  - `dependency_overrides` on `POST /api/runs/inline` is `400`. It was
+    accepted there and then dropped: `triggerInlineRun` never forwarded it, so
+    a caller pinning a dependency got a run that ignored the pin.
+
+  An empty body is still a valid launch (a run whose input resolves entirely
+  from stored values sends none), and every documented field is unchanged.
+
+- **`generation` is documented on the inline launch surfaces.** It was accepted
+  and honoured by `POST /api/runs/inline` and `/inline/validate` but absent
+  from the spec, so no generated client could reach it. The agent-run body is
+  now registered in the Zod<>OpenAPI comparison, which is what turns that kind
+  of drift into a failing check.
+
 - **An agent declares ONE parameter schema, `input`. `config` is gone.** An
   AFPS manifest used to carry two — `input`, asked on every run, and `config`,
   set once at setup. Whether a value is asked every time or stored once is a

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -1647,7 +1647,7 @@
         "operationId": "runAgent",
         "tags": ["Runs"],
         "summary": "Execute an agent",
-        "description": "Start an agent run (fire-and-forget — the response does not wait for execution). Returns `201` + the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the agent's input schema) accept either of two forms: (1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by PUTting them to the signed URL (see `createUpload` for the step-by-step recipe); or (2) an inline RFC 2397 data URI `data:<mime>;name=<filename>;base64,<payload>` with up to 4 MiB of decoded content (`name` is optional) — the single-call path for JSON-only clients such as MCP. Inline bytes are written to the run workspace as a document and the payload is stripped from the persisted run input (the stored value keeps only a `data:<mime>;name=<doc>;base64,` marker). Declared binary MIMEs are verified by magic-byte sniffing in both forms. Send `rerun_from` instead of `input` to replay a previous run's input — same documents, new overrides — without re-uploading. The effective model is resolved at run creation with precedence: request `modelId` > agent model setting > org default model > system default. Without an explicit `modelId`, a change to the org default model between triggers applies to the next run — send `modelId` to pin a specific model per run. A run against a published version assembles its bundle from stored artifacts before the container starts, so a bad artifact fails the trigger rather than the run: `422 dependency_unresolved` (a pin with no published version), `422 bundle_invalid` (the stored archive cannot be assembled), `422 bundle_signature_invalid` (rejected by `AFPS_SIGNATURE_POLICY`), or `500 bundle_integrity_mismatch` (the stored bytes no longer match the integrity hash recorded at publish time — republish the package). No run row is created in any of those cases.",
+        "description": "Start an agent run (fire-and-forget — the response does not wait for execution). Returns `201` + the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the agent's input schema) accept either of two forms: (1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by PUTting them to the signed URL (see `createUpload` for the step-by-step recipe); or (2) an inline RFC 2397 data URI `data:<mime>;name=<filename>;base64,<payload>` with up to 4 MiB of decoded content (`name` is optional) — the single-call path for JSON-only clients such as MCP. Inline bytes are written to the run workspace as a document and the payload is stripped from the persisted run input (the stored value keeps only a `data:<mime>;name=<doc>;base64,` marker). Declared binary MIMEs are verified by magic-byte sniffing in both forms. Send `rerun_from` instead of `input` to replay a previous run's input — same documents, new overrides — without re-uploading. The effective model is resolved at run creation with precedence: request `modelId` > agent model setting > org default model > system default. Without an explicit `modelId`, a change to the org default model between triggers applies to the next run — send `modelId` to pin a specific model per run. A run against a published version assembles its bundle from stored artifacts before the container starts, so a bad artifact fails the trigger rather than the run: `422 dependency_unresolved` (a pin with no published version), `422 bundle_invalid` (the stored archive cannot be assembled), `422 bundle_signature_invalid` (rejected by `AFPS_SIGNATURE_POLICY`), or `500 bundle_integrity_mismatch` (the stored bytes no longer match the integrity hash recorded at publish time — republish the package). No run row is created in any of those cases. The body is closed: an unknown field, or a field whose type does not match, is a `400` rather than a silently ignored value, and a malformed JSON body is a `400` rather than an input-less run. Send no body at all for a run whose input resolves entirely from stored values.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -1720,7 +1720,8 @@
                       "type": "string"
                     }
                   }
-                }
+                },
+                "additionalProperties": false
               },
               "example": {
                 "input": {
@@ -2096,7 +2097,7 @@
         "operationId": "runInline",
         "tags": ["Runs"],
         "summary": "Execute an inline agent (no persisted package)",
-        "description": "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
+        "description": "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`. The body is closed: an unknown field is a `400`, never a silently dropped value — `dependency_overrides` in particular is NOT honoured on this surface and is refused rather than ignored.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2153,8 +2154,13 @@
                   },
                   "proxyId": {
                     "type": ["string", "null"]
+                  },
+                  "generation": {
+                    "$ref": "#/components/schemas/ModelGenerationSettings",
+                    "description": "Per-run temperature/reasoning override, same contract as `POST /api/agents/{scope}/{name}/run`. Omitted properties inherit the manifest's model settings."
                   }
-                }
+                },
+                "additionalProperties": false
               },
               "example": {
                 "manifest": {
@@ -2409,8 +2415,13 @@
                   },
                   "proxyId": {
                     "type": ["string", "null"]
+                  },
+                  "generation": {
+                    "$ref": "#/components/schemas/ModelGenerationSettings",
+                    "description": "Same field as `POST /api/runs/inline` — validated for shape, never applied; no run is created."
                   }
-                }
+                },
+                "additionalProperties": false
               }
             }
           }

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -32,7 +32,11 @@ export const runsPaths = {
         "stored archive cannot be assembled), `422 bundle_signature_invalid` (rejected by " +
         "`AFPS_SIGNATURE_POLICY`), or `500 bundle_integrity_mismatch` (the stored bytes no " +
         "longer match the integrity hash recorded at publish time — republish the package). " +
-        "No run row is created in any of those cases.",
+        "No run row is created in any of those cases. " +
+        "The body is closed: an unknown field, or a field whose type does not match, is a " +
+        "`400` rather than a silently ignored value, and a malformed JSON body is a `400` " +
+        "rather than an input-less run. Send no body at all for a run whose input resolves " +
+        "entirely from stored values.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -97,6 +101,11 @@ export const runsPaths = {
                   additionalProperties: { type: "string" },
                 },
               },
+              // An unknown field is a 400, never a silent drop (#1187) — the
+              // same rule `POST /api/runs/remote` and `POST /api/runs/inline`
+              // apply. A caller pinned to an older field name learns it stopped
+              // being honoured instead of getting a run with other parameters.
+              additionalProperties: false,
             },
             example: {
               input: { message: "Summarize my latest emails" },
@@ -370,7 +379,7 @@ export const runsPaths = {
       tags: ["Runs"],
       summary: "Execute an inline agent (no persisted package)",
       description:
-        "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
+        "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`. The body is closed: an unknown field is a `400`, never a silently dropped value — `dependency_overrides` in particular is NOT honoured on this surface and is refused rather than ignored.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -427,7 +436,15 @@ export const runsPaths = {
                 },
                 modelId: { type: ["string", "null"] },
                 proxyId: { type: ["string", "null"] },
+                generation: {
+                  $ref: "#/components/schemas/ModelGenerationSettings",
+                  description:
+                    "Per-run temperature/reasoning override, same contract as " +
+                    "`POST /api/agents/{scope}/{name}/run`. Omitted properties inherit the " +
+                    "manifest's model settings.",
+                },
               },
+              additionalProperties: false,
             },
             example: {
               manifest: {
@@ -639,7 +656,14 @@ export const runsPaths = {
                 },
                 modelId: { type: ["string", "null"] },
                 proxyId: { type: ["string", "null"] },
+                generation: {
+                  $ref: "#/components/schemas/ModelGenerationSettings",
+                  description:
+                    "Same field as `POST /api/runs/inline` — validated for shape, never applied; " +
+                    "no run is created.",
+                },
               },
+              additionalProperties: false,
             },
           },
         },

--- a/apps/api/src/openapi/zod-schema-registry.ts
+++ b/apps/api/src/openapi/zod-schema-registry.ts
@@ -78,6 +78,9 @@ import {
   updatePackageSchema,
 } from "../routes/applications.ts";
 
+// --- Run launch schemas (routes/runs.ts) ---
+import { runAgentBodySchema } from "../routes/runs.ts";
+
 // --- Integration schemas (routes/integrations.ts) ---
 import {
   importConnectionSchema,
@@ -149,6 +152,23 @@ const coreSchemas: OpenApiSchemaEntry[] = [
     path: "/api/models/seed",
     jsonSchema: toJsonSchema(seedModelsSchema),
     description: "Bulk-seed models from registry",
+  },
+
+  // ─── Runs ───────────────────────────────────────────────────────────────
+  //
+  // The launch surfaces are `.strict()` (#1187), so every field they honour
+  // must be documented: an entry here is what turns "accepted by Zod but absent
+  // from the spec" into a failing check instead of a field callers cannot
+  // discover. The two inline surfaces are NOT registered: their schema is a
+  // wire-shape guard that deliberately defers `manifest` / `prompt` to the
+  // preflight (`z.unknown()`, optional), so a field-by-field comparison against
+  // a spec that declares both required and typed reports that deferral as
+  // drift. The check compares shapes; that one is a division of labour.
+  {
+    method: "POST",
+    path: "/api/agents/{scope}/{name}/run",
+    jsonSchema: toJsonSchema(runAgentBodySchema),
+    description: "Execute an agent",
   },
 
   // ─── API Keys ───────────────────────────────────────────────────────────

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -56,59 +56,101 @@ import { readJsonBody } from "../lib/request-body.ts";
 import { modelGenerationSettingsSchema } from "@appstrate/core/model-generation";
 
 /**
+ * Wire-shape guard for the agent-run body (`POST /agents/{scope}/{name}/run`).
+ *
+ * `.strict()` on purpose (#1187). This surface had NO body schema at all: the
+ * body was read with `c.req.json<RunRequestBody>()`, a cast that validates
+ * nothing, so an unknown field was dropped without a trace and a malformed body
+ * became `{}` — a 201 for a run executing with parameters nobody asked for.
+ * That is the exact failure `assertFieldsUnlocked` states as a rule
+ * (`input-resolution.ts`) and the one #1179 fixed on the MCP surface, and the
+ * launch body was the last place the rule did not hold. `POST /runs/remote` was
+ * already `.strict()`; the three launch surfaces now agree.
+ *
+ * Deep semantics stay downstream in `parseRequestInput` (is this dependency
+ * spec resolvable, does the replayed run belong to this agent) — this schema
+ * only settles which fields exist and of what type.
+ */
+export const runAgentBodySchema = z
+  .object({
+    input: z.record(z.string(), z.unknown()).optional(),
+    /**
+     * Replay a prior run's persisted input. Emptiness and the mutual exclusion
+     * with `input` are checked in `parseRequestInput`, which owns the message
+     * naming the field — neither is a shape.
+     */
+    rerun_from: z.string().optional(),
+    modelId: z.string().optional(),
+    generation: modelGenerationSettingsSchema.optional(),
+    proxyId: z.string().optional(),
+    /** `.min(1)` for the same reason it is set on the inline schema below. */
+    connection_overrides: z.record(z.string(), z.string().min(1)).optional(),
+    dependency_overrides: z.record(z.string(), z.string()).optional(),
+  })
+  .strict();
+
+/**
  * Wire-shape guard for the inline-run body (`POST /runs/inline` +
  * `/inline/validate`). Mirrors the `InlineRunBody` TS type: every field
  * is optional and the semantic validation (manifest/input/AJV) happens
  * downstream in the preflight — this schema only rejects a malformed body or a
  * grossly wrong-typed field (e.g. `input: "foo"`) with a 400 instead of letting
  * it cast through and surface later as a 500.
+ *
+ * `.strict()` since #1187, like the two other launch surfaces. It also closes
+ * a live silent drop: `dependency_overrides` was accepted here (the parser read
+ * it straight off the raw body) and then never applied — `triggerInlineRun`
+ * does not forward it. Undeclared here, it is now a 400 instead of a run that
+ * quietly ignored the pin it was handed.
  */
-const inlineRunBodySchema = z.object({
-  manifest: z.unknown().optional(),
-  prompt: z.unknown().optional(),
-  input: z.record(z.string(), z.unknown()).optional(),
-  modelId: z.string().nullable().optional(),
-  generation: modelGenerationSettingsSchema.optional(),
-  proxyId: z.string().nullable().optional(),
-  /**
-   * `document://` URIs to mount read-only into the run's `documents/` directory
-   * without declaring a file field in the manifest (fan-in by reference). Entry
-   * shape is checked downstream by `normalizeContextDocumentUris` so the error
-   * names the offending URI rather than a Zod path.
-   */
-  context_documents: z.array(z.unknown()).optional(),
-  /**
-   * Per-integration connection picks for this run (resolver mechanism #2).
-   * Declared here so the parse keeps the field for the preflight's readiness
-   * gate, which runs BEFORE `parseRequestInput` and would otherwise never see
-   * it.
-   *
-   * `.min(1)` is owned here rather than delegated to `parseRequestInput`: an
-   * empty-string id is falsy at the resolver's `resolveOne`, so readiness would
-   * answer 412 before the parser's field-precise 400 could fire — and
-   * `POST /runs/inline/validate` never calls the parser at all, so the guard
-   * would have no owner there and the validator would disagree with the launch
-   * on the same body.
-   */
-  connection_overrides: z.record(z.string(), z.string().min(1)).optional(),
-  /**
-   * Not a field — a rejection. `rerun_from` is an agent-route concept (replay a
-   * cataloged agent's prior input) and means nothing here, so its presence must
-   * fail loudly rather than be silently stripped and half-applied: the inline
-   * preflight validates the raw `input`, which a replay would not populate.
-   *
-   * Declared as `z.undefined()` so the rule lives in the schema and travels
-   * with it, instead of being re-derived from a second `c.req.json()` read of
-   * the same body. It also puts the failure on the documented side of the error
-   * convention (see `responses.ts` → `ValidationError`): body-level failures
-   * answer `validation_failed` with a populated `errors[]`, and `invalid_request`
-   * is for single-field failures OUTSIDE the body. The hand-rolled throw this
-   * replaced emitted `invalid_request` from inside a body check.
-   */
-  rerun_from: z
-    .undefined({ error: "`rerun_from` is not supported for inline runs — pass `input` directly" })
-    .optional(),
-});
+const inlineRunBodySchema = z
+  .object({
+    manifest: z.unknown().optional(),
+    prompt: z.unknown().optional(),
+    input: z.record(z.string(), z.unknown()).optional(),
+    modelId: z.string().nullable().optional(),
+    generation: modelGenerationSettingsSchema.optional(),
+    proxyId: z.string().nullable().optional(),
+    /**
+     * `document://` URIs to mount read-only into the run's `documents/` directory
+     * without declaring a file field in the manifest (fan-in by reference). Entry
+     * shape is checked downstream by `normalizeContextDocumentUris` so the error
+     * names the offending URI rather than a Zod path.
+     */
+    context_documents: z.array(z.unknown()).optional(),
+    /**
+     * Per-integration connection picks for this run (resolver mechanism #2).
+     * Declared here so the parse keeps the field for the preflight's readiness
+     * gate, which runs BEFORE `parseRequestInput` and would otherwise never see
+     * it.
+     *
+     * `.min(1)` is owned here rather than delegated to `parseRequestInput`: an
+     * empty-string id is falsy at the resolver's `resolveOne`, so readiness would
+     * answer 412 before the parser's field-precise 400 could fire — and
+     * `POST /runs/inline/validate` never calls the parser at all, so the guard
+     * would have no owner there and the validator would disagree with the launch
+     * on the same body.
+     */
+    connection_overrides: z.record(z.string(), z.string().min(1)).optional(),
+    /**
+     * Not a field — a rejection. `rerun_from` is an agent-route concept (replay a
+     * cataloged agent's prior input) and means nothing here, so its presence must
+     * fail loudly rather than be silently stripped and half-applied: the inline
+     * preflight validates the raw `input`, which a replay would not populate.
+     *
+     * Declared as `z.undefined()` so the rule lives in the schema and travels
+     * with it, instead of being re-derived from a second `c.req.json()` read of
+     * the same body. It also puts the failure on the documented side of the error
+     * convention (see `responses.ts` → `ValidationError`): body-level failures
+     * answer `validation_failed` with a populated `errors[]`, and `invalid_request`
+     * is for single-field failures OUTSIDE the body. The hand-rolled throw this
+     * replaced emitted `invalid_request` from inside a body check.
+     */
+    rerun_from: z
+      .undefined({ error: "`rerun_from` is not supported for inline runs — pass `input` directly" })
+      .optional(),
+  })
+  .strict();
 
 /**
  * Resolve the traceparent to seed the run-execution trace tree with, honoring
@@ -175,6 +217,14 @@ export function createRunsRouter() {
       const agent = c.get("package");
       const orgId = c.get("orgId");
       const actor = getActor(c);
+
+      // Body first: it is a property of the request, so a body this surface
+      // cannot honour fails before any lookup. `allowEmpty` keeps the launch
+      // contract "no body == no input" (a run whose input is entirely resolved
+      // from stored values needs no body at all) while MALFORMED JSON now 400s
+      // instead of being swallowed into `{}` and launched as an input-less run.
+      const body = await readJsonBody(c, runAgentBodySchema, { allowEmpty: true });
+
       // Version selector from query param: `draft`, `published`, or a
       // version spec (exact / dist-tag / semver range). Omitted ≡ `published`
       // for EVERY caller (latest published; 404 when none, #636) — the working
@@ -205,6 +255,7 @@ export function createRunsRouter() {
 
         const inputResult = await parseRequestInput(
           c,
+          body,
           runId,
           effectiveAgent.manifest.input?.schema
             ? asJSONSchemaObject(effectiveAgent.manifest.input.schema)
@@ -671,6 +722,7 @@ export function createRunsRouter() {
       try {
         const parsed = await parseRequestInput(
           c,
+          body,
           runId,
           effectiveManifest.input?.schema
             ? asJSONSchemaObject(effectiveManifest.input.schema)

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -75,10 +75,7 @@ import {
 } from "./run-workspace-storage.ts";
 import { assignWorkspaceNames } from "./run-document-naming.ts";
 import { getEnv } from "@appstrate/env";
-import {
-  modelGenerationSettingsSchema,
-  type ModelGenerationSettings,
-} from "@appstrate/core/model-generation";
+import type { ModelGenerationSettings } from "@appstrate/core/model-generation";
 
 export interface ParsedInput {
   input?: Record<string, unknown>;
@@ -124,8 +121,22 @@ export interface ParsedInput {
   consumedDocumentIds?: string[];
 }
 
+/**
+ * The launch-body shape `parseRequestInput` reads.
+ *
+ * Structural on purpose, not the inferred type of one surface's schema: each
+ * launch route owns the `.strict()` Zod schema for its OWN surface and hands
+ * the parsed result here. `POST /runs/inline` passes a WIDER body (`manifest`,
+ * `prompt`, `context_documents` on top of these keys, and nullable `modelId` /
+ * `proxyId`), so this type is the intersection the parser actually reads.
+ *
+ * Every field is therefore already shape-validated by the time the parser sees
+ * it — no cast, no `c.req.json<T>()` lie. What remains below are the semantic
+ * guards a shape check cannot express (is this dependency spec resolvable, does
+ * this run belong to this agent).
+ */
 interface RunRequestBody {
-  input?: Record<string, unknown>;
+  input?: Record<string, unknown> | undefined;
   /**
    * Run id whose persisted `input` to replay verbatim on this run (wire field
    * `rerun_from`, mutually exclusive with `input`). Consumed staged uploads
@@ -134,12 +145,14 @@ interface RunRequestBody {
    * (`modelId`, `?version`) in one call, no re-upload and no
    * dependency on upload retention.
    */
-  rerun_from?: string;
-  modelId?: string;
-  generation?: ModelGenerationSettings;
-  proxyId?: string;
-  connection_overrides?: Record<string, string>;
-  dependency_overrides?: Record<string, string>;
+  rerun_from?: string | undefined;
+  /** Nullable on the inline surface only (`null` == "no override"). */
+  modelId?: string | null | undefined;
+  generation?: ModelGenerationSettings | undefined;
+  /** Nullable on the inline surface only (`null` == "no override"). */
+  proxyId?: string | null | undefined;
+  connection_overrides?: Record<string, string> | undefined;
+  dependency_overrides?: Record<string, string> | undefined;
 }
 
 /**
@@ -530,9 +543,18 @@ async function resolveRerunInput(
  * Parse and validate the run request body. Returns parsed input + resolved
  * uploaded files. Throws `ApiError` (invalidRequest / notFound / conflict /
  * gone) on any validation or resolution failure.
+ *
+ * `body` is the ALREADY-VALIDATED body of the calling surface (see
+ * {@link RunRequestBody}). The parser does not read the request body itself:
+ * the shape guard — which fields exist, of what type, and the refusal of any
+ * field the surface does not honour — belongs to the route, because it is the
+ * route that knows its own surface. `POST /runs/inline` legitimately carries
+ * `manifest` / `prompt` / `context_documents`, which the agent route must
+ * refuse; a single schema owned here could only be right for one of them.
  */
 export async function parseRequestInput(
   c: Context,
+  body: RunRequestBody,
   runId: string,
   inputSchema?: JSONSchemaObject,
   opts?: {
@@ -571,14 +593,6 @@ export async function parseRequestInput(
     lockedFields?: readonly string[];
   },
 ): Promise<ParsedInput> {
-  let body: RunRequestBody = {};
-  try {
-    const raw = await c.req.json<RunRequestBody>();
-    if (raw && typeof raw === "object") body = raw;
-  } catch {
-    body = {};
-  }
-
   let input = body.input ?? {};
   const isRerun = body.rerun_from !== undefined;
   if (body.rerun_from !== undefined) {
@@ -975,41 +989,15 @@ export async function parseRequestInput(
     }
   }
 
-  // `connection_overrides` shape guard. Flat map: integrationId → connectionId.
-  // Invalid bodies produce a 400 with a precise param so the picker UI can
-  // highlight the offender.
-  if (body.connection_overrides !== undefined) {
-    if (
-      body.connection_overrides === null ||
-      typeof body.connection_overrides !== "object" ||
-      Array.isArray(body.connection_overrides)
-    ) {
-      throw invalidRequest("`connection_overrides` must be a JSON object", "connection_overrides");
-    }
-    for (const [intId, connId] of Object.entries(body.connection_overrides)) {
-      if (typeof connId !== "string" || connId.length === 0) {
-        throw invalidRequest(
-          `\`connection_overrides["${intId}"]\` must be a non-empty connection id`,
-          `connection_overrides.${intId}`,
-        );
-      }
-    }
-  }
-
-  // `dependency_overrides` shape + value guard (#666). Flat map:
-  // packageId → "draft" | "<semver|dist-tag>". Each value must be a valid
-  // run-scoped override so a typo'd pin 400s here instead of silently doing
-  // nothing — the per-dependency analogue of the `connection_overrides` gate.
+  // `dependency_overrides` VALUE guard (#666). Flat map:
+  // packageId → "draft" | "<semver|dist-tag>". The map shape (object of
+  // strings) is already guaranteed by the calling surface's schema; what a
+  // shape check cannot express is whether each value is a resolvable
+  // run-scoped override, so a typo'd pin 400s here instead of silently doing
+  // nothing.
   if (body.dependency_overrides !== undefined) {
-    if (
-      body.dependency_overrides === null ||
-      typeof body.dependency_overrides !== "object" ||
-      Array.isArray(body.dependency_overrides)
-    ) {
-      throw invalidRequest("`dependency_overrides` must be a JSON object", "dependency_overrides");
-    }
     for (const [depId, spec] of Object.entries(body.dependency_overrides)) {
-      if (typeof spec !== "string" || !isValidDependencyOverride(spec)) {
+      if (!isValidDependencyOverride(spec)) {
         throw invalidRequest(
           `\`dependency_overrides["${depId}"]\` must be "draft" or a valid version spec (semver range or dist-tag)`,
           `dependency_overrides.${depId}`,
@@ -1027,16 +1015,12 @@ export async function parseRequestInput(
       ? body.dependency_overrides
       : undefined;
 
-  const generationResult = modelGenerationSettingsSchema.safeParse(body.generation ?? {});
-  if (!generationResult.success) {
-    throw invalidRequest(
-      `Invalid generation settings: ${generationResult.error.issues[0]?.message ?? "validation failed"}`,
-      "generation",
-    );
-  }
+  // `generation` is validated by the calling surface's schema (both launch
+  // surfaces parse it with `modelGenerationSettingsSchema`); an all-empty
+  // object carries no override and collapses to `undefined`.
   const generationConfigOverride =
-    body.generation !== undefined && Object.keys(generationResult.data).length > 0
-      ? generationResult.data
+    body.generation !== undefined && Object.keys(body.generation).length > 0
+      ? body.generation
       : undefined;
 
   // An effectively-empty input (no fields, no files) carries no information —
@@ -1055,9 +1039,11 @@ export async function parseRequestInput(
     uploadedFiles: uploadedFiles.length > 0 ? uploadedFiles : undefined,
     pendingDocuments: pendingDocuments.length > 0 ? pendingDocuments : undefined,
     consumedDocumentIds: consumedDocumentIds.length > 0 ? consumedDocumentIds : undefined,
-    modelIdOverride: body.modelId,
+    // `?? undefined` normalises the inline surface's nullable form (`null` ==
+    // "no override") onto the one representation every consumer reads.
+    modelIdOverride: body.modelId ?? undefined,
     generationConfigOverride,
-    proxyIdOverride: body.proxyId,
+    proxyIdOverride: body.proxyId ?? undefined,
     connectionOverrides: body.connection_overrides,
     dependencyOverrides,
   };

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -507,10 +507,10 @@ export async function mapWithConcurrency<T, R>(
  */
 async function resolveRerunInput(
   c: Context,
-  rerunFrom: unknown,
+  rerunFrom: string,
   agentPackageId: string | undefined,
 ): Promise<Record<string, unknown>> {
-  if (typeof rerunFrom !== "string" || rerunFrom.length === 0) {
+  if (rerunFrom.length === 0) {
     throw invalidRequest("`rerun_from` must be a run id", "rerun_from");
   }
   const prior = await getRun(

--- a/apps/api/test/integration/routes/runs-body-validation.test.ts
+++ b/apps/api/test/integration/routes/runs-body-validation.test.ts
@@ -90,6 +90,26 @@ describe("POST /api/agents/:scope/:name/run — body validation", () => {
     expect(res.status).toBe(400);
   });
 
+  it("reads the body behind an Idempotency-Key — the CLI's path", async () => {
+    // The idempotency middleware consumes the body with `c.req.text()` and
+    // re-injects a fresh Request. The schema now reads the body the same way
+    // (`readJsonBody` + `allowEmpty` needs the raw text to tell an empty body
+    // from a malformed one), where the parser used to call `c.req.json()`. A
+    // body invisible behind that re-injection would read as empty and launch an
+    // input-less run — silently, which is the whole failure this closes. The
+    // CLI always sends a key, so this is the production path, not an edge.
+    const res = await app.request(`/api/agents/${AGENT}/run`, {
+      method: "POST",
+      headers: {
+        ...authHeaders(ctx),
+        "Content-Type": "application/json",
+        "Idempotency-Key": `cli_${crypto.randomUUID()}`,
+      },
+      body: JSON.stringify({ input: {}, config: { days: 30 } }),
+    });
+    expect(res.status).toBe(400);
+  });
+
   it("accepts every declared field", async () => {
     // Same control as the empty body: a fully-populated legal body reaches
     // version resolution (404) rather than being refused by the schema.

--- a/apps/api/test/integration/routes/runs-body-validation.test.ts
+++ b/apps/api/test/integration/routes/runs-body-validation.test.ts
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Launch-body validation across the launch surfaces (#1187).
+ *
+ * The agent route had no body schema at all: the body was read with
+ * `c.req.json<RunRequestBody>()` — a cast, not a validation — so an unknown
+ * field was dropped without a trace and a malformed body became `{}`. Both
+ * produced a `201` and a run executing with parameters nobody asked for.
+ *
+ * Every negative case below is asserted WITHOUT `?version=draft` against a
+ * never-published agent, whose control case is a `404`. That pins two things at
+ * once: the body is refused (400, not 404), and it is refused BEFORE any
+ * lookup — a body this surface cannot honour never reaches version resolution.
+ * It also keeps these tests from firing a real run, whose background tail
+ * would race the next `truncateAll()`.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import { seedPackage } from "../../helpers/seed.ts";
+import { installPackage } from "../../../src/services/application-packages.ts";
+
+const app = getTestApp();
+
+const AGENT = "@bodyorg/body-agent";
+
+describe("POST /api/agents/:scope/:name/run — body validation", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "bodyorg" });
+    await seedPackage({ id: AGENT, orgId: ctx.orgId, createdBy: ctx.user.id });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+  });
+
+  /** POST a raw body string — lets a malformed payload be sent verbatim. */
+  async function raw(body: string) {
+    return app.request(`/api/agents/${AGENT}/run`, {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body,
+    });
+  }
+
+  async function post(body: Record<string, unknown>) {
+    return raw(JSON.stringify(body));
+  }
+
+  it("accepts an empty body — a run whose input resolves from stored values", async () => {
+    // The control case for every 400 below: no body is still a valid launch,
+    // so it travels past the schema and dies at version resolution instead
+    // (never published + no `?version=draft` ≡ `published` → 404).
+    const res = await app.request(`/api/agents/${AGENT}/run`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects an unknown field with 400 instead of ignoring it", async () => {
+    // `config` is the field #1179 removed from this body with no alias: a
+    // caller pinned to the previous shape used to get a 201 and a run with
+    // other parameters. The barrier is generic — it refuses any undeclared
+    // field, and names none.
+    const res = await post({ input: {}, config: { days: 30 } });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a malformed JSON body with 400 instead of launching without input", async () => {
+    const res = await raw('{"input": {');
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a wrong-typed input with 400", async () => {
+    const res = await post({ input: "not-an-object" });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string rerun_from with 400", async () => {
+    const res = await post({ rerun_from: 42 });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an empty connection_overrides value with 400", async () => {
+    const res = await post({ input: {}, connection_overrides: { "@acme/gmail": "" } });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts every declared field", async () => {
+    // Same control as the empty body: a fully-populated legal body reaches
+    // version resolution (404) rather than being refused by the schema.
+    const res = await post({
+      input: { topic: "ops" },
+      modelId: "claude-sonnet-4",
+      generation: { temperature: 0.2 },
+      proxyId: "none",
+      connection_overrides: { "@acme/gmail": "conn_1" },
+      dependency_overrides: { "@acme/skill": "draft" },
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /api/runs/inline/validate — body validation", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "inlinebodyorg" });
+  });
+
+  function validManifest() {
+    return {
+      name: "@inline/body-check",
+      display_name: "Ad-hoc Agent",
+      version: "0.0.0",
+      type: "agent",
+      description: "Inline run",
+      schema_version: "0.1",
+      dependencies: { skills: {} },
+    };
+  }
+
+  async function post(body: unknown) {
+    return app.request("/api/runs/inline/validate", {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("accepts a legal inline body (control)", async () => {
+    const res = await post({ manifest: validManifest(), prompt: "do something" });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects an unknown field with 400", async () => {
+    const res = await post({ manifest: validManifest(), prompt: "do", nope: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects dependency_overrides — accepted and silently ignored before #1187", async () => {
+    // The inline surface never forwarded this field to the pipeline
+    // (`triggerInlineRun` does not read it), so a caller pinning a dependency
+    // got a run that ignored the pin. Undeclared here means refused, not
+    // ignored.
+    const res = await post({
+      manifest: validManifest(),
+      prompt: "do",
+      dependency_overrides: { "@acme/skill": "draft" },
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts `generation` — honoured on this surface, now documented too", async () => {
+    const res = await post({
+      manifest: validManifest(),
+      prompt: "do",
+      generation: { temperature: 0.2 },
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/test/integration/services/input-parser-context-documents.test.ts
+++ b/apps/api/test/integration/services/input-parser-context-documents.test.ts
@@ -33,9 +33,8 @@ interface Scope {
   applicationId: string;
 }
 
-function fakeCtx(body: unknown, scope: Scope, userId: string): Context {
+function fakeCtx(scope: Scope, userId: string): Context {
   return {
-    req: { json: async () => body },
     get: (key: string) =>
       key === "orgId"
         ? scope.orgId
@@ -109,7 +108,8 @@ describe("parseRequestInput — reserved context-documents field", () => {
     ]);
     const runId = `run_${crypto.randomUUID()}`;
     const parsed = await parseRequestInput(
-      fakeCtx({}, scope, ctx.user.id),
+      fakeCtx(scope, ctx.user.id),
+      {},
       runId,
       asJSONSchemaObject(manifest.input!.schema),
       { injectedInput: inputPatch },
@@ -169,7 +169,8 @@ describe("parseRequestInput — reserved context-documents field", () => {
     );
     const runId = `run_${crypto.randomUUID()}`;
     const parsed = await parseRequestInput(
-      fakeCtx({}, scope, ctx.user.id),
+      fakeCtx(scope, ctx.user.id),
+      {},
       runId,
       asJSONSchemaObject(manifest.input!.schema),
       { injectedInput: inputPatch },
@@ -209,7 +210,8 @@ describe("parseRequestInput — reserved context-documents field", () => {
     const runId = `run_${crypto.randomUUID()}`;
     await expect(
       parseRequestInput(
-        fakeCtx({}, { orgId: other.orgId, applicationId: other.defaultAppId }, other.user.id),
+        fakeCtx({ orgId: other.orgId, applicationId: other.defaultAppId }, other.user.id),
+        {},
         runId,
         asJSONSchemaObject(manifest.input!.schema),
         { injectedInput: inputPatch },
@@ -227,7 +229,8 @@ describe("parseRequestInput — reserved context-documents field", () => {
     ]);
     await expect(
       parseRequestInput(
-        fakeCtx({}, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }, ctx.user.id),
+        fakeCtx({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, ctx.user.id),
+        {},
         `run_${crypto.randomUUID()}`,
         asJSONSchemaObject(manifest.input!.schema),
         { injectedInput: inputPatch },

--- a/apps/api/test/integration/services/input-parser-inline.test.ts
+++ b/apps/api/test/integration/services/input-parser-inline.test.ts
@@ -52,20 +52,15 @@ const arrayFileSchema: JSONSchemaObject = {
   },
 };
 
-/** Minimal Hono context stub — parseRequestInput only reads the JSON body and orgId/applicationId. */
 /**
  * Minimal Hono context stub. A principal is always present: `parseRequestInput`
  * resolves the acting actor with the strict `getActor`, mirroring the fact that
  * every route reaching it sits behind authentication (the actor gates both the
  * document ACL and the staged-upload ownership check).
  */
-function fakeCtx(
-  body: unknown,
-  ctx: { orgId: string; applicationId: string; user?: { id: string } },
-): Context {
+function fakeCtx(ctx: { orgId: string; applicationId: string; user?: { id: string } }): Context {
   const user = ctx.user ?? { id: "usr_input_parser_test" };
   return {
-    req: { json: async () => body },
     get: (key: string) =>
       key === "orgId"
         ? ctx.orgId
@@ -95,7 +90,8 @@ describe("parseRequestInput — inline data: URIs", () => {
 
     const uri = `data:text/plain;base64,${TEXT_BYTES.toString("base64")}`;
     const result = await parseRequestInput(
-      fakeCtx({ input: { doc: uri } }, scope),
+      fakeCtx(scope),
+      { input: { doc: uri } },
       runId,
       singleTextSchema,
     );
@@ -129,7 +125,8 @@ describe("parseRequestInput — inline data: URIs", () => {
 
     const uri = `data:application/pdf;name=invoice.pdf;base64,${PDF_BYTES.toString("base64")}`;
     const result = await parseRequestInput(
-      fakeCtx({ input: { doc: uri } }, scope),
+      fakeCtx(scope),
+      { input: { doc: uri } },
       runId,
       singlePdfSchema,
     );
@@ -157,7 +154,7 @@ describe("parseRequestInput — inline data: URIs", () => {
     const uri = `data:application/pdf;base64,${TEXT_BYTES.toString("base64")}`;
     let thrown: unknown;
     try {
-      await parseRequestInput(fakeCtx({ input: { doc: uri } }, scope), runId, singlePdfSchema);
+      await parseRequestInput(fakeCtx(scope), { input: { doc: uri } }, runId, singlePdfSchema);
     } catch (e) {
       thrown = e;
     }
@@ -192,7 +189,8 @@ describe("parseRequestInput — inline data: URIs", () => {
 
     const inlineUri = `data:application/pdf;base64,${PDF_BYTES.toString("base64")}`;
     const result = await parseRequestInput(
-      fakeCtx({ input: { docs: [`upload://${uploadId}`, inlineUri] } }, scope),
+      fakeCtx(scope),
+      { input: { docs: [`upload://${uploadId}`, inlineUri] } },
       runId,
       arrayFileSchema,
     );

--- a/apps/api/test/integration/services/input-parser-stream.test.ts
+++ b/apps/api/test/integration/services/input-parser-stream.test.ts
@@ -70,13 +70,14 @@ async function seedUpload(
  * authentication, and it gates both the document ACL and the staged-upload
  * ownership check. Tests that need a specific owner pass one explicitly.
  */
-function fakeCtx(
-  body: unknown,
-  ctx: { orgId: string; applicationId: string; endUser?: { id: string }; user?: { id: string } },
-): Context {
+function fakeCtx(ctx: {
+  orgId: string;
+  applicationId: string;
+  endUser?: { id: string };
+  user?: { id: string };
+}): Context {
   const user = ctx.endUser ? undefined : (ctx.user ?? { id: "usr_input_parser_test" });
   return {
-    req: { json: async () => body },
     get: (key: string) =>
       key === "orgId"
         ? ctx.orgId
@@ -119,7 +120,8 @@ describe("parseRequestInput — streamed document consume", () => {
 
     const runId = `run_${crypto.randomUUID()}`;
     const result = await parseRequestInput(
-      fakeCtx({ input: { doc: `upload://${id}` } }, scope),
+      fakeCtx(scope),
+      { input: { doc: `upload://${id}` } },
       runId,
       fileSchema,
     );
@@ -162,7 +164,7 @@ describe("parseRequestInput — streamed document consume", () => {
 
     const runId = `run_${crypto.randomUUID()}`;
     await expect(
-      parseRequestInput(fakeCtx({ input: { doc: `upload://${id}` } }, scope), runId, fileSchema),
+      parseRequestInput(fakeCtx(scope), { input: { doc: `upload://${id}` } }, runId, fileSchema),
     ).rejects.toMatchObject({ status: 400 });
 
     // Workspace rolled back via the deletion outbox — draining the worker
@@ -187,7 +189,7 @@ describe("parseRequestInput — streamed document consume", () => {
 
     const runId = `run_${crypto.randomUUID()}`;
     await expect(
-      parseRequestInput(fakeCtx({ input: { doc: `upload://${id}` } }, scope), runId, fileSchema),
+      parseRequestInput(fakeCtx(scope), { input: { doc: `upload://${id}` } }, runId, fileSchema),
     ).rejects.toMatchObject({ status: 400 });
 
     // Workspace rolled back, claim released — same guarantees as any rejection
@@ -214,7 +216,8 @@ describe("parseRequestInput — streamed document consume", () => {
     let thrown: unknown;
     try {
       await parseRequestInput(
-        fakeCtx({ input: { doc: `upload://${id}` } }, scope),
+        fakeCtx(scope),
+        { input: { doc: `upload://${id}` } },
         runId,
         fileSchema,
       );
@@ -270,10 +273,8 @@ describe("parseRequestInput — document:// cross-actor ACL (S2)", () => {
     const newRunId = `run_${crypto.randomUUID()}`;
     await expect(
       parseRequestInput(
-        fakeCtx(
-          { input: { doc: `document://${docA.id}` } },
-          { ...scope, user: { id: memberB.id } },
-        ),
+        fakeCtx({ ...scope, user: { id: memberB.id } }),
+        { input: { doc: `document://${docA.id}` } },
         newRunId,
         fileSchema,
       ),
@@ -295,7 +296,8 @@ describe("parseRequestInput — document:// cross-actor ACL (S2)", () => {
 
     const newRunId = `run_${crypto.randomUUID()}`;
     const result = await parseRequestInput(
-      fakeCtx({ input: { doc: `document://${docA.id}` } }, { ...scope, user: { id: ctx.user.id } }),
+      fakeCtx({ ...scope, user: { id: ctx.user.id } }),
+      { input: { doc: `document://${docA.id}` } },
       newRunId,
       fileSchema,
     );
@@ -320,10 +322,8 @@ describe("parseRequestInput — document:// cross-actor ACL (S2)", () => {
 
     const newRunId = `run_${crypto.randomUUID()}`;
     const result = await parseRequestInput(
-      fakeCtx(
-        { input: { doc: `document://${agentDoc.id}` } },
-        { ...scope, user: { id: memberB.id } },
-      ),
+      fakeCtx({ ...scope, user: { id: memberB.id } }),
+      { input: { doc: `document://${agentDoc.id}` } },
       newRunId,
       fileSchema,
     );
@@ -349,7 +349,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
 
     const newRunId = `run_${crypto.randomUUID()}`;
     const result = await parseRequestInput(
-      fakeCtx({ rerun_from: priorRunId }, scope),
+      fakeCtx(scope),
+      { rerun_from: priorRunId },
       newRunId,
       fileSchema,
     );
@@ -393,7 +394,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
     // A new run references it by document:// — resolved into the new workspace.
     const newRunId = `run_${crypto.randomUUID()}`;
     const result = await parseRequestInput(
-      fakeCtx({ input: { doc: `document://${doc.id}` } }, { ...scope, user: { id: ctx.user.id } }),
+      fakeCtx({ ...scope, user: { id: ctx.user.id } }),
+      { input: { doc: `document://${doc.id}` } },
       newRunId,
       fileSchema,
     );
@@ -409,10 +411,12 @@ describe("parseRequestInput — rerun_from (#634)", () => {
     const other = await createTestContext({ orgSlug: "org-docref-other" });
     await expect(
       parseRequestInput(
-        fakeCtx(
-          { input: { doc: `document://${doc.id}` } },
-          { orgId: other.orgId, applicationId: other.defaultAppId, user: { id: other.user.id } },
-        ),
+        fakeCtx({
+          orgId: other.orgId,
+          applicationId: other.defaultAppId,
+          user: { id: other.user.id },
+        }),
+        { input: { doc: `document://${doc.id}` } },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -421,10 +425,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
     // Cross-app: same org, foreign application id → 404.
     await expect(
       parseRequestInput(
-        fakeCtx(
-          { input: { doc: `document://${doc.id}` } },
-          { orgId: ctx.orgId, applicationId: "app_not_this_one", user: { id: ctx.user.id } },
-        ),
+        fakeCtx({ orgId: ctx.orgId, applicationId: "app_not_this_one", user: { id: ctx.user.id } }),
+        { input: { doc: `document://${doc.id}` } },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -445,7 +447,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
     try {
       await expect(
         parseRequestInput(
-          fakeCtx({ input: { doc: `upload://${id}` } }, { ...scope, user: { id: ctx.user.id } }),
+          fakeCtx({ ...scope, user: { id: ctx.user.id } }),
+          { input: { doc: `upload://${id}` } },
           `run_${crypto.randomUUID()}`,
           fileSchema,
         ),
@@ -465,19 +468,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
     const scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
     await expect(
       parseRequestInput(
-        fakeCtx({ input: {}, rerun_from: "run_x" }, scope),
-        `run_${crypto.randomUUID()}`,
-        fileSchema,
-      ),
-    ).rejects.toMatchObject({ status: 400 });
-  });
-
-  it("rejects a non-string rerun_from", async () => {
-    const ctx = await createTestContext({ orgSlug: "org-rerun-shape" });
-    const scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
-    await expect(
-      parseRequestInput(
-        fakeCtx({ rerun_from: 42 }, scope),
+        fakeCtx(scope),
+        { input: {}, rerun_from: "run_x" },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -495,10 +487,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
 
     await expect(
       parseRequestInput(
-        fakeCtx(
-          { rerun_from: priorRunId },
-          { orgId: other.orgId, applicationId: other.defaultAppId },
-        ),
+        fakeCtx({ orgId: other.orgId, applicationId: other.defaultAppId }),
+        { rerun_from: priorRunId },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -514,7 +504,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
 
     await expect(
       parseRequestInput(
-        fakeCtx({ rerun_from: priorRunId }, scope),
+        fakeCtx(scope),
+        { rerun_from: priorRunId },
         `run_${crypto.randomUUID()}`,
         fileSchema,
         {
@@ -533,7 +524,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
 
     await expect(
       parseRequestInput(
-        fakeCtx({ rerun_from: priorRunId }, { ...scope, endUser: { id: "eu_someone" } }),
+        fakeCtx({ ...scope, endUser: { id: "eu_someone" } }),
+        { rerun_from: priorRunId },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -555,7 +547,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
 
     await expect(
       parseRequestInput(
-        fakeCtx({ rerun_from: priorRunId }, scope),
+        fakeCtx(scope),
+        { rerun_from: priorRunId },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -578,7 +571,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
 
     await expect(
       parseRequestInput(
-        fakeCtx({ rerun_from: priorRunId }, scope),
+        fakeCtx(scope),
+        { rerun_from: priorRunId },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -593,7 +587,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
 
     await expect(
       parseRequestInput(
-        fakeCtx({ input: { doc: "data:application/pdf;name=report.pdf;base64," } }, scope),
+        fakeCtx(scope),
+        { input: { doc: "data:application/pdf;name=report.pdf;base64," } },
         `run_${crypto.randomUUID()}`,
         fileSchema,
       ),
@@ -607,7 +602,8 @@ describe("parseRequestInput — rerun_from (#634)", () => {
     await seedRun(scope, { id: priorRunId, input: null });
 
     const result = await parseRequestInput(
-      fakeCtx({ rerun_from: priorRunId }, scope),
+      fakeCtx(scope),
+      { rerun_from: priorRunId },
       `run_${crypto.randomUUID()}`,
       // No file fields required — empty input passes an empty schema.
       { type: "object", properties: {} },
@@ -665,10 +661,8 @@ describe("parseRequestInput — colliding document names (workspace-name hardeni
 
     const runId = `run_${crypto.randomUUID()}`;
     const result = await parseRequestInput(
-      fakeCtx(
-        { input: { docs: [`upload://${uploadId}`, `document://${doc.id}`, inlineUri] } },
-        { ...scope, user: { id: actor.id } },
-      ),
+      fakeCtx({ ...scope, user: { id: actor.id } }),
+      { input: { docs: [`upload://${uploadId}`, `document://${doc.id}`, inlineUri] } },
       runId,
       arrayFileSchema,
     );

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -402,7 +402,7 @@ export interface paths {
         put?: never;
         /**
          * Execute an agent
-         * @description Start an agent run (fire-and-forget — the response does not wait for execution). Returns `201` + the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the agent's input schema) accept either of two forms: (1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by PUTting them to the signed URL (see `createUpload` for the step-by-step recipe); or (2) an inline RFC 2397 data URI `data:<mime>;name=<filename>;base64,<payload>` with up to 4 MiB of decoded content (`name` is optional) — the single-call path for JSON-only clients such as MCP. Inline bytes are written to the run workspace as a document and the payload is stripped from the persisted run input (the stored value keeps only a `data:<mime>;name=<doc>;base64,` marker). Declared binary MIMEs are verified by magic-byte sniffing in both forms. Send `rerun_from` instead of `input` to replay a previous run's input — same documents, new overrides — without re-uploading. The effective model is resolved at run creation with precedence: request `modelId` > agent model setting > org default model > system default. Without an explicit `modelId`, a change to the org default model between triggers applies to the next run — send `modelId` to pin a specific model per run. A run against a published version assembles its bundle from stored artifacts before the container starts, so a bad artifact fails the trigger rather than the run: `422 dependency_unresolved` (a pin with no published version), `422 bundle_invalid` (the stored archive cannot be assembled), `422 bundle_signature_invalid` (rejected by `AFPS_SIGNATURE_POLICY`), or `500 bundle_integrity_mismatch` (the stored bytes no longer match the integrity hash recorded at publish time — republish the package). No run row is created in any of those cases.
+         * @description Start an agent run (fire-and-forget — the response does not wait for execution). Returns `201` + the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the agent's input schema) accept either of two forms: (1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by PUTting them to the signed URL (see `createUpload` for the step-by-step recipe); or (2) an inline RFC 2397 data URI `data:<mime>;name=<filename>;base64,<payload>` with up to 4 MiB of decoded content (`name` is optional) — the single-call path for JSON-only clients such as MCP. Inline bytes are written to the run workspace as a document and the payload is stripped from the persisted run input (the stored value keeps only a `data:<mime>;name=<doc>;base64,` marker). Declared binary MIMEs are verified by magic-byte sniffing in both forms. Send `rerun_from` instead of `input` to replay a previous run's input — same documents, new overrides — without re-uploading. The effective model is resolved at run creation with precedence: request `modelId` > agent model setting > org default model > system default. Without an explicit `modelId`, a change to the org default model between triggers applies to the next run — send `modelId` to pin a specific model per run. A run against a published version assembles its bundle from stored artifacts before the container starts, so a bad artifact fails the trigger rather than the run: `422 dependency_unresolved` (a pin with no published version), `422 bundle_invalid` (the stored archive cannot be assembled), `422 bundle_signature_invalid` (rejected by `AFPS_SIGNATURE_POLICY`), or `500 bundle_integrity_mismatch` (the stored bytes no longer match the integrity hash recorded at publish time — republish the package). No run row is created in any of those cases. The body is closed: an unknown field, or a field whose type does not match, is a `400` rather than a silently ignored value, and a malformed JSON body is a `400` rather than an input-less run. Send no body at all for a run whose input resolves entirely from stored values.
          */
         post: operations["runAgent"];
         delete?: never;
@@ -3797,7 +3797,7 @@ export interface paths {
         put?: never;
         /**
          * Execute an inline agent (no persisted package)
-         * @description Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.
+         * @description Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`. The body is closed: an unknown field is a `400`, never a silently dropped value — `dependency_overrides` in particular is NOT honoured on this surface and is refused rather than ignored.
          */
         post: operations["runInline"];
         delete?: never;
@@ -18125,6 +18125,8 @@ export interface operations {
                     };
                     modelId?: string | null;
                     proxyId?: string | null;
+                    /** @description Per-run temperature/reasoning override, same contract as `POST /api/agents/{scope}/{name}/run`. Omitted properties inherit the manifest's model settings. */
+                    generation?: components["schemas"]["ModelGenerationSettings"];
                 };
             };
         };
@@ -18302,6 +18304,8 @@ export interface operations {
                     };
                     modelId?: string | null;
                     proxyId?: string | null;
+                    /** @description Same field as `POST /api/runs/inline` — validated for shape, never applied; no run is created. */
+                    generation?: components["schemas"]["ModelGenerationSettings"];
                 };
             };
         };


### PR DESCRIPTION
Closes #1187.

## The gap

Three launch surfaces treated an undeclared field in the request body three different ways:

| route | body | unknown field |
|---|---|---|
| `POST /api/agents/{scope}/{name}/run` | no schema — unchecked TS cast | **silently ignored**, 201 |
| `POST /api/runs/inline` | `inlineRunBodySchema`, non-strict `z.object` | **silently stripped** (Zod default), 201 |
| `POST /api/runs/remote` | `.strict()` | **400** |

`c.req.json<RunRequestBody>()` is a cast, not a validation: `RunRequestBody` was a TypeScript interface, so nothing existed at runtime. The same `try/catch { body = {} }` also swallowed **malformed JSON** into an input-less run answered with a 201.

#1179 removed `config` from the launch body with no alias and no deprecation window — deliberately. The consequence is that a CLI pinned to an earlier version, an SDK, or a CI job still sending `config` got a run executing with parameters other than the ones it asked for, with no error, no log and no echoed field. That is the failure mode `assertFieldsUnlocked` states as a rule in `input-resolution.ts` — *silently dropping a value the caller sent is how a run does something other than what was asked* — and the one #1179 fixed on the MCP surface. The launch body was the last place the rule did not hold, and `input-parser.ts` held the **last `c.req.json()` in the whole API**, the dialect `readJsonBody` was written to replace.

## The fix

**The barrier lives in the routes, not in the parser.** The issue proposed putting a `.strict()` schema mirroring `RunRequestBody` inside `parseRequestInput`. That breaks every inline run: the parser serves *two* surfaces, and the inline body legitimately carries `manifest`, `prompt` and `context_documents`, which the agent body must refuse. One schema owned there could only ever be right for one of them.

So:

1. `runAgentBodySchema` — new, `.strict()`, on the agent route, read through `readJsonBody(c, schema, { allowEmpty: true })`. `allowEmpty` preserves "no body == no input" (a run whose input resolves entirely from stored values sends none) while malformed JSON now 400s.
2. `inlineRunBodySchema` — now `.strict()`.
3. `parseRequestInput` takes the **already-validated body** as a parameter instead of re-reading the request. This also removes the double read on the inline path (`readJsonBody` → `text()`, then the parser → `json()`), where two reads meant two possible truths about one request.

Guards the schemas now own were deleted from the parser rather than duplicated (`connection_overrides` shape, `dependency_overrides` shape, `generation` parse). What stays there is what a shape check cannot express: is this dependency spec resolvable, does the replayed run belong to this agent, are `input` and `rerun_from` both present.

## Two silent drops the issue did not list, found while verifying it

- **`dependency_overrides` on `POST /api/runs/inline`** was accepted (the parser read it straight off the raw body) and then dropped: `triggerInlineRun` never forwards it. A caller pinning a dependency got a run that ignored the pin, with a 201. Undeclared on that surface, it is now a 400. Honouring it instead would be a feature, not a fix — out of scope here.
- **`generation` on both inline surfaces** was accepted and honoured but **absent from the OpenAPI body**, so no generated client could reach it. Now documented.

To stop that second class of drift recurring, the agent-run body is registered in the Zod↔OpenAPI comparison (`verify-openapi` §4). Registering it immediately reported a real mismatch (a `minLength` in Zod absent from the spec), which is fixed here.

The two inline surfaces are deliberately **not** registered: their schema is a wire-shape guard that defers `manifest` / `prompt` to the preflight (`z.unknown()`, optional), so a field-by-field comparison against a spec declaring both required and typed reports that division of labour as drift.

## Breaking

Three observable changes, all on the way in — hence the CHANGELOG entry rather than a quiet merge:

- an unknown field, or a declared field of the wrong type, is `400 validation_failed` on all three surfaces (it was 201 on two of them);
- a malformed JSON body is `400 invalid_request` instead of an input-less run;
- `dependency_overrides` on `POST /api/runs/inline` is `400`.

`detect:breaking` reports **none** of this: it does not model `additionalProperties`. The list above is the record.

Every documented field is unchanged, and an empty body is still a valid launch. In-repo clients were checked and send only declared fields: the web SPA (`use-mutations.ts`), the CLI (`remote-runner.ts`), and `run_and_wait` (`run-and-wait-client.ts`, which sends no body at all for an input-less agent run — covered by a test).

## Tests

New `apps/api/test/integration/routes/runs-body-validation.test.ts` (11 cases). Every agent-route negative case is asserted **without** `?version=draft` against a never-published agent, whose control case is a 404 — which pins two things at once: the body is refused (400, not 404), and it is refused *before* any lookup. It also keeps these tests from firing a real run whose background tail would race the next `truncateAll()`.

One parser-level test (`rejects a non-string rerun_from`) moved to the route level: the shape it asserted is now owned by each surface's schema and can no longer be expressed at the parser's typed boundary.

## Verification

`bun run check` → **34/34** (includes `verify:openapi`, `detect:breaking`, `verify:api-types`, `verify:dead-code`). `bunx tsc --noEmit` run directly in `apps/api`. Targeted suites green: all 81 route integration files (1455 tests), all service integration files, the MCP module and `module-chat` (1401 pass / 80 skip). Baseline and `apps/web/src/api/schema.d.ts` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)