### PR TITLE
test(web): cover the live uploader and the client error normalizer

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -80,29 +80,40 @@ const orgContext: Middleware = {
   },
 };
 
+/**
+ * Normalizes a non-2xx response into the error the caller sees. A body with an
+ * RFC 9457 `code` becomes an `ApiError` carrying the problem details; anything
+ * else (an HTML error page, a bare status) degrades to a plain `Error` whose
+ * message is the `detail`, the `statusText`, or the status itself — never an
+ * unhelpful parse failure.
+ */
+export async function toApiError(response: Response): Promise<Error> {
+  const body: Partial<ProblemDetail> = await response
+    .clone()
+    .json()
+    .catch(() => ({ detail: response.statusText }));
+  if (body.code) {
+    return new ApiError(
+      body.code,
+      body.detail || `API Error: ${response.status}`,
+      response.status,
+      // `ApiError.details` is intentionally an open record: the spec models
+      // `errors` as a typed array, but runtime problem bodies are polymorphic
+      // by `code` (validation → array of field errors; conflict codes →
+      // code-specific object), so consumers narrow per `code`. The cast
+      // bridges the spec's array type to that open shape.
+      body.errors as unknown as Record<string, unknown> | undefined,
+      body.requestId,
+      body.param,
+    );
+  }
+  return new Error(body.detail || `API Error: ${response.status}`);
+}
+
 const problemDetailErrors: Middleware = {
   async onResponse({ response }) {
     if (response.ok) return response;
-    const body: Partial<ProblemDetail> = await response
-      .clone()
-      .json()
-      .catch(() => ({ detail: response.statusText }));
-    if (body.code) {
-      throw new ApiError(
-        body.code,
-        body.detail || `API Error: ${response.status}`,
-        response.status,
-        // `ApiError.details` is intentionally an open record: the spec models
-        // `errors` as a typed array, but runtime problem bodies are polymorphic
-        // by `code` (validation → array of field errors; conflict codes →
-        // code-specific object), so consumers narrow per `code`. The cast
-        // bridges the spec's array type to that open shape.
-        body.errors as unknown as Record<string, unknown> | undefined,
-        body.requestId,
-        body.param,
-      );
-    }
-    throw new Error(body.detail || `API Error: ${response.status}`);
+    throw await toApiError(response);
   },
 };
 

--- a/apps/web/src/api/test/client.test.ts
+++ b/apps/web/src/api/test/client.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Error normalization for the typed API client. Every non-2xx response the SPA
+ * ever sees goes through `toApiError`, so this is what decides whether a
+ * failure surfaces as a translatable `ApiError` (with `code`, `status`,
+ * `requestId`, `param`) or as a plain message — and, when the body is not the
+ * problem JSON the spec promises, whether the user reads something meaningful
+ * or a JSON parse failure.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { toApiError } from "../client.ts";
+import { ApiError } from "../errors.ts";
+
+const problem = (body: unknown, status: number, statusText = "") =>
+  new Response(JSON.stringify(body), {
+    status,
+    statusText,
+    headers: { "Content-Type": "application/problem+json" },
+  });
+
+describe("toApiError", () => {
+  it("maps an RFC 9457 body with a code to ApiError, detail first", async () => {
+    const error = await toApiError(
+      problem(
+        {
+          code: "quota_exceeded",
+          detail: "quota exceeded",
+          requestId: "req_1",
+          param: "input.file",
+        },
+        413,
+      ),
+    );
+
+    expect(error).toBeInstanceOf(ApiError);
+    const apiError = error as ApiError;
+    expect(apiError.message).toBe("quota exceeded");
+    expect(apiError.code).toBe("quota_exceeded");
+    expect(apiError.status).toBe(413);
+    expect(apiError.requestId).toBe("req_1");
+    expect(apiError.param).toBe("input.file");
+  });
+
+  it("carries the polymorphic `errors` payload through as details", async () => {
+    const error = (await toApiError(
+      problem({ code: "validation_failed", detail: "invalid", errors: [{ path: "name" }] }, 400),
+    )) as ApiError;
+
+    expect(error.details).toEqual([{ path: "name" }] as never);
+  });
+
+  it("falls back to the status when a coded problem has no detail", async () => {
+    const error = await toApiError(problem({ code: "conflict" }, 409));
+
+    expect(error.message).toBe("API Error: 409");
+  });
+
+  it("degrades to a plain Error when the body has no code", async () => {
+    const error = await toApiError(problem({ detail: "something went wrong" }, 500));
+
+    expect(error).not.toBeInstanceOf(ApiError);
+    expect(error.message).toBe("something went wrong");
+  });
+
+  it("falls back to statusText when the error body is not JSON", async () => {
+    // A proxy or the dev server can answer with HTML; parsing it must not
+    // replace the real failure with a SyntaxError.
+    const error = await toApiError(
+      new Response("<html>oops</html>", { status: 502, statusText: "Bad Gateway" }),
+    );
+
+    expect(error).not.toBeInstanceOf(ApiError);
+    expect(error.message).toBe("Bad Gateway");
+  });
+
+  it("falls back to the status when there is neither a body nor a statusText", async () => {
+    const error = await toApiError(new Response(null, { status: 500, statusText: "" }));
+
+    expect(error.message).toBe("API Error: 500");
+  });
+
+  it("leaves the response body readable for the caller", async () => {
+    // The middleware clones before reading — a consumer inspecting the same
+    // response afterwards must not hit a locked stream.
+    const response = problem({ code: "conflict", detail: "nope" }, 409);
+
+    await toApiError(response);
+
+    expect(await response.json()).toEqual({ code: "conflict", detail: "nope" });
+  });
+});

--- a/apps/web/src/api/test/uploads.test.ts
+++ b/apps/web/src/api/test/uploads.test.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Protocol guards for `uploadClient` — THE uploader behind every file input
+ * (`<SchemaForm upload={...} />` via `hooks/use-upload.ts`).
+ *
+ * The same protocol used to be specified by `packages/ui/test/upload-client.test.ts`,
+ * but it covered `createUploader`, a parallel implementation nothing called;
+ * #1178 removed both. These cases re-anchor it on the implementation that ships.
+ *
+ * Both legs are injected rather than stubbed on `globalThis.fetch`: the typed
+ * client builds a Request from a relative spec path, which only resolves inside
+ * a browser (see the `UploadDeps` note in `uploads.ts`). Injection also keeps
+ * the two legs independently observable — and leaks no global into the rest of
+ * the single-process suite.
+ *
+ * Error-shape behaviour (RFC 9457 `detail`, `statusText` fallback) is NOT
+ * asserted here: `uploads.ts` parses no errors, it inherits them from the
+ * shared client middleware. Those cases live in `client.test.ts`.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { uploadClient } from "../uploads.ts";
+
+const DESCRIPTOR = {
+  id: "upl_abc",
+  uri: "upload://upl_abc",
+  url: "https://storage.example.com/upl_abc",
+  method: "PUT" as const,
+  headers: { "Content-Type": "text/plain" },
+};
+
+interface PostCall {
+  path: string;
+  body: { name: string; size: number; mime: string };
+  signal?: AbortSignal | null;
+}
+interface PutCall {
+  url: string;
+  init?: RequestInit;
+}
+
+/**
+ * A recording stand-in for the two injected legs. `descriptor: null` models a
+ * 2xx with no body (the typed client yields `data: undefined`); `putStatus`
+ * drives the sink so a failing PUT needs no bespoke stub.
+ */
+function harness(options: { descriptor?: typeof DESCRIPTOR | null; putStatus?: number } = {}) {
+  const { descriptor = DESCRIPTOR, putStatus = 200 } = options;
+  const posts: PostCall[] = [];
+  const puts: PutCall[] = [];
+  const deps = {
+    client: {
+      POST: (async (path: string, init: { body: PostCall["body"]; signal?: AbortSignal }) => {
+        posts.push({ path, body: init.body, signal: init.signal });
+        return { data: descriptor ?? undefined, error: undefined, response: new Response() };
+      }) as never,
+    },
+    fetch: (async (url: string | URL | Request, init?: RequestInit) => {
+      puts.push({ url: String(url), init });
+      return new Response(null, {
+        status: putStatus,
+        statusText: putStatus === 502 ? "Bad Gateway" : "",
+      });
+    }) as unknown as typeof globalThis.fetch,
+  };
+  return { deps, posts, puts };
+}
+
+describe("uploadClient", () => {
+  it("POSTs the descriptor, PUTs the bytes to the returned url, returns the uri", async () => {
+    const { deps, posts, puts } = harness();
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+
+    const uri = await uploadClient(file, undefined, deps);
+
+    expect(uri).toBe("upload://upl_abc");
+    expect(posts).toHaveLength(1);
+    expect(posts[0]!.path).toBe("/api/uploads");
+    expect(puts).toHaveLength(1);
+    expect(puts[0]!.url).toBe("https://storage.example.com/upl_abc");
+    expect(puts[0]!.init?.method).toBe("PUT");
+    expect(puts[0]!.init?.headers).toEqual({ "Content-Type": "text/plain" });
+    // The raw bytes, not a FormData wrapper — the sink stores the body verbatim.
+    expect(puts[0]!.init?.body).toBe(file);
+  });
+
+  it("describes the file by name, size and mime in the descriptor request", async () => {
+    const { deps, posts } = harness();
+
+    await uploadClient(new File(["hello"], "hello.txt", { type: "text/plain" }), undefined, deps);
+
+    expect(posts[0]!.body.name).toBe("hello.txt");
+    expect(posts[0]!.body.size).toBe(5);
+    expect(posts[0]!.body.mime).toMatch(/^text\/plain/);
+  });
+
+  it("falls back to application/octet-stream for a file the browser gave no type", async () => {
+    const { deps, posts } = harness();
+
+    // No extension, no explicit type — `file.type` is the empty string, and an
+    // empty mime is not something the sink can store.
+    await uploadClient(new File(["x"], "blob"), undefined, deps);
+
+    expect(posts[0]!.body.mime).toBe("application/octet-stream");
+  });
+
+  it("throws when the sink rejects the PUT", async () => {
+    const { deps } = harness({ putStatus: 502 });
+
+    await expect(uploadClient(new File(["x"], "x.txt"), undefined, deps)).rejects.toThrow(
+      /^upload failed: 502 Bad Gateway$/,
+    );
+  });
+
+  it("throws when the descriptor response carries no body", async () => {
+    const { deps, puts } = harness({ descriptor: null });
+
+    await expect(uploadClient(new File(["x"], "x.txt"), undefined, deps)).rejects.toThrow(
+      "upload failed: empty descriptor response",
+    );
+    // And never reaches the sink with an undefined url.
+    expect(puts).toHaveLength(0);
+  });
+
+  it("forwards the AbortSignal to both legs", async () => {
+    const { deps, posts, puts } = harness();
+    const controller = new AbortController();
+
+    await uploadClient(new File(["x"], "x.txt"), controller.signal, deps);
+
+    // Cancelling the form must cancel the upload in flight, whichever leg it is
+    // on: a signal wired to only one of them leaves the other running.
+    expect(posts[0]!.signal).toBe(controller.signal);
+    expect(puts[0]!.init?.signal).toBe(controller.signal);
+  });
+});

--- a/apps/web/src/api/uploads.ts
+++ b/apps/web/src/api/uploads.ts
@@ -10,8 +10,27 @@
 import type { UploadFn } from "@appstrate/ui/schema-form";
 import { client } from "./client";
 
-export const uploadClient: UploadFn = async (file, signal) => {
-  const { data: desc } = await client.POST("/api/uploads", {
+/**
+ * Test seam, third and defaulted so `uploadClient` still satisfies `UploadFn`.
+ * The spec paths are relative (`/api/uploads`) because the SPA is served
+ * same-origin, and a relative URL only resolves against a document — outside a
+ * browser the typed client cannot even construct its Request, so the descriptor
+ * call is injected rather than stubbed on `globalThis.fetch`. Injecting the PUT
+ * as well keeps the two legs independently observable.
+ */
+interface UploadDeps {
+  client: Pick<typeof client, "POST">;
+  fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+}
+
+const defaultDeps: UploadDeps = {
+  client,
+  // Bound at call time rather than captured, so the live global always wins.
+  fetch: (input, init) => globalThis.fetch(input, init),
+};
+
+export const uploadClient = (async (file, signal, deps: UploadDeps = defaultDeps) => {
+  const { data: desc } = await deps.client.POST("/api/uploads", {
     body: {
       name: file.name,
       size: file.size,
@@ -21,7 +40,7 @@ export const uploadClient: UploadFn = async (file, signal) => {
   });
   if (!desc) throw new Error("upload failed: empty descriptor response");
 
-  const putRes = await fetch(desc.url, {
+  const putRes = await deps.fetch(desc.url, {
     method: desc.method,
     headers: desc.headers,
     body: file,
@@ -31,4 +50,4 @@ export const uploadClient: UploadFn = async (file, signal) => {
     throw new Error(`upload failed: ${putRes.status} ${putRes.statusText}`);
   }
   return desc.uri;
-};
+}) satisfies UploadFn;


### PR DESCRIPTION
Closes #1183.

## Ce que l'issue constatait

`packages/ui/test/upload-client.test.ts` était la seule spécification exécutable du protocole d'upload en 2 étapes du dépôt. #1178 l'a supprimée en même temps que son sujet, `createUploader` — une implémentation parallèle que personne n'appelait. La suppression était correcte ; ce qui restait, c'est que l'uploader **réellement utilisé**, `uploadClient` (`apps/web/src/api/uploads.ts`), n'a jamais eu le moindre test.

Ce n'est donc pas une régression de couverture, mais un trou qui était masqué par le test d'à côté.

## Ce que fait cette PR

**`apps/web/src/api/test/uploads.test.ts`** (6 cas) — le protocole, porté sur l'implémentation qui expédie :

1. descripteur POST → PUT des octets vers l'URL retournée → retour de l'`uri` (octets bruts, pas de `FormData`)
2. `name` / `size` / `mime` envoyés dans la requête de descripteur
3. repli `mime: "application/octet-stream"` pour un fichier sans type
4. `throw` quand le sink rejette le PUT
5. `throw` quand le descripteur revient sans corps, **et** le sink n'est jamais appelé avec une URL `undefined`
6. `AbortSignal` transmis aux **deux** jambes — annuler le formulaire doit annuler l'upload en vol, quelle que soit l'étape en cours

**`apps/web/src/api/test/client.test.ts`** (7 cas) — les deux comportements d'erreur que l'issue listait, placés là où ils vivent vraiment.

`uploads.ts` ne parse aucune erreur : il hérite de la normalisation du middleware du client typé. Les tester à travers `uploadClient` aurait laissé croire l'inverse. Le corps du middleware est donc extrait en `toApiError`, testable comme une unité : mapping RFC 9457 → `ApiError` (`code`, `status`, `requestId`, `param`, `errors`), repli sur `detail` puis `statusText` puis le statut, et le fait que le corps de la réponse reste lisible après coup (le middleware `clone()`). Ce chemin décide de la façon dont **toute** réponse non-2xx remonte dans la SPA, et n'avait aucun test non plus.

## Le seul changement de production visible

`uploadClient` gagne un troisième paramètre `deps`, défaillé — la convention d'injection de dépendances du dépôt (`mock.module()` est proscrit ; même forme que `ssrf-dns.ts`, `enduser-token.ts`, `run-package-catalog.ts`).

Ce n'est pas de la décoration : les chemins du spec sont relatifs (`/api/uploads`) parce que la SPA est servie en same-origin, et une URL relative ne se résout que contre un document. Hors navigateur, le client typé **ne peut même pas construire sa `Request`** (`TypeError: Invalid URL "/api/uploads"`) — un stub de `globalThis.fetch` n'est jamais atteint. Injecter aussi la jambe PUT garde les deux étapes observables séparément et ne fuite aucun global dans la suite mono-processus.

`satisfies UploadFn` remplace l'annotation `: UploadFn`, sinon le paramètre supplémentaire serait invisible pour les appelants ; l'assignabilité au contrat reste vérifiée à la compilation.

## Vérification

Chaque garde a été contrôlée par mutation — supprimer le comportement décrit fait rougir **exactement un** test :

| Mutation | Résultat |
| --- | --- |
| repli `mime` retiré | 1 fail |
| `signal` retiré du PUT | 1 fail |
| `signal` retiré du POST | 1 fail |
| garde descripteur vide retirée | 1 fail |
| contrôle `putRes.ok` retiré | 1 fail |
| repli `statusText` retiré | 1 fail |
| contrôle (code intact) | 21 pass, 0 fail |

`bun test apps/web/src/ packages/ui/` → 555 pass. `tsc --noEmit` + `eslint` propres sur `apps/web`.

## Hors périmètre, sur preuve

`useUploadClient` (`hooks/use-upload.ts`) enveloppe `uploadClient` d'un `invalidateOrgStorage` et reste non testé : le dépôt n'a ni `@testing-library`, ni `happy-dom`, ni aucune infra de rendu de hook (les tests de `hooks/` ne couvrent que des fonctions pures exportées). Le couvrir demanderait d'introduire cette infra, ce qui déborde largement de l'issue.

Note : la suite e2e couvre déjà le côté serveur du protocole (`e2e/tests/uploads/upload-flow.api.spec.ts`) — c'est le client navigateur qui n'avait rien.

🤖 Generated with [Claude Code](https://claude.com/claude-code)