### PR TITLE
Give CLI tests their own output sink instead of capturing the global streams

### DIFF
--- a/apps/cli/src/commands/api/types.ts
+++ b/apps/cli/src/commands/api/types.ts
@@ -7,6 +7,8 @@
  * cycle: api.ts → helpers/*.ts → api.ts).
  */
 
+import { DEFAULT_IO as BASE_IO, type CommandIO } from "../../lib/io.ts";
+
 export interface ApiCommandOptions {
   profile?: string;
   /**
@@ -141,35 +143,23 @@ export interface ApiCommandOptions {
 }
 
 /**
- * Test seam. Production writes directly to `process.stdout.write` etc.;
- * unit tests inject in-memory sinks to assert on output ordering + byte
- * counts without spawning a subprocess.
+ * The shared `CommandIO` seam (see `lib/io.ts`) plus the two hooks only the
+ * `api` command needs: it installs a SIGINT handler and can stream a request
+ * body from stdin, neither of which any other command does.
  */
-export interface ApiCommandIO {
-  stdout: { write(chunk: Uint8Array | string): void };
-  stderr: { write(chunk: Uint8Array | string): void };
-  /** Hook so tests can assert exit codes without terminating the runner. */
-  exit: (code: number) => never;
+export interface ApiCommandIO extends CommandIO {
   /** Install SIGINT handler. Tests pass a no-op to skip. */
   onSigint?: (cb: () => void) => void;
   /** Optional stdin override. Defaults to `Bun.stdin.stream()`. */
   stdinStream?: () => ReadableStream<Uint8Array>;
 }
 
+/**
+ * Production wiring: the shared defaults, extended — not re-implemented — so
+ * stdout / stderr / exit have exactly one definition in the CLI.
+ */
 export const DEFAULT_IO: ApiCommandIO = {
-  stdout: {
-    write(chunk) {
-      if (typeof chunk === "string") process.stdout.write(chunk);
-      else process.stdout.write(chunk);
-    },
-  },
-  stderr: {
-    write(chunk) {
-      if (typeof chunk === "string") process.stderr.write(chunk);
-      else process.stderr.write(chunk);
-    },
-  },
-  exit: (code) => process.exit(code),
+  ...BASE_IO,
   onSigint: (cb) => {
     process.once("SIGINT", cb);
   },

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -10,6 +10,11 @@
  * interactive-picker semantics are identical so adding a third layer
  * (if ever needed) would follow the same rails.
  *
+ * Mirroring extends to the IO seam: every subcommand takes a trailing
+ * `io: CommandIO = DEFAULT_IO` (after `deps`, since `list` and `current`
+ * have no `deps`), so tests capture output in a sink they own instead of
+ * reassigning the process-wide streams — issue #1180.
+ *
  * Subcommands:
  *   app list          — enumerate apps in the pinned org
  *   app switch [ref]  — re-pin (interactive if no arg)
@@ -25,6 +30,7 @@ import {
   type Application,
 } from "../lib/applications.ts";
 import { askText, select, exitWithError } from "../lib/ui.ts";
+import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
 
 interface AppBaseOptions {
   profile?: string;
@@ -74,52 +80,61 @@ const defaultDeps: Required<AppCommandDeps> = {
   },
 };
 
-export async function appListCommand(opts: AppBaseOptions): Promise<void> {
+export async function appListCommand(
+  opts: AppBaseOptions,
+  io: CommandIO = DEFAULT_IO,
+): Promise<void> {
   const { profileName, profile } = await resolveActiveProfile(opts.profile);
-  requireLoggedIn(profileName, profile);
+  requireLoggedIn(profileName, profile, io);
 
   try {
     const apps = await listApplications(profileName);
     if (apps.length === 0) {
-      process.stdout.write("(no applications)\n");
+      io.stdout.write("(no applications)\n");
       return;
     }
     for (const a of apps) {
       const marker = a.id === profile.applicationId ? "*" : " ";
       const def = a.isDefault ? " [default]" : "";
-      process.stdout.write(`${marker} ${a.name.padEnd(24)}  ${a.id}${def}\n`);
+      io.stdout.write(`${marker} ${a.name.padEnd(24)}  ${a.id}${def}\n`);
     }
   } catch (err) {
-    exitWithError(err);
+    // `io` is forwarded so the terminal error and the exit go to the
+    // caller's sink; the default would fire the real `process.exit`.
+    exitWithError(err, io);
   }
 }
 
-export async function appCurrentCommand(opts: AppBaseOptions): Promise<void> {
+export async function appCurrentCommand(
+  opts: AppBaseOptions,
+  io: CommandIO = DEFAULT_IO,
+): Promise<void> {
   const { profile } = await resolveActiveProfile(opts.profile);
   if (!profile) {
-    process.stderr.write("Not logged in. Run: appstrate login\n");
-    process.exit(1);
+    io.stderr.write("Not logged in. Run: appstrate login\n");
+    io.exit(1);
   }
   if (!profile.applicationId) {
-    process.stderr.write("No application pinned. Run: appstrate app switch\n");
-    process.exit(1);
+    io.stderr.write("No application pinned. Run: appstrate app switch\n");
+    io.exit(1);
   }
-  process.stdout.write(`${profile.applicationId}\n`);
+  io.stdout.write(`${profile.applicationId}\n`);
 }
 
 export async function appSwitchCommand(
   opts: AppSwitchOptions,
   deps: AppCommandDeps = {},
+  io: CommandIO = DEFAULT_IO,
 ): Promise<void> {
   const { profileName, profile } = await resolveActiveProfile(opts.profile);
-  requireLoggedIn(profileName, profile);
+  requireLoggedIn(profileName, profile, io);
   const picker = { ...defaultDeps, ...deps };
 
   try {
     const apps = await listApplications(profileName);
     if (apps.length === 0) {
-      process.stderr.write("No applications — run `appstrate app create <name>` to create one.\n");
-      process.exit(1);
+      io.stderr.write("No applications — run `appstrate app create <name>` to create one.\n");
+      io.exit(1);
     }
 
     let chosen: Application;
@@ -128,27 +143,26 @@ export async function appSwitchCommand(
     } else {
       const picked = await picker.pickApp(apps, profile.applicationId);
       if (!picked) {
-        process.stderr.write(
-          "Cannot prompt in non-TTY — pass an id: `appstrate app switch <id>`.\n",
-        );
-        process.exit(1);
+        io.stderr.write("Cannot prompt in non-TTY — pass an id: `appstrate app switch <id>`.\n");
+        io.exit(1);
       }
       chosen = picked;
     }
 
     await updateProfile(profileName, { applicationId: chosen.id });
-    process.stdout.write(`Pinned "${chosen.name}" (${chosen.id}) on profile "${profileName}".\n`);
+    io.stdout.write(`Pinned "${chosen.name}" (${chosen.id}) on profile "${profileName}".\n`);
   } catch (err) {
-    exitWithError(err);
+    exitWithError(err, io);
   }
 }
 
 export async function appCreateCommand(
   opts: AppCreateOptions,
   deps: AppCommandDeps = {},
+  io: CommandIO = DEFAULT_IO,
 ): Promise<void> {
   const { profileName, profile } = await resolveActiveProfile(opts.profile);
-  requireLoggedIn(profileName, profile);
+  requireLoggedIn(profileName, profile, io);
   const picker = { ...defaultDeps, ...deps };
 
   try {
@@ -158,19 +172,17 @@ export async function appCreateCommand(
     } else {
       const prompted = await picker.promptCreateApp();
       if (!prompted) {
-        process.stderr.write(
-          "Cannot prompt in non-TTY — pass a name: `appstrate app create <name>`.\n",
-        );
-        process.exit(1);
+        io.stderr.write("Cannot prompt in non-TTY — pass a name: `appstrate app create <name>`.\n");
+        io.exit(1);
       }
       name = prompted.name;
     }
     const created = await createApplication(profileName, name);
     await updateProfile(profileName, { applicationId: created.id });
-    process.stdout.write(
+    io.stdout.write(
       `Created "${created.name}" (${created.id}) and pinned it on profile "${profileName}".\n`,
     );
   } catch (err) {
-    exitWithError(err);
+    exitWithError(err, io);
   }
 }

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -14,7 +14,7 @@
 import { closeSync, openSync, writeSync } from "node:fs";
 import { join, resolve } from "node:path";
 import * as clack from "@clack/prompts";
-import { intro, outro, askText, confirm, spinner, exitWithError } from "../lib/ui.ts";
+import { intro, outro, askText, confirm, withSpinner, exitWithError } from "../lib/ui.ts";
 import {
   generateBootstrapToken,
   generateEnvForTier,
@@ -29,7 +29,6 @@ import {
 import {
   assertDockerAvailable,
   checkDockerNetworkBudget,
-  DockerMissingError,
   dockerComposeUp,
   findRunningComposeProject as findRunningComposeProjectImport,
   isDockerAvailable,
@@ -1573,10 +1572,7 @@ async function installTier0(
     if (!proceed) {
       throw new Error("Tier 0 needs Bun. Install it manually from https://bun.sh and re-run.");
     }
-    const bunSpinner = spinner();
-    bunSpinner.start("Installing Bun");
-    await installBun();
-    bunSpinner.stop("Bun installed");
+    await withSpinner("Installing Bun", () => installBun(), "Bun installed");
     // No re-probe: `installBun()` placed the binary at `~/.bun/bin/bun`
     // and verified it via `access()`. Downstream spawns PATH-resolve
     // through `bunEnv()`, which includes BUN_BIN.
@@ -1588,17 +1584,15 @@ async function installTier0(
   // static package.json import in `lib/version.ts`; falling back to
   // `undefined` when the value is a dev placeholder lets `main` be
   // checked out instead of a bogus tag.
-  const cloneSpinner = spinner();
-  cloneSpinner.start("Cloning Appstrate source");
   const versionTag = CLI_VERSION === "0.0.0" ? undefined : `v${CLI_VERSION}`;
-  await cloneAppstrateSource(dir, { version: versionTag });
-  cloneSpinner.stop("Source cloned");
+  await withSpinner(
+    "Cloning Appstrate source",
+    () => cloneAppstrateSource(dir, { version: versionTag }),
+    "Source cloned",
+  );
 
   // Dependencies.
-  const installSpinner = spinner();
-  installSpinner.start("Installing dependencies");
-  await runBunInstall(dir);
-  installSpinner.stop("Dependencies installed");
+  await withSpinner("Installing dependencies", () => runBunInstall(dir), "Dependencies installed");
 
   // `.env`.
   const env = generateEnvForTier(0, appUrl, { port }, opts.bootstrap);
@@ -1617,10 +1611,11 @@ async function installTier0(
     return;
   }
 
-  const devSpinner = spinner();
-  devSpinner.start("Starting dev server");
-  const { pid } = await spawnDevServer(dir, localUrl);
-  devSpinner.stop(`Dev server running (pid ${pid})`);
+  const { pid } = await withSpinner(
+    "Starting dev server",
+    () => spawnDevServer(dir, localUrl),
+    (started) => `Dev server running (pid ${started.pid})`,
+  );
 
   await openBrowser(postInstallBrowserUrl(localUrl, opts.bootstrap));
   printBootstrapFollowup(appUrl, opts.bootstrap);
@@ -1764,16 +1759,9 @@ async function installDockerTier(
   // reverse proxy is configured, which happens AFTER the install.
   const localUrl = appUrlForPort(port);
   // Docker.
-  const dockerSpinner = spinner();
-  dockerSpinner.start("Checking Docker");
-  try {
-    await assertDockerAvailable();
-    dockerSpinner.stop("Docker OK");
-  } catch (err) {
-    dockerSpinner.stop("Docker not found");
-    if (err instanceof DockerMissingError) throw err;
-    throw err;
-  }
+  await withSpinner("Checking Docker", () => assertDockerAvailable(), "Docker OK", {
+    errorLabel: "Docker not found",
+  });
 
   // Informational pre-flight: Docker's default address pool (~31 user-defined
   // networks) is easy to exhaust once Appstrate's stack plus per-run networks
@@ -1842,35 +1830,34 @@ async function installDockerTier(
     backedUp,
     async () => {
       // Compose + .env.
-      const writeSpinner = spinner();
-      writeSpinner.start(
+      await withSpinner(
         mode === "upgrade" ? "Rewriting compose + merging .env" : "Writing compose + .env",
-      );
-      await writeComposeFile(dir, tier);
-      const fresh = generateEnvForTier(tier, appUrl, { port }, opts.bootstrap, runBackendEnv);
-      let envVars = mode === "upgrade" ? mergeEnv(existing.existingEnv, fresh) : fresh;
-      // Firecracker pairing token/URL must track the CURRENT install, not
-      // whatever `mergeEnv` happened to keep: `runSameHostRunnerInstall` below
-      // (and the remote one-liner) pair the daemon with `runBackend.token`, so
-      // the platform `.env` must carry that exact token. `runBackend.token` was
-      // already resolved by `seedUpgradeRunnerToken` above — on a remote/generated
-      // upgrade it holds the PRESERVED token so we don't rotate the platform away
-      // from the daemon; otherwise it's the flag/minted token being (re-)paired.
-      if (mode === "upgrade" && runBackend.adapter === "firecracker") {
-        envVars = {
-          ...envVars,
-          FIRECRACKER_RUNNER_URL: runBackend.runnerUrl,
-          FIRECRACKER_RUNNER_TOKEN: runBackend.token,
-        };
-        // The plaintext escape hatch tracks the CURRENT runner URL. Carrying
-        // a stale `=0` forward after the operator moved to https:// (or to
-        // the unix socket) would silently keep the plaintext door open for
-        // the next http:// misconfiguration.
-        if (runBackend.plaintextOptIn) envVars.FIRECRACKER_RUNNER_TLS_REQUIRED = "0";
-        else delete envVars.FIRECRACKER_RUNNER_TLS_REQUIRED;
-      }
-      await writeComposeEnv(dir, renderEnvFile(envVars));
-      writeSpinner.stop(
+        async () => {
+          await writeComposeFile(dir, tier);
+          const fresh = generateEnvForTier(tier, appUrl, { port }, opts.bootstrap, runBackendEnv);
+          let envVars = mode === "upgrade" ? mergeEnv(existing.existingEnv, fresh) : fresh;
+          // Firecracker pairing token/URL must track the CURRENT install, not
+          // whatever `mergeEnv` happened to keep: `runSameHostRunnerInstall` below
+          // (and the remote one-liner) pair the daemon with `runBackend.token`, so
+          // the platform `.env` must carry that exact token. `runBackend.token` was
+          // already resolved by `seedUpgradeRunnerToken` above — on a remote/generated
+          // upgrade it holds the PRESERVED token so we don't rotate the platform away
+          // from the daemon; otherwise it's the flag/minted token being (re-)paired.
+          if (mode === "upgrade" && runBackend.adapter === "firecracker") {
+            envVars = {
+              ...envVars,
+              FIRECRACKER_RUNNER_URL: runBackend.runnerUrl,
+              FIRECRACKER_RUNNER_TOKEN: runBackend.token,
+            };
+            // The plaintext escape hatch tracks the CURRENT runner URL. Carrying
+            // a stale `=0` forward after the operator moved to https:// (or to
+            // the unix socket) would silently keep the plaintext door open for
+            // the next http:// misconfiguration.
+            if (runBackend.plaintextOptIn) envVars.FIRECRACKER_RUNNER_TLS_REQUIRED = "0";
+            else delete envVars.FIRECRACKER_RUNNER_TLS_REQUIRED;
+          }
+          await writeComposeEnv(dir, renderEnvFile(envVars));
+        },
         mode === "upgrade"
           ? `Rewrote ${dir}/docker-compose.yml (secrets preserved)`
           : `Wrote ${dir}/docker-compose.yml + .env`,
@@ -1879,16 +1866,18 @@ async function installDockerTier(
       // Bring stack up. The project name is pinned via `--project-name`
       // rather than baked into the compose template, so two installs
       // under different dirs get isolated namespaces.
-      const upSpinner = spinner();
-      upSpinner.start(`Starting Appstrate (docker compose --project-name ${project.name} up -d)`);
-      await dockerComposeUp(dir, project.name);
-      upSpinner.stop("Containers up");
+      await withSpinner(
+        `Starting Appstrate (docker compose --project-name ${project.name} up -d)`,
+        () => dockerComposeUp(dir, project.name),
+        "Containers up",
+      );
 
       // Healthcheck.
-      const healthSpinner = spinner();
-      healthSpinner.start("Waiting for Appstrate to become healthy");
-      await waitForAppstrate(localUrl);
-      healthSpinner.stop("Appstrate is healthy");
+      await withSpinner(
+        "Waiting for Appstrate to become healthy",
+        () => waitForAppstrate(localUrl),
+        "Appstrate is healthy",
+      );
 
       // Persist the project-name binding on success. Written AFTER the
       // healthcheck so a stack that never came up doesn't leave a

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -31,7 +31,7 @@ import {
   outro,
   askText,
   select,
-  spinner,
+  withSpinner,
   formatUserCode,
   exitWithError,
 } from "../lib/ui.ts";
@@ -189,10 +189,12 @@ async function runLogin(
   io: CommandIO,
 ): Promise<void> {
   // Step 1 — device code.
-  const s = spinner(io);
-  s.start("Requesting device code");
-  const code = await startDeviceFlow(instance, CLI_CLIENT_ID, CLI_SCOPE);
-  s.stop(`Code received — expires in ${Math.round(code.expiresIn / 60)}m`);
+  const code = await withSpinner(
+    "Requesting device code",
+    () => startDeviceFlow(instance, CLI_CLIENT_ID, CLI_SCOPE),
+    (issued) => `Code received — expires in ${Math.round(issued.expiresIn / 60)}m`,
+    { io },
+  );
 
   const display = formatUserCode(code.userCode);
 
@@ -207,14 +209,17 @@ async function runLogin(
   defaultOpenUrl(code.verificationUriComplete).catch(() => {});
 
   // Step 4 — poll until approval or terminal error.
-  const pollSpinner = spinner(io);
-  pollSpinner.start("Waiting for approval in your browser");
-  const token = await pollDeviceFlow(instance, code.deviceCode, CLI_CLIENT_ID, {
-    interval: code.interval,
-    expiresIn: code.expiresIn,
-    deviceName: opts.deviceName,
-  });
-  pollSpinner.stop("Approved");
+  const token = await withSpinner(
+    "Waiting for approval in your browser",
+    () =>
+      pollDeviceFlow(instance, code.deviceCode, CLI_CLIENT_ID, {
+        interval: code.interval,
+        expiresIn: code.expiresIn,
+        deviceName: opts.deviceName,
+      }),
+    "Approved",
+    { io },
+  );
 
   // Step 5 — extract identity from the access token claims. The JWT
   // minted by /api/auth/cli/token carries `sub` (BA user id), `email`,

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -35,6 +35,7 @@ import {
   formatUserCode,
   exitWithError,
 } from "../lib/ui.ts";
+import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import {
   readConfig,
@@ -102,42 +103,57 @@ async function defaultOpenUrl(url: string): Promise<void> {
   await open(url);
 }
 
-const defaultDeps: Required<LoginDeps> = {
-  pickOrg: async (orgs: Org[]): Promise<Org | null> => {
-    if (!process.stdin.isTTY) {
-      process.stdout.write(
-        "Multiple organizations — pass --org <id-or-slug> to pin non-interactively.\n",
+/**
+ * Built as a function of `io` rather than a module constant so the non-TTY
+ * fallbacks write to the caller's sink. The hooks themselves keep their
+ * `io`-free signatures — a test injecting `pickOrg` is choosing an org, not
+ * choosing where bytes go.
+ */
+function makeDefaultDeps(io: CommandIO): Required<LoginDeps> {
+  return {
+    pickOrg: async (orgs: Org[]): Promise<Org | null> => {
+      if (!process.stdin.isTTY) {
+        io.stdout.write(
+          "Multiple organizations — pass --org <id-or-slug> to pin non-interactively.\n",
+        );
+        return null;
+      }
+      return select<Org>(
+        "Select the organization to pin on this profile",
+        orgs.map((o) => ({
+          value: o,
+          label: `${o.name} — ${o.slug}`,
+          hint: o.id,
+        })),
       );
-      return null;
-    }
-    return select<Org>(
-      "Select the organization to pin on this profile",
-      orgs.map((o) => ({
-        value: o,
-        label: `${o.name} — ${o.slug}`,
-        hint: o.id,
-      })),
-    );
-  },
-  promptCreateOrg: async (): Promise<{ name: string; slug?: string } | null> => {
-    if (!process.stdin.isTTY) {
-      process.stdout.write(
-        "No organization yet on this account — run `appstrate org create <name>` to create one.\n",
-      );
-      return null;
-    }
-    const name = await askText("Organization name");
-    const slugRaw = await askText("Slug (optional — leave blank to auto-generate)", "");
-    const slug = slugRaw.trim();
-    return slug.length > 0 ? { name, slug } : { name };
-  },
-};
+    },
+    promptCreateOrg: async (): Promise<{ name: string; slug?: string } | null> => {
+      if (!process.stdin.isTTY) {
+        io.stdout.write(
+          "No organization yet on this account — run `appstrate org create <name>` to create one.\n",
+        );
+        return null;
+      }
+      const name = await askText("Organization name");
+      const slugRaw = await askText("Slug (optional — leave blank to auto-generate)", "");
+      const slug = slugRaw.trim();
+      return slug.length > 0 ? { name, slug } : { name };
+    },
+  };
+}
 
-export async function loginCommand(opts: LoginOptions): Promise<void> {
+/**
+ * `io` is a trailing parameter rather than another `LoginDeps` member: it is
+ * threaded through every helper below, including the ones that never prompt
+ * (`pinAppOnProfile`), whereas `LoginDeps` is documented — and injected by
+ * tests — as the interactive-prompt seam alone. The default keeps `cli.ts`'s
+ * single-argument call site working untouched.
+ */
+export async function loginCommand(opts: LoginOptions, io: CommandIO = DEFAULT_IO): Promise<void> {
   const config = await readConfig();
   const profileName = resolveProfileName(opts.profile, config);
 
-  intro(`Appstrate login — profile "${profileName}"`);
+  intro(`Appstrate login — profile "${profileName}"`, io);
 
   const rawInstance =
     opts.instance ??
@@ -154,19 +170,26 @@ export async function loginCommand(opts: LoginOptions): Promise<void> {
   try {
     normalizedInstance = normalizeInstance(rawInstance);
   } catch (err) {
-    exitWithError(err);
+    // Pass `io` explicitly: the default would exit the *process*, which in a
+    // test run means killing the runner instead of failing one test.
+    exitWithError(err, io);
   }
 
   try {
-    await runLogin(profileName, normalizedInstance, opts);
+    await runLogin(profileName, normalizedInstance, opts, io);
   } catch (err) {
-    exitWithError(err);
+    exitWithError(err, io);
   }
 }
 
-async function runLogin(profileName: string, instance: string, opts: LoginOptions): Promise<void> {
+async function runLogin(
+  profileName: string,
+  instance: string,
+  opts: LoginOptions,
+  io: CommandIO,
+): Promise<void> {
   // Step 1 — device code.
-  const s = spinner();
+  const s = spinner(io);
   s.start("Requesting device code");
   const code = await startDeviceFlow(instance, CLI_CLIENT_ID, CLI_SCOPE);
   s.stop(`Code received — expires in ${Math.round(code.expiresIn / 60)}m`);
@@ -175,8 +198,8 @@ async function runLogin(profileName: string, instance: string, opts: LoginOption
 
   // Step 2 — show the user what to do. Print outside the spinner so the
   // code remains visible even after the spinner rewinds the cursor.
-  process.stdout.write(`\n  Visit: ${code.verificationUri}\n`);
-  process.stdout.write(`  Code:  ${display}\n\n`);
+  io.stdout.write(`\n  Visit: ${code.verificationUri}\n`);
+  io.stdout.write(`  Code:  ${display}\n\n`);
 
   // Step 3 — open the browser on the complete URI (pre-fills user_code).
   // If `open` fails (headless SSH / no display), the printed URL + code
@@ -184,7 +207,7 @@ async function runLogin(profileName: string, instance: string, opts: LoginOption
   defaultOpenUrl(code.verificationUriComplete).catch(() => {});
 
   // Step 4 — poll until approval or terminal error.
-  const pollSpinner = spinner();
+  const pollSpinner = spinner(io);
   pollSpinner.start("Waiting for approval in your browser");
   const token = await pollDeviceFlow(instance, code.deviceCode, CLI_CLIENT_ID, {
     interval: code.interval,
@@ -256,23 +279,23 @@ async function runLogin(profileName: string, instance: string, opts: LoginOption
   // persisted so `listOrgs` / `createOrg` (both authenticated) work.
   // Any failure here leaves the login valid but unpinned — surfaced as
   // a hint to the user, never as a hard failure.
-  const pinned = await pinOrgOnProfile(profileName, opts);
+  const pinned = await pinOrgOnProfile(profileName, opts, io);
 
   // Step 8 — cascade into application pinning. Issue #217. Requires an
   // `orgId` in context (listApplications is org-scoped), so we gate on
   // `pinned` rather than re-fetching from the keyring.
-  const pinnedApp = await pinAppOnProfile(profileName, opts, pinned);
+  const pinnedApp = await pinAppOnProfile(profileName, opts, pinned, io);
 
   const orgSuffix = pinned ? ` to "${pinned.name}" (${pinned.id})` : "";
   const appSuffix = pinnedApp ? ` / app "${pinnedApp.name}" (${pinnedApp.id})` : "";
-  outro(`Logged in as ${identity.email}${orgSuffix}${appSuffix}`);
+  outro(`Logged in as ${identity.email}${orgSuffix}${appSuffix}`, io);
 
   if (!pinned) {
-    process.stdout.write(
+    io.stdout.write(
       `No org pinned — pass -H "X-Org-Id: …" on each call, or run \`appstrate org switch\` later.\n`,
     );
   } else if (!pinnedApp && !opts.noApp) {
-    process.stdout.write(
+    io.stdout.write(
       `No app pinned — pass -H "X-Application-Id: …" on each call, or run \`appstrate app switch\` later.\n`,
     );
   }
@@ -303,8 +326,12 @@ async function pinOrgResettingStaleApp(profileName: string, orgId: string): Prom
   });
 }
 
-async function pinOrgOnProfile(profileName: string, opts: LoginOptions): Promise<Org | null> {
-  const deps = { ...defaultDeps, ...(opts.deps ?? {}) };
+async function pinOrgOnProfile(
+  profileName: string,
+  opts: LoginOptions,
+  io: CommandIO,
+): Promise<Org | null> {
+  const deps = { ...makeDefaultDeps(io), ...(opts.deps ?? {}) };
 
   // `--no-org` short-circuits everything, including the network call.
   if (opts.noOrg) return null;
@@ -323,7 +350,7 @@ async function pinOrgOnProfile(profileName: string, opts: LoginOptions): Promise
   } catch (err) {
     // Don't fail the login if /api/orgs is temporarily down — tokens
     // are already persisted and the user can retry with `org switch`.
-    process.stderr.write(`Failed to list organizations: ${getErrorMessage(err)}\n`);
+    io.stderr.write(`Failed to list organizations: ${getErrorMessage(err)}\n`);
     return null;
   }
 
@@ -372,6 +399,7 @@ async function pinAppOnProfile(
   profileName: string,
   opts: LoginOptions,
   orgPinned: Org | null,
+  io: CommandIO,
 ): Promise<Application | null> {
   if (opts.noApp) return null;
   if (!orgPinned) return null;
@@ -386,7 +414,7 @@ async function pinAppOnProfile(
   try {
     apps = await listApplications(profileName);
   } catch (err) {
-    process.stderr.write(`Failed to list applications: ${getErrorMessage(err)}\n`);
+    io.stderr.write(`Failed to list applications: ${getErrorMessage(err)}\n`);
     return null;
   }
 
@@ -400,7 +428,7 @@ async function pinAppOnProfile(
   if (apps.length === 0) {
     // Should be impossible in practice — every org has a server-provisioned
     // default app. Surface defensively in case of partial state.
-    process.stderr.write(
+    io.stderr.write(
       "No applications found on the pinned organization — run `appstrate app create <name>` to create one.\n",
     );
     return null;
@@ -419,7 +447,7 @@ async function pinAppOnProfile(
     await updateProfile(profileName, { applicationId: def.id });
     return def;
   }
-  process.stderr.write(
+  io.stderr.write(
     "Multiple applications but none marked default — run `appstrate app switch` to pin one.\n",
   );
   return null;

--- a/apps/cli/src/commands/openapi.ts
+++ b/apps/cli/src/commands/openapi.ts
@@ -35,6 +35,7 @@
 import { Command } from "commander";
 import { resolveProfileName, readConfig } from "../lib/config.ts";
 import { formatError } from "../lib/ui.ts";
+import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
 import { fetchOpenApi, type OpenApiDocument } from "../lib/openapi-cache.ts";
 import {
   collectOperations,
@@ -95,7 +96,17 @@ function detectColor(): boolean {
   return Boolean(process.stdout.isTTY);
 }
 
-export async function openapiListCommand(opts: OpenapiListOptions): Promise<void> {
+/**
+ * All three subcommands take a trailing `io` defaulting to `DEFAULT_IO`, so
+ * `registerOpenapiCommand` below (and therefore `cli.ts`) needs no change
+ * while tests get a sink they exclusively own — reassigning the global
+ * streams made every `toBe("")` here an assertion about writes from other
+ * suites running in the same `bun test` process (issue #1180).
+ */
+export async function openapiListCommand(
+  opts: OpenapiListOptions,
+  io: CommandIO = DEFAULT_IO,
+): Promise<void> {
   try {
     const doc = await loadSchema(opts);
     const entries = collectOperations(doc);
@@ -106,13 +117,13 @@ export async function openapiListCommand(opts: OpenapiListOptions): Promise<void
       search: opts.search,
     });
     if (opts.json) {
-      process.stdout.write(JSON.stringify(toListJson(filtered), null, 2) + "\n");
+      io.stdout.write(JSON.stringify(toListJson(filtered), null, 2) + "\n");
       return;
     }
-    process.stdout.write(formatList(filtered, detectColor()));
+    io.stdout.write(formatList(filtered, detectColor()));
   } catch (err) {
-    process.stderr.write(formatError(err) + "\n");
-    process.exit(1);
+    io.stderr.write(formatError(err) + "\n");
+    io.exit(1);
   }
 }
 
@@ -120,6 +131,7 @@ export async function openapiShowCommand(
   identifier: string,
   pathArg: string | undefined,
   opts: OpenapiShowOptions,
+  io: CommandIO = DEFAULT_IO,
 ): Promise<void> {
   try {
     const doc = await loadSchema(opts);
@@ -128,10 +140,10 @@ export async function openapiShowCommand(
       const hint = pathArg
         ? `No operation matches "${identifier} ${pathArg}".`
         : `No operation matches "${identifier}" (tried operationId, then "METHOD /path").`;
-      process.stderr.write(
+      io.stderr.write(
         `${hint}\nTip: run \`appstrate openapi list\` to see available operations.\n`,
       );
-      process.exit(1);
+      io.exit(1);
       return;
     }
     // Dereference $refs so parameter/request/response schemas are
@@ -189,29 +201,32 @@ export async function openapiShowCommand(
           2,
         );
       }
-      process.stdout.write(serialized + "\n");
+      io.stdout.write(serialized + "\n");
       return;
     }
-    process.stdout.write(formatShow(derefEntry, detectColor()));
+    io.stdout.write(formatShow(derefEntry, detectColor()));
   } catch (err) {
-    process.stderr.write(formatError(err) + "\n");
-    process.exit(1);
+    io.stderr.write(formatError(err) + "\n");
+    io.exit(1);
   }
 }
 
-export async function openapiExportCommand(opts: OpenapiExportOptions): Promise<void> {
+export async function openapiExportCommand(
+  opts: OpenapiExportOptions,
+  io: CommandIO = DEFAULT_IO,
+): Promise<void> {
   try {
     const doc = await loadSchema(opts);
     const payload = JSON.stringify(doc, null, 2);
     if (opts.output) {
       await writeFile(opts.output, payload + "\n", { mode: 0o600 });
-      process.stderr.write(`Wrote ${payload.length} bytes to ${opts.output}\n`);
+      io.stderr.write(`Wrote ${payload.length} bytes to ${opts.output}\n`);
       return;
     }
-    process.stdout.write(payload + "\n");
+    io.stdout.write(payload + "\n");
   } catch (err) {
-    process.stderr.write(formatError(err) + "\n");
-    process.exit(1);
+    io.stderr.write(formatError(err) + "\n");
+    io.exit(1);
   }
 }
 

--- a/apps/cli/src/commands/org.ts
+++ b/apps/cli/src/commands/org.ts
@@ -12,6 +12,13 @@
  *   org current       — print pinned org id (scripts / prompts)
  *   org create [name] — create + auto-pin
  *
+ * Every subcommand takes a trailing `io: CommandIO = DEFAULT_IO`. It sits
+ * after `deps` rather than on it because `list` and `current` have no
+ * `deps` at all, and "io is always the last argument" is the only rule that
+ * holds for all four. `cli.ts` passes neither, so production keeps writing
+ * to the real streams; tests inject a per-test sink instead of swapping the
+ * process-wide ones (issue #1180).
+ *
  * Cascade invariant (issue #217): the pinned `applicationId` is always scoped to
  * the pinned `orgId`. `org switch` and `org create` therefore clear the
  * stale app pin and re-pin the new org's default application in the same
@@ -23,6 +30,7 @@ import { resolveActiveProfile, requireLoggedIn, updateProfile } from "../lib/con
 import { listOrgs, createOrg, resolveOrgRef, type Org } from "../lib/orgs.ts";
 import { listApplications, findDefaultApplication, type Application } from "../lib/applications.ts";
 import { askText, select, exitWithError } from "../lib/ui.ts";
+import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
 
 interface OrgBaseOptions {
   profile?: string;
@@ -70,51 +78,60 @@ const defaultDeps: Required<OrgCommandDeps> = {
   },
 };
 
-export async function orgListCommand(opts: OrgBaseOptions): Promise<void> {
+export async function orgListCommand(
+  opts: OrgBaseOptions,
+  io: CommandIO = DEFAULT_IO,
+): Promise<void> {
   const { profileName, profile } = await resolveActiveProfile(opts.profile);
-  requireLoggedIn(profileName, profile);
+  requireLoggedIn(profileName, profile, io);
 
   try {
     const orgs = await listOrgs(profileName);
     if (orgs.length === 0) {
-      process.stdout.write("(no organizations)\n");
+      io.stdout.write("(no organizations)\n");
       return;
     }
     for (const o of orgs) {
       const marker = o.id === profile.orgId ? "*" : " ";
-      process.stdout.write(`${marker} ${o.slug.padEnd(24)}  ${o.id}  ${o.name}\n`);
+      io.stdout.write(`${marker} ${o.slug.padEnd(24)}  ${o.id}  ${o.name}\n`);
     }
   } catch (err) {
-    exitWithError(err);
+    // `io` is forwarded so the terminal error and the exit go to the
+    // caller's sink; the default would fire the real `process.exit`.
+    exitWithError(err, io);
   }
 }
 
-export async function orgCurrentCommand(opts: OrgBaseOptions): Promise<void> {
+export async function orgCurrentCommand(
+  opts: OrgBaseOptions,
+  io: CommandIO = DEFAULT_IO,
+): Promise<void> {
   const { profile } = await resolveActiveProfile(opts.profile);
   if (!profile) {
-    process.stderr.write("Not logged in. Run: appstrate login\n");
-    process.exit(1);
+    io.stderr.write("Not logged in. Run: appstrate login\n");
+    io.exit(1);
   }
   if (!profile.orgId) {
-    process.stderr.write("No organization pinned. Run: appstrate org switch\n");
-    process.exit(1);
+    io.stderr.write("No organization pinned. Run: appstrate org switch\n");
+    io.exit(1);
   }
-  process.stdout.write(`${profile.orgId}\n`);
+  io.stdout.write(`${profile.orgId}\n`);
 }
 
 export async function orgSwitchCommand(
   opts: OrgSwitchOptions,
   deps: OrgCommandDeps = {},
+  io: CommandIO = DEFAULT_IO,
 ): Promise<void> {
   const { profileName, profile } = await resolveActiveProfile(opts.profile);
-  requireLoggedIn(profileName, profile);
+  requireLoggedIn(profileName, profile, io);
   const picker = { ...defaultDeps, ...deps };
 
   try {
     const orgs = await listOrgs(profileName);
     if (orgs.length === 0) {
-      process.stderr.write("No organizations — run `appstrate org create <name>` to create one.\n");
-      process.exit(1);
+      io.stderr.write("No organizations — run `appstrate org create <name>` to create one.\n");
+      io.exit(1);
     }
 
     let chosen: Org;
@@ -123,10 +140,10 @@ export async function orgSwitchCommand(
     } else {
       const picked = await picker.pickOrg(orgs, profile.orgId);
       if (!picked) {
-        process.stderr.write(
+        io.stderr.write(
           "Cannot prompt in non-TTY — pass an id or slug: `appstrate org switch <id-or-slug>`.\n",
         );
-        process.exit(1);
+        io.exit(1);
       }
       chosen = picked;
     }
@@ -137,20 +154,21 @@ export async function orgSwitchCommand(
     await updateProfile(profileName, { orgId: chosen.id, applicationId: undefined });
     const repinned = await repinAppAfterOrgChange(profileName);
     const appSuffix = repinned ? ` / app "${repinned.name}" (${repinned.id})` : "";
-    process.stdout.write(
+    io.stdout.write(
       `Pinned "${chosen.name}" (${chosen.id})${appSuffix} on profile "${profileName}".\n`,
     );
   } catch (err) {
-    exitWithError(err);
+    exitWithError(err, io);
   }
 }
 
 export async function orgCreateCommand(
   opts: OrgCreateOptions,
   deps: OrgCommandDeps = {},
+  io: CommandIO = DEFAULT_IO,
 ): Promise<void> {
   const { profileName, profile } = await resolveActiveProfile(opts.profile);
-  requireLoggedIn(profileName, profile);
+  requireLoggedIn(profileName, profile, io);
   const picker = { ...defaultDeps, ...deps };
 
   try {
@@ -161,10 +179,8 @@ export async function orgCreateCommand(
     } else {
       const prompted = await picker.promptCreateOrg();
       if (!prompted) {
-        process.stderr.write(
-          "Cannot prompt in non-TTY — pass a name: `appstrate org create <name>`.\n",
-        );
-        process.exit(1);
+        io.stderr.write("Cannot prompt in non-TTY — pass a name: `appstrate org create <name>`.\n");
+        io.exit(1);
       }
       input = prompted;
     }
@@ -174,11 +190,11 @@ export async function orgCreateCommand(
     await updateProfile(profileName, { orgId: created.id, applicationId: undefined });
     const repinned = await repinAppAfterOrgChange(profileName);
     const appSuffix = repinned ? ` / app "${repinned.name}" (${repinned.id})` : "";
-    process.stdout.write(
+    io.stdout.write(
       `Created "${created.name}" (${created.id})${appSuffix} and pinned it on profile "${profileName}".\n`,
     );
   } catch (err) {
-    exitWithError(err);
+    exitWithError(err, io);
   }
 }
 

--- a/apps/cli/src/commands/run/remote-runner.ts
+++ b/apps/cli/src/commands/run/remote-runner.ts
@@ -307,10 +307,16 @@ export async function runRemote(
   // `appstrate.remote.triggered` line emitted just above is the lone
   // exception — it carries the runId + instance for debugging, has no
   // local-mode counterpart, and lands before any RunEvents do.
+  // Both writers are forwarded. `writeStderr` matters for the human sink's
+  // one stderr line (the `⚠` advisory on `appstrate.error`): leaving it unset
+  // would silently fall back to the sink's own `process.stderr.write` default,
+  // so a caller that injected `writeStderr` would still get that line on the
+  // global stream — the very leak this seam exists to close (issue #1180).
   const consoleSink: EventSink = createConsoleSink({
     json: opts.json,
     verbosity: opts.verbosity ?? "normal",
     writeStdout,
+    writeStderr,
   });
 
   // ─── 2. Signal wiring ──────────────────────────────────────────────

--- a/apps/cli/src/commands/run/sink.ts
+++ b/apps/cli/src/commands/run/sink.ts
@@ -19,15 +19,26 @@
  * The sinks never touch the network and swallow no errors silently —
  * any thrown exception bubbles up to the run command's top-level handler.
  *
- * **`writeStdout` injection.** All stdout output is routed through the
- * caller-supplied `writeStdout` (defaulting to `process.stdout.write`).
- * The `appstrate run` command installs a stdout-JSONL bridge around the
- * runner's sink to capture canonical events emitted by system tools
- * via `process.stdout.write(JSON+\n)` — without `writeStdout`, this
- * sink's JSONL mode would re-emit canonical events directly to stdout
- * and the bridge would re-aspirate them, dispatching every event a
- * second time. Routing through the bridge's `writeRaw` escape hatch
- * bypasses the interceptor and breaks the loop.
+ * **Writer injection.** Every byte this module emits goes through one
+ * of two caller-supplied writers, `writeStdout` / `writeStderr`, each
+ * defaulting to the matching `process.*.write`. The sink itself never
+ * names a global stream.
+ *
+ * `writeStdout` exists for a production reason: the `appstrate run`
+ * command installs a stdout-JSONL bridge around the runner's sink to
+ * capture canonical events emitted by system tools via
+ * `process.stdout.write(JSON+\n)` — without `writeStdout`, this sink's
+ * JSONL mode would re-emit canonical events directly to stdout and the
+ * bridge would re-aspirate them, dispatching every event a second time.
+ * Routing through the bridge's `writeRaw` escape hatch bypasses the
+ * interceptor and breaks the loop. `writeStderr` has no such bridge to
+ * dodge — stderr is not intercepted — but it closes the seam so tests
+ * can observe the error channel without swapping the *global*
+ * `process.stderr.write`. Global-stream capture is what issue #1180 is
+ * about: `bun test` runs every package in one process, so a buffer
+ * installed on a global stream collects writes from concurrent suites
+ * and `expect(captured).toBe("")` becomes a coin flip that blames an
+ * innocent test.
  */
 
 import type { EventSink } from "@appstrate/afps-runtime/interfaces";
@@ -61,6 +72,14 @@ interface SinkOptions {
    * for the full rationale.
    */
   writeStdout?: (chunk: string) => void;
+  /**
+   * Writer used for all stderr output. Defaults to
+   * `process.stderr.write`. Production leaves it unset — stderr is not
+   * bridged — so this is the seam tests use to read back the advisory
+   * `appstrate.error` lines without patching the global stream. See
+   * module docstring for why the global is off limits.
+   */
+  writeStderr?: (chunk: string) => void;
 }
 
 const USE_COLOR = Boolean(process.stdout.isTTY) && !process.env.NO_COLOR;
@@ -78,10 +97,16 @@ const defaultWriteStdout = (chunk: string): void => {
   process.stdout.write(chunk);
 };
 
+const defaultWriteStderr = (chunk: string): void => {
+  process.stderr.write(chunk);
+};
+
 export function createConsoleSink(opts: SinkOptions = {}): EventSink {
   const writeStdout = opts.writeStdout ?? defaultWriteStdout;
+  // JSONL mode is stdout-only by contract (one machine-readable line per
+  // event), so only the human sink is handed the stderr writer.
   if (opts.json) return createJsonlSink(opts, writeStdout);
-  return createHumanSink(opts, writeStdout);
+  return createHumanSink(opts, writeStdout, opts.writeStderr ?? defaultWriteStderr);
 }
 
 /**
@@ -189,7 +214,11 @@ function createJsonlSink(opts: SinkOptions, writeStdout: (chunk: string) => void
   };
 }
 
-function createHumanSink(opts: SinkOptions, writeStdout: (chunk: string) => void): EventSink {
+function createHumanSink(
+  opts: SinkOptions,
+  writeStdout: (chunk: string) => void,
+  writeStderr: (chunk: string) => void,
+): EventSink {
   const verbosity: Verbosity = opts.verbosity ?? "normal";
   return {
     async handle(event: RunEvent): Promise<void> {
@@ -231,9 +260,13 @@ function createHumanSink(opts: SinkOptions, writeStdout: (chunk: string) => void
           // surfaced separately via `[run failed]` at finalize, which
           // keeps the red treatment.
           //
-          // stderr bypasses the stdout bridge entirely — no need to
-          // route through `writeStdout`.
-          process.stderr.write(yellow(`⚠ ${event.message ?? "error"}\n`));
+          // This is the one line that leaves on stderr. It deliberately
+          // does NOT go through `writeStdout`: stderr bypasses the
+          // stdout bridge entirely, and mixing it into the `--json`
+          // stream would corrupt the JSONL contract. It still goes
+          // through an injected writer — `writeStderr` — so the channel
+          // stays observable without touching the global stream.
+          writeStderr(yellow(`⚠ ${event.message ?? "error"}\n`));
           return;
         }
         case "appstrate.metric": {

--- a/apps/cli/src/commands/runner.ts
+++ b/apps/cli/src/commands/runner.ts
@@ -375,6 +375,39 @@ export async function promoteStagedDaemon(d: { fs: RunnerFs }, stagedPath: strin
   }
 }
 
+/**
+ * Run `fn` with a started clack spinner, stopping it on **every** exit path.
+ *
+ * A clack spinner paints its frames from a `setInterval`. A body that throws
+ * past `stop()` leaves that interval running for the rest of the process,
+ * writing to the global stdout forever. In the shipped CLI the error unwinds
+ * to `exitWithError` and the process exits, so the leak is invisible — but
+ * `bun test` runs the whole repo in one process, where those frames land in
+ * whatever another suite happens to be reading and fail it (issue #1180:
+ * `Received: "◒  Enabling systemd unit..."` on an innocent `whoami` test).
+ *
+ */
+async function withSpinner<T>(
+  startLabel: string,
+  fn: (spin: ReturnType<typeof clack.spinner>) => Promise<T>,
+  stopLabel: string,
+): Promise<T> {
+  const spin = clack.spinner();
+  spin.start(startLabel);
+  let value: T;
+  try {
+    value = await fn(spin);
+  } catch (err) {
+    // clack's `stop()` takes no status code in this version, so the frame
+    // closes on the start label. What matters is that it closes at all: the
+    // interval is cleared and the error message that follows is the report.
+    spin.stop(startLabel);
+    throw err;
+  }
+  spin.stop(stopLabel);
+  return value;
+}
+
 async function downloadAndInstallBinaries(
   config: RunnerConfig,
   version: string,
@@ -384,37 +417,42 @@ async function downloadAndInstallBinaries(
   const paths = runnerDataPaths(config.dataDir);
   await d.fs.mkdirp(paths.binDir);
 
-  const daemonSpin = clack.spinner();
   const daemonLabel = `Downloading runner daemon ${version} (${arch})`;
-  daemonSpin.start(daemonLabel);
-  const { stagedPath } = await downloadDaemon({
-    http: d.http,
-    exec: d.exec,
-    fs: d.fs,
-    version,
-    arch,
-    destPath: RUNNER_BIN_PATH,
-    onProgress: (p) => daemonSpin.message(`${daemonLabel} — ${formatProgress(p)}`),
-  });
-  await promoteStagedDaemon(d, stagedPath);
-  daemonSpin.stop(`Installed daemon → ${RUNNER_BIN_PATH}`);
+  await withSpinner(
+    daemonLabel,
+    async (spin) => {
+      const { stagedPath } = await downloadDaemon({
+        http: d.http,
+        exec: d.exec,
+        fs: d.fs,
+        version,
+        arch,
+        destPath: RUNNER_BIN_PATH,
+        onProgress: (p) => spin.message(`${daemonLabel} — ${formatProgress(p)}`),
+      });
+      await promoteStagedDaemon(d, stagedPath);
+    },
+    `Installed daemon → ${RUNNER_BIN_PATH}`,
+  );
 
-  const fcSpin = clack.spinner();
   const fcLabel = `Downloading firecracker + jailer v${FIRECRACKER_VERSION} (${arch})`;
-  fcSpin.start(fcLabel);
-  await installFirecracker({
-    http: d.http,
-    exec: d.exec,
-    fs: d.fs,
-    version: FIRECRACKER_VERSION,
-    arch,
-    destPath: paths.firecrackerBin,
-    // Same verified tarball — the daemon requires firecracker + jailer
-    // to come from one release (FIRECRACKER_JAILER=on confinement).
-    jailerDestPath: paths.jailerBin,
-    onProgress: (p) => fcSpin.message(`${fcLabel} — ${formatProgress(p)}`),
-  });
-  fcSpin.stop(`Installed firecracker → ${paths.firecrackerBin} (+ jailer → ${paths.jailerBin})`);
+  await withSpinner(
+    fcLabel,
+    (spin) =>
+      installFirecracker({
+        http: d.http,
+        exec: d.exec,
+        fs: d.fs,
+        version: FIRECRACKER_VERSION,
+        arch,
+        destPath: paths.firecrackerBin,
+        // Same verified tarball — the daemon requires firecracker + jailer
+        // to come from one release (FIRECRACKER_JAILER=on confinement).
+        jailerDestPath: paths.jailerBin,
+        onProgress: (p) => spin.message(`${fcLabel} — ${formatProgress(p)}`),
+      }),
+    `Installed firecracker → ${paths.firecrackerBin} (+ jailer → ${paths.jailerBin})`,
+  );
 }
 
 async function writeHostFiles(config: RunnerConfig, d: ResolvedDeps): Promise<void> {
@@ -433,30 +471,33 @@ async function writeHostFiles(config: RunnerConfig, d: ResolvedDeps): Promise<vo
 }
 
 export async function enableService(d: ResolvedDeps): Promise<void> {
-  const spin = clack.spinner();
-  spin.start("Enabling systemd unit");
-  const reload = await d.exec.run("systemctl", ["daemon-reload"]);
-  if (!reload.ok)
-    throw new Error(`systemctl daemon-reload failed: ${reload.stderr || reload.exitCode}`);
-  // `enable` (persistence) then `restart` — NOT `enable --now`: on a re-install
-  // over an already-active unit `enable --now` is a no-op that leaves the OLD
-  // binary running, so the health poll would validate the stale daemon. `restart`
-  // is idempotent (starts if stopped, restarts if running) → always the new binary.
-  const enable = await d.exec.run("systemctl", ["enable", RUNNER_SERVICE_NAME]);
-  if (!enable.ok) {
-    throw new Error(
-      `systemctl enable ${RUNNER_SERVICE_NAME} failed: ${enable.stderr || enable.exitCode}. ` +
-        `Inspect with \`journalctl -u ${RUNNER_SERVICE_NAME} -n 50\`.`,
-    );
-  }
-  const restart = await d.exec.run("systemctl", ["restart", RUNNER_SERVICE_NAME]);
-  if (!restart.ok) {
-    throw new Error(
-      `systemctl restart ${RUNNER_SERVICE_NAME} failed: ${restart.stderr || restart.exitCode}. ` +
-        `Inspect with \`journalctl -u ${RUNNER_SERVICE_NAME} -n 50\`.`,
-    );
-  }
-  spin.stop("systemd unit enabled + started");
+  await withSpinner(
+    "Enabling systemd unit",
+    async () => {
+      const reload = await d.exec.run("systemctl", ["daemon-reload"]);
+      if (!reload.ok)
+        throw new Error(`systemctl daemon-reload failed: ${reload.stderr || reload.exitCode}`);
+      // `enable` (persistence) then `restart` — NOT `enable --now`: on a re-install
+      // over an already-active unit `enable --now` is a no-op that leaves the OLD
+      // binary running, so the health poll would validate the stale daemon. `restart`
+      // is idempotent (starts if stopped, restarts if running) → always the new binary.
+      const enable = await d.exec.run("systemctl", ["enable", RUNNER_SERVICE_NAME]);
+      if (!enable.ok) {
+        throw new Error(
+          `systemctl enable ${RUNNER_SERVICE_NAME} failed: ${enable.stderr || enable.exitCode}. ` +
+            `Inspect with \`journalctl -u ${RUNNER_SERVICE_NAME} -n 50\`.`,
+        );
+      }
+      const restart = await d.exec.run("systemctl", ["restart", RUNNER_SERVICE_NAME]);
+      if (!restart.ok) {
+        throw new Error(
+          `systemctl restart ${RUNNER_SERVICE_NAME} failed: ${restart.stderr || restart.exitCode}. ` +
+            `Inspect with \`journalctl -u ${RUNNER_SERVICE_NAME} -n 50\`.`,
+        );
+      }
+    },
+    "systemd unit enabled + started",
+  );
 }
 
 /**
@@ -758,22 +799,25 @@ export async function runnerUpdateCommand(opts: RunnerUpdateOptions = {}): Promi
     const arch = resolveRunnerArch();
     const version = resolveDaemonVersion();
 
-    const spin = clack.spinner();
     const label = `Downloading runner daemon ${version} (${arch})`;
-    spin.start(label);
-    const { stagedPath } = await downloadDaemon({
-      http: d.http,
-      exec: d.exec,
-      fs: d.fs,
-      version,
-      arch,
-      destPath: RUNNER_BIN_PATH,
-      onProgress: (p) => spin.message(`${label} — ${formatProgress(p)}`),
-    });
-    // Atomic swap over the live binary — rename(2) keeps the running
-    // process's fd valid; the restart below picks up the new inode.
-    await promoteStagedDaemon(d, stagedPath);
-    spin.stop(`Installed daemon → ${RUNNER_BIN_PATH}`);
+    await withSpinner(
+      label,
+      async (spin) => {
+        const { stagedPath } = await downloadDaemon({
+          http: d.http,
+          exec: d.exec,
+          fs: d.fs,
+          version,
+          arch,
+          destPath: RUNNER_BIN_PATH,
+          onProgress: (p) => spin.message(`${label} — ${formatProgress(p)}`),
+        });
+        // Atomic swap over the live binary — rename(2) keeps the running
+        // process's fd valid; the restart below picks up the new inode.
+        await promoteStagedDaemon(d, stagedPath);
+      },
+      `Installed daemon → ${RUNNER_BIN_PATH}`,
+    );
 
     // Re-pin the guest artifacts to the new daemon version BEFORE the restart:
     // if this update crosses a guest-protocol bump, a pin still pointing at the
@@ -924,38 +968,40 @@ export async function runnerUninstallCommand(opts: RunnerUninstallOptions = {}):
       }
     }
 
-    const spin = clack.spinner();
-    spin.start("Removing appstrate-runner");
+    const removed = await withSpinner(
+      "Removing appstrate-runner",
+      async () => {
+        // 1. Stop + disable the unit. Both tolerate an absent/inactive unit
+        //    (systemctl exits non-zero, which we intentionally ignore here).
+        await d.exec.run("systemctl", ["stop", RUNNER_SERVICE_NAME]);
+        await d.exec.run("systemctl", ["disable", RUNNER_SERVICE_NAME]);
 
-    // 1. Stop + disable the unit. Both tolerate an absent/inactive unit
-    //    (systemctl exits non-zero, which we intentionally ignore here).
-    await d.exec.run("systemctl", ["stop", RUNNER_SERVICE_NAME]);
-    await d.exec.run("systemctl", ["disable", RUNNER_SERVICE_NAME]);
+        // 2. Remove the unit + any drop-in dir, reload, and clear a lingering
+        //    failed state so a later reinstall starts clean. `remove` is
+        //    rm -rf (force) → removing a missing path is a no-op.
+        const paths: string[] = [];
+        for (const p of [RUNNER_UNIT_PATH, `${RUNNER_UNIT_PATH}.d`]) {
+          await d.fs.remove(p);
+          paths.push(p);
+        }
+        await d.exec.run("systemctl", ["daemon-reload"]);
+        await d.exec.run("systemctl", ["reset-failed", RUNNER_SERVICE_NAME]);
 
-    // 2. Remove the unit + any drop-in dir, reload, and clear a lingering
-    //    failed state so a later reinstall starts clean. `remove` is
-    //    rm -rf (force) → removing a missing path is a no-op.
-    const removed: string[] = [];
-    for (const p of [RUNNER_UNIT_PATH, `${RUNNER_UNIT_PATH}.d`]) {
-      await d.fs.remove(p);
-      removed.push(p);
-    }
-    await d.exec.run("systemctl", ["daemon-reload"]);
-    await d.exec.run("systemctl", ["reset-failed", RUNNER_SERVICE_NAME]);
+        // 3. Binary + config (token).
+        for (const p of [RUNNER_BIN_PATH, RUNNER_ETC_DIR]) {
+          await d.fs.remove(p);
+          paths.push(p);
+        }
 
-    // 3. Binary + config (token).
-    for (const p of [RUNNER_BIN_PATH, RUNNER_ETC_DIR]) {
-      await d.fs.remove(p);
-      removed.push(p);
-    }
-
-    // 4. State dir — only when not preserving it.
-    if (removeData) {
-      await d.fs.remove(dataDir);
-      removed.push(dataDir);
-    }
-
-    spin.stop("appstrate-runner removed");
+        // 4. State dir — only when not preserving it.
+        if (removeData) {
+          await d.fs.remove(dataDir);
+          paths.push(dataDir);
+        }
+        return paths;
+      },
+      "appstrate-runner removed",
+    );
     clack.note(removed.map((p) => `  • ${p}`).join("\n"), "Removed");
     outro(
       removeData

--- a/apps/cli/src/commands/runner.ts
+++ b/apps/cli/src/commands/runner.ts
@@ -19,7 +19,7 @@
 
 import * as clack from "@clack/prompts";
 import { dirname, isAbsolute, normalize } from "node:path";
-import { intro, outro, askText, confirm, exitWithError } from "../lib/ui.ts";
+import { intro, outro, askText, confirm, exitWithError, withSpinner } from "../lib/ui.ts";
 import { CLI_VERSION, DEV_CLI_VERSION } from "../lib/version.ts";
 import {
   RUNNER_BIN_PATH,
@@ -373,39 +373,6 @@ export async function promoteStagedDaemon(d: { fs: RunnerFs }, stagedPath: strin
     await d.fs.remove(stagedPath).catch(() => {});
     throw err;
   }
-}
-
-/**
- * Run `fn` with a started clack spinner, stopping it on **every** exit path.
- *
- * A clack spinner paints its frames from a `setInterval`. A body that throws
- * past `stop()` leaves that interval running for the rest of the process,
- * writing to the global stdout forever. In the shipped CLI the error unwinds
- * to `exitWithError` and the process exits, so the leak is invisible — but
- * `bun test` runs the whole repo in one process, where those frames land in
- * whatever another suite happens to be reading and fail it (issue #1180:
- * `Received: "◒  Enabling systemd unit..."` on an innocent `whoami` test).
- *
- */
-async function withSpinner<T>(
-  startLabel: string,
-  fn: (spin: ReturnType<typeof clack.spinner>) => Promise<T>,
-  stopLabel: string,
-): Promise<T> {
-  const spin = clack.spinner();
-  spin.start(startLabel);
-  let value: T;
-  try {
-    value = await fn(spin);
-  } catch (err) {
-    // clack's `stop()` takes no status code in this version, so the frame
-    // closes on the start label. What matters is that it closes at all: the
-    // interval is cleared and the error message that follows is the report.
-    spin.stop(startLabel);
-    throw err;
-  }
-  spin.stop(stopLabel);
-  return value;
 }
 
 async function downloadAndInstallBinaries(

--- a/apps/cli/src/commands/self-update.ts
+++ b/apps/cli/src/commands/self-update.ts
@@ -13,6 +13,7 @@ import * as clack from "@clack/prompts";
 import { INSTALL_SOURCE, upgradeHint, type InstallSource } from "../lib/install-source.ts";
 import { CLI_VERSION } from "../lib/version.ts";
 import { formatProgress, type ProgressFn } from "../lib/download.ts";
+import { spinner } from "../lib/ui.ts";
 import {
   detectPlatform,
   performCurlUpdate,
@@ -159,7 +160,11 @@ export async function selfUpdateCommand(opts: SelfUpdateOptions = {}): Promise<n
   // Live download progress so a 113 MB binary is not a silent multi-minute gap
   // (issue #821). The spinner starts on the first byte-tick and stops once the
   // run finishes; it degrades to a static line on a non-TTY (piped installs).
-  const spin = clack.spinner();
+  // Not `withSpinner`: the start is conditional (no ticks, no spinner — a
+  // no-op update must not paint a download line). The `finally` carries the
+  // same obligation the helper would: a spinner that outlives its scope keeps
+  // painting from a `setInterval` for the rest of the process (issue #1180).
+  const spin = spinner();
   let spinning = false;
   const onProgress: ProgressFn = (p) => {
     if (!spinning) {
@@ -168,7 +173,13 @@ export async function selfUpdateCommand(opts: SelfUpdateOptions = {}): Promise<n
     }
     spin.message(`Downloading appstrate binary — ${formatProgress(p)}`);
   };
-  const result = await runSelfUpdate({ ...opts, onProgress });
+  let result: SelfUpdateRunResult;
+  try {
+    result = await runSelfUpdate({ ...opts, onProgress });
+  } catch (err) {
+    if (spinning) spin.stop("Download failed");
+    throw err;
+  }
   if (spinning) {
     spin.stop(result.exitCode === SELF_UPDATE_EXIT.OK ? "Download complete" : "Download failed");
   }

--- a/apps/cli/src/commands/token.ts
+++ b/apps/cli/src/commands/token.ts
@@ -23,31 +23,38 @@ import { readConfig, resolveProfileName } from "../lib/config.ts";
 import { loadTokens } from "../lib/keyring.ts";
 import { decodeJwtPayload } from "../lib/jwt-identity.ts";
 import { formatError } from "../lib/ui.ts";
+import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
 
 interface TokenOptions {
   profile?: string;
 }
 
-export async function tokenCommand(opts: TokenOptions): Promise<void> {
+/**
+ * `io` is injected rather than written through the global streams: a test
+ * that swapped `process.stdout` captured every other suite's writes too, so
+ * "the plaintext never reaches stdout" was an assertion about a shared
+ * buffer (issue #1180). `cli.ts` passes nothing and gets `DEFAULT_IO`.
+ */
+export async function tokenCommand(opts: TokenOptions, io: CommandIO = DEFAULT_IO): Promise<void> {
   const config = await readConfig();
   const profileName = resolveProfileName(opts.profile, config);
   const profile = config.profiles[profileName];
 
   if (!profile) {
-    process.stderr.write(
+    io.stderr.write(
       `Profile "${profileName}" not configured. Run: appstrate login --profile ${profileName}\n`,
     );
-    process.exit(1);
+    io.exit(1);
     return;
   }
 
   try {
     const stored = await loadTokens(profileName);
     if (!stored) {
-      process.stderr.write(
+      io.stderr.write(
         `No tokens stored for profile "${profileName}". Run: appstrate login --profile ${profileName}\n`,
       );
-      process.exit(1);
+      io.exit(1);
       return;
     }
 
@@ -103,10 +110,10 @@ export async function tokenCommand(opts: TokenOptions): Promise<void> {
       lines.push("", `JWT claims:        unavailable (token is not a JWT)`);
     }
 
-    process.stdout.write(lines.join("\n") + "\n");
+    io.stdout.write(lines.join("\n") + "\n");
   } catch (err) {
-    process.stderr.write(formatError(err) + "\n");
-    process.exit(1);
+    io.stderr.write(formatError(err) + "\n");
+    io.exit(1);
   }
 }
 

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -20,6 +20,7 @@ import { readConfig, resolveProfileName } from "../lib/config.ts";
 import { apiFetch } from "../lib/api.ts";
 import { listOrgs } from "../lib/orgs.ts";
 import { formatError } from "../lib/ui.ts";
+import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
 
 interface WhoamiOptions {
   profile?: string;
@@ -33,16 +34,26 @@ interface ProfileResponse {
   name: string | null;
 }
 
-export async function whoamiCommand(opts: WhoamiOptions): Promise<void> {
+/**
+ * `io` is injected so tests own their own sink. Reassigning the global
+ * stdout/stderr streams used to be the only way to read this command's
+ * output, and in a single-process `bun test` run that buffer collected
+ * writes from every other suite too (issue #1180). Production callers pass
+ * nothing and get `DEFAULT_IO`, so `cli.ts` is unchanged.
+ */
+export async function whoamiCommand(
+  opts: WhoamiOptions,
+  io: CommandIO = DEFAULT_IO,
+): Promise<void> {
   const config = await readConfig();
   const profileName = resolveProfileName(opts.profile, config);
   const profile = config.profiles[profileName];
 
   if (!profile) {
-    process.stderr.write(
+    io.stderr.write(
       `Profile "${profileName}" not configured. Run: appstrate login --profile ${profileName}\n`,
     );
-    process.exit(1);
+    io.exit(1);
   }
 
   try {
@@ -69,7 +80,7 @@ export async function whoamiCommand(opts: WhoamiOptions): Promise<void> {
       }
     }
 
-    process.stdout.write(
+    io.stdout.write(
       [
         `Profile:  ${profileName}`,
         `Instance: ${profile.instance}`,
@@ -81,7 +92,7 @@ export async function whoamiCommand(opts: WhoamiOptions): Promise<void> {
         .join("\n") + "\n",
     );
   } catch (err) {
-    process.stderr.write(formatError(err) + "\n");
-    process.exit(1);
+    io.stderr.write(formatError(err) + "\n");
+    io.exit(1);
   }
 }

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -24,6 +24,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { mkdir, readFile, rename, writeFile, unlink } from "node:fs/promises";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
+import { DEFAULT_IO, type CommandIO } from "./io.ts";
 
 export interface Profile {
   instance: string;
@@ -188,16 +189,23 @@ export async function resolveActiveProfile(
  * Used by every `appstrate org …` / `appstrate app …` subcommand —
  * centralized so the phrasing stays in sync across the two command
  * families.
+ *
+ * Takes the caller's `io` so the "not configured" branch lands in the same
+ * sink as the rest of the command. A test that injects a memory sink into
+ * `orgListCommand` would otherwise still hit the real `process.exit` here
+ * and kill the test worker (issue #1180). `models.ts` and any other caller
+ * that passes nothing keeps the production wiring via the default.
  */
 export function requireLoggedIn(
   profileName: string,
   profile: Profile | undefined,
+  io: CommandIO = DEFAULT_IO,
 ): asserts profile is Profile {
   if (!profile) {
-    process.stderr.write(
+    io.stderr.write(
       `Profile "${profileName}" not configured. Run: appstrate login --profile ${profileName}\n`,
     );
-    process.exit(1);
+    io.exit(1);
   }
 }
 

--- a/apps/cli/src/lib/io.ts
+++ b/apps/cli/src/lib/io.ts
@@ -29,11 +29,13 @@ export interface CommandIO {
   /** Hook so tests assert exit codes without terminating the runner. */
   exit: (code: number) => never;
   /**
-   * Optional terminal-error renderer. Production uses `clack.cancel` so the
-   * message keeps its styled treatment; tests supply a plain sink. When
-   * absent, `exitWithError` falls back to `stderr.write`.
+   * Terminal-error renderer. Production uses `clack.cancel` so the message
+   * keeps its styled treatment; a test sink supplies a plain writer on the
+   * same channel. Required, not optional: every sink in the CLI supplies one,
+   * so an optional member would only buy `exitWithError` a fallback branch
+   * that nothing but its own test could reach.
    */
-  cancel?: (message: string) => void;
+  cancel: (message: string) => void;
 }
 
 /**

--- a/apps/cli/src/lib/io.ts
+++ b/apps/cli/src/lib/io.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Injectable stdout / stderr / exit seam, shared by every command.
+ *
+ * **The flake it prevents (issue #1180).** `bun test` runs the whole repo in
+ * a single process, so a suite that swaps the *global* `process.stdout.write`
+ * to capture a command's output also captures whatever any other suite, any
+ * library, or the runner itself happens to write during that window. An
+ * `expect(captured).toBe("")` written that way is an assertion about a buffer
+ * the test does not own: it fails non-deterministically, and it names an
+ * innocent command when it does. Handing each command its own sink removes
+ * the shared mutable state instead of trying to time around it.
+ *
+ * This generalises two seams that already existed in this CLI:
+ * `ApiCommandIO` in `src/commands/api/types.ts` (now an extension of
+ * `CommandIO`) and the `writeStdout` option of `src/commands/run/sink.ts`.
+ *
+ * Four members, deliberately — no colour, TTY or logger abstraction. A
+ * command that needs more than "write bytes, exit" keeps that logic in the
+ * command; widening the seam would put it in everyone's way.
+ */
+
+import * as clack from "@clack/prompts";
+
+export interface CommandIO {
+  stdout: { write(chunk: string | Uint8Array): void };
+  stderr: { write(chunk: string | Uint8Array): void };
+  /** Hook so tests assert exit codes without terminating the runner. */
+  exit: (code: number) => never;
+  /**
+   * Optional terminal-error renderer. Production uses `clack.cancel` so the
+   * message keeps its styled treatment; tests supply a plain sink. When
+   * absent, `exitWithError` falls back to `stderr.write`.
+   */
+  cancel?: (message: string) => void;
+}
+
+/**
+ * Production wiring — what every command gets when the caller injects
+ * nothing.
+ *
+ * `cancel` is wired here rather than in `ui.ts` so the dependency arrow stays
+ * one-way (`ui.ts` → `io.ts`, never the reverse). `@clack/prompts` is an
+ * external leaf, so importing it from this module cannot close a cycle, and
+ * `exitWithError` needs no special case for its own default.
+ */
+export const DEFAULT_IO: CommandIO = {
+  stdout: {
+    write(chunk) {
+      process.stdout.write(chunk);
+    },
+  },
+  stderr: {
+    write(chunk) {
+      process.stderr.write(chunk);
+    },
+  },
+  exit: (code) => process.exit(code),
+  // Wrapped rather than passed by reference so the seam pins the one-argument
+  // form regardless of what else clack's export carries.
+  cancel: (message) => {
+    clack.cancel(message);
+  },
+};

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -177,13 +177,10 @@ export function formatError(err: unknown): string {
  * Render `err` and stop the process. `io` defaults to `DEFAULT_IO`, whose
  * `cancel` is `clack.cancel` — so the production rendering is byte-for-byte
  * what it has always been, on the same stream. Tests inject a sink instead of
- * swapping the global streams (issue #1180); an `io` that supplies no
- * `cancel` gets the plain message on stderr.
+ * swapping the global streams (issue #1180).
  */
 export function exitWithError(err: unknown, io: CommandIO = DEFAULT_IO, code = 1): never {
-  const message = formatError(err);
-  if (io.cancel) io.cancel(message);
-  else io.stderr.write(`${message}\n`);
+  io.cancel(formatError(err));
   io.exit(code);
 }
 

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -7,6 +7,7 @@
  */
 
 import * as clack from "@clack/prompts";
+import { DEFAULT_IO, type CommandIO } from "./io.ts";
 import { DeviceFlowError } from "./device-flow.ts";
 import { ApiError, AuthError } from "./api.ts";
 import { InsecureInstanceError } from "./instance-url.ts";
@@ -136,9 +137,18 @@ export function formatError(err: unknown): string {
   return String(err);
 }
 
-export function exitWithError(err: unknown, code = 1): never {
-  clack.cancel(formatError(err));
-  process.exit(code);
+/**
+ * Render `err` and stop the process. `io` defaults to `DEFAULT_IO`, whose
+ * `cancel` is `clack.cancel` — so the production rendering is byte-for-byte
+ * what it has always been, on the same stream. Tests inject a sink instead of
+ * swapping the global streams (issue #1180); an `io` that supplies no
+ * `cancel` gets the plain message on stderr.
+ */
+export function exitWithError(err: unknown, io: CommandIO = DEFAULT_IO, code = 1): never {
+  const message = formatError(err);
+  if (io.cancel) io.cancel(message);
+  else io.stderr.write(`${message}\n`);
+  io.exit(code);
 }
 
 /**

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -12,12 +12,45 @@ import { DeviceFlowError } from "./device-flow.ts";
 import { ApiError, AuthError } from "./api.ts";
 import { InsecureInstanceError } from "./instance-url.ts";
 
-export function intro(title: string): void {
-  clack.intro(title);
+/**
+ * Adapt a `CommandIO` into the stream clack renders to.
+ *
+ * clack accepts an `output` sink on every helper, so this is the seam that
+ * lets a command's framing (`intro`, `outro`, the spinners) land in a
+ * caller-owned buffer instead of the process-global stdout — the coupling
+ * issue #1180 is about. Only the *bytes* are redirected: everything else is
+ * inherited from the real stream, because clack asks its output for more
+ * than `write`. `spinner()` reads `output.columns` to wrap frames (a bare
+ * four-member sink has none, and clack would silently fall back to 80
+ * columns, rewrapping every spinner line on a wider terminal) and hands the
+ * stream to `node:readline`, which expects a stream. Prototyping off
+ * `process.stdout` keeps the geometry, the `isTTY` flags and the readline
+ * interop exactly as they are today, so the default path stays
+ * byte-for-byte what it renders now.
+ *
+ * The trailing arguments cover `write(chunk, cb)` / `write(chunk, enc, cb)`:
+ * readline passes a continuation there and stalls its cursor bookkeeping if
+ * nobody calls it.
+ */
+function clackOutput(io: CommandIO): typeof process.stdout {
+  return Object.create(process.stdout, {
+    write: {
+      value(chunk: string | Uint8Array, ...rest: unknown[]): boolean {
+        io.stdout.write(chunk);
+        const done = rest.find((arg) => typeof arg === "function") as (() => void) | undefined;
+        done?.();
+        return true;
+      },
+    },
+  }) as typeof process.stdout;
 }
 
-export function outro(message: string): void {
-  clack.outro(message);
+export function intro(title: string, io: CommandIO = DEFAULT_IO): void {
+  clack.intro(title, { output: clackOutput(io) });
+}
+
+export function outro(message: string, io: CommandIO = DEFAULT_IO): void {
+  clack.outro(message, { output: clackOutput(io) });
 }
 
 /**
@@ -96,8 +129,11 @@ export async function select<T>(
   return value as T;
 }
 
-export function spinner(): { start(msg: string): void; stop(msg?: string): void } {
-  return clack.spinner();
+export function spinner(io: CommandIO = DEFAULT_IO): {
+  start(msg: string): void;
+  stop(msg?: string): void;
+} {
+  return clack.spinner({ output: clackOutput(io) });
 }
 
 /**

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -129,11 +129,58 @@ export async function select<T>(
   return value as T;
 }
 
+/**
+ * A spinner whose `start` / `stop` the caller drives itself.
+ *
+ * Prefer `withSpinner` — a caller that owns the pair owns the obligation to
+ * stop it on **every** path, and the frames come from a `setInterval` nothing
+ * else clears. Reach for this only when the start is conditional (the
+ * self-update download starts on the first byte-tick), and stop it in a
+ * `finally`.
+ */
 export function spinner(io: CommandIO = DEFAULT_IO): {
   start(msg: string): void;
+  message(msg: string): void;
   stop(msg?: string): void;
 } {
   return clack.spinner({ output: clackOutput(io) });
+}
+
+/**
+ * Run `fn` with a started spinner, stopping it on **every** exit path.
+ *
+ * A clack spinner paints from a `setInterval` that only `stop()` clears, so a
+ * body that throws past it leaves the frames painting for the rest of the
+ * process. In the shipped CLI that is invisible — the error unwinds to
+ * `exitWithError` and the process exits — but `bun test` runs the whole repo
+ * in one process, where the leak outlives its test: `runner.test.ts` exercised
+ * exactly such a path and its frames landed in another suite's capture
+ * (issue #1180, `Received: "◒  Enabling systemd unit..."` on `whoami`). With
+ * an injected `io` the frames go to that test's own sink instead — quieter,
+ * but an unbounded buffer growing every 80ms for the rest of the run.
+ *
+ * `stopLabel` may be a callback when the success line quotes the result (the
+ * dev server's pid). `errorLabel` defaults to `startLabel`: the frame closes
+ * on what it was doing, and the thrown error is the report. Pass it when the
+ * failure has a name of its own ("Docker not found").
+ */
+export async function withSpinner<T>(
+  startLabel: string,
+  fn: (spin: { message(msg: string): void }) => Promise<T>,
+  stopLabel: string | ((value: T) => string),
+  opts: { io?: CommandIO; errorLabel?: string } = {},
+): Promise<T> {
+  const spin = clack.spinner({ output: clackOutput(opts.io ?? DEFAULT_IO) });
+  spin.start(startLabel);
+  let value: T;
+  try {
+    value = await fn(spin);
+  } catch (err) {
+    spin.stop(opts.errorLabel ?? startLabel);
+    throw err;
+  }
+  spin.stop(typeof stopLabel === "function" ? stopLabel(value) : stopLabel);
+  return value;
 }
 
 /**

--- a/apps/cli/test/api-command.integration.test.ts
+++ b/apps/cli/test/api-command.integration.test.ts
@@ -129,6 +129,9 @@ function makeIO(overrides?: { stdinStream?: ApiCommandIO["stdinStream"] }): Capt
       exitCode.value = code;
       throw new ExitSentinel(code);
     },
+    // Production `cancel` is `clack.cancel`, a stdout writer — the capture
+    // keeps that channel so an assertion on stdout stays truthful.
+    cancel: (message) => void stdout.push(toBytes(`${message}\n`)),
     onSigint: (cb) => {
       sigintCb = cb;
     },

--- a/apps/cli/test/api-command.test.ts
+++ b/apps/cli/test/api-command.test.ts
@@ -137,6 +137,9 @@ function makeIO(): {
       // `return io.exit(…)`, so throwing short-circuits cleanly.
       throw new ExitSentinel(code);
     },
+    // Production `cancel` is `clack.cancel`, a stdout writer — the capture
+    // keeps that channel so an assertion on stdout stays truthful.
+    cancel: (message) => void stdout.push(toBytes(`${message}\n`)),
     onSigint: () => {},
   };
   return { io, stdout, stderr, exitCode };
@@ -635,6 +638,7 @@ describe("apiCommand — redirect + TLS flags", () => {
       exit: () => {
         throw new Error("should not reach exit — sync throw must bypass io.exit");
       },
+      cancel: () => {},
       onSigint: () => {},
     };
 

--- a/apps/cli/test/app-command.test.ts
+++ b/apps/cli/test/app-command.test.ts
@@ -6,6 +6,10 @@
  * We call each subcommand directly — commander is not in the loop — so
  * injected `deps` (picker / create prompt) aren't bypassed by non-TTY
  * guards.
+ *
+ * Output is captured through a per-test `createMemoryIO()` sink passed as the
+ * command's trailing `io` argument, not by reassigning the global streams —
+ * issue #1180.
  */
 
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
@@ -44,31 +48,11 @@ type FetchCall = { url: string; method: string | undefined; body?: string };
 let tmpDir: string;
 let originalXdg: string | undefined;
 const originalFetch = globalThis.fetch;
-const originalExit = process.exit;
-const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
 let fetchCalls: FetchCall[];
-let stdoutChunks: string[];
-let stderrChunks: string[];
 
 import { ExitError } from "./helpers/process-exit.ts";
-
-function captureIo(): void {
-  stdoutChunks = [];
-  stderrChunks = [];
-  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
-    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stderr.write;
-  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
-    throw new ExitError(code ?? 0);
-  }) as (code?: number) => never;
-}
+import { createMemoryIO } from "./helpers/memory-io.ts";
 
 interface Responders {
   listApps?: () => Response;
@@ -110,15 +94,11 @@ beforeEach(async () => {
   FakeKeyring.store.clear();
   _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
   fetchCalls = [];
-  captureIo();
 });
 
 afterEach(async () => {
   _setKeyringFactoryForTesting(null);
   globalThis.fetch = originalFetch;
-  process.stdout.write = originalStdoutWrite;
-  process.stderr.write = originalStderrWrite;
-  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -170,6 +150,7 @@ const twoApps = {
 
 describe("app list", () => {
   it("prints each app with a `*` marker on the pinned one and [default] tag", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn("app_2");
     installFetch({
       listApps: () =>
@@ -179,9 +160,9 @@ describe("app list", () => {
         }),
     });
 
-    await appListCommand({ profile: "default" });
+    await appListCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     const lines = out.split("\n").filter((l) => l.length > 0);
     const defaultLine = lines.find((l) => l.includes("Default"));
     const stagingLine = lines.find((l) => l.includes("Staging"));
@@ -195,6 +176,7 @@ describe("app list", () => {
   });
 
   it("prints a friendly message when the org has no applications", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn();
     installFetch({
       listApps: () =>
@@ -204,13 +186,14 @@ describe("app list", () => {
         }),
     });
 
-    await appListCommand({ profile: "default" });
-    expect(stdoutChunks.join("")).toContain("(no applications)");
+    await appListCommand({ profile: "default" }, io);
+    expect(stdout()).toContain("(no applications)");
   });
 
   it("errors out when the profile is not logged in", async () => {
-    await expect(appListCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("not configured");
+    const { io, stderr } = createMemoryIO();
+    await expect(appListCommand({ profile: "default" }, io)).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("not configured");
   });
 });
 
@@ -218,20 +201,23 @@ describe("app list", () => {
 
 describe("app current", () => {
   it("prints the pinned app id to stdout", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn("app_42");
-    await appCurrentCommand({ profile: "default" });
-    expect(stdoutChunks.join("").trim()).toBe("app_42");
+    await appCurrentCommand({ profile: "default" }, io);
+    expect(stdout().trim()).toBe("app_42");
   });
 
   it("exits 1 with a hint when no app is pinned", async () => {
+    const { io, stderr } = createMemoryIO();
     await seedLoggedIn();
-    await expect(appCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("No application pinned");
+    await expect(appCurrentCommand({ profile: "default" }, io)).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("No application pinned");
   });
 
   it("exits 1 when the profile is unconfigured", async () => {
-    await expect(appCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("Not logged in");
+    const { io, stderr } = createMemoryIO();
+    await expect(appCurrentCommand({ profile: "default" }, io)).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("Not logged in");
   });
 });
 
@@ -239,6 +225,7 @@ describe("app current", () => {
 
 describe("app switch", () => {
   it("pins the app matching the positional arg (by id)", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn("app_1");
     installFetch({
       listApps: () =>
@@ -248,13 +235,14 @@ describe("app switch", () => {
         }),
     });
 
-    await appSwitchCommand({ profile: "default", ref: "app_2" });
+    await appSwitchCommand({ profile: "default", ref: "app_2" }, {}, io);
 
     expect(await pinnedAppId()).toBe("app_2");
-    expect(stdoutChunks.join("")).toContain('Pinned "Staging"');
+    expect(stdout()).toContain('Pinned "Staging"');
   });
 
   it("uses the injected picker when no ref is passed", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn("app_1");
     installFetch({
       listApps: () =>
@@ -273,6 +261,7 @@ describe("app switch", () => {
           return apps[1]!;
         },
       },
+      io,
     );
 
     expect(seenCurrent).toBe("app_1");
@@ -280,6 +269,7 @@ describe("app switch", () => {
   });
 
   it("exits 1 when no apps exist", async () => {
+    const { io, stderr } = createMemoryIO();
     await seedLoggedIn("app_1");
     installFetch({
       listApps: () =>
@@ -289,27 +279,14 @@ describe("app switch", () => {
         }),
     });
 
-    await expect(appSwitchCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("No applications");
+    await expect(appSwitchCommand({ profile: "default" }, {}, io)).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(stderr()).toContain("No applications");
   });
 
   it("exits with an error when the ref does not match any app", async () => {
-    await seedLoggedIn("app_1");
-    installFetch({
-      listApps: () =>
-        new Response(JSON.stringify(twoApps), {
-          status: 200,
-          headers: { "Content-Type": "application/json" },
-        }),
-    });
-
-    await expect(appSwitchCommand({ profile: "default", ref: "nope" })).rejects.toBeInstanceOf(
-      ExitError,
-    );
-    expect(await pinnedAppId()).toBe("app_1"); // unchanged
-  });
-
-  it("exits with a hint when the picker returns null (non-TTY, no ref)", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn("app_1");
     installFetch({
       listApps: () =>
@@ -320,9 +297,26 @@ describe("app switch", () => {
     });
 
     await expect(
-      appSwitchCommand({ profile: "default" }, { pickApp: async () => null }),
+      appSwitchCommand({ profile: "default", ref: "nope" }, {}, io),
     ).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("non-TTY");
+    expect(await pinnedAppId()).toBe("app_1"); // unchanged
+  });
+
+  it("exits with a hint when the picker returns null (non-TTY, no ref)", async () => {
+    const { io, stderr } = createMemoryIO();
+    await seedLoggedIn("app_1");
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify(twoApps), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await expect(
+      appSwitchCommand({ profile: "default" }, { pickApp: async () => null }, io),
+    ).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("non-TTY");
     expect(await pinnedAppId()).toBe("app_1"); // unchanged
   });
 });
@@ -331,6 +325,7 @@ describe("app switch", () => {
 
 describe("app create", () => {
   it("POSTs with the positional name + auto-pins", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn();
     let createdBody: unknown;
     installFetch({
@@ -349,14 +344,15 @@ describe("app create", () => {
       },
     });
 
-    await appCreateCommand({ profile: "default", name: "Fresh" });
+    await appCreateCommand({ profile: "default", name: "Fresh" }, {}, io);
 
     expect(createdBody).toEqual({ name: "Fresh" });
     expect(await pinnedAppId()).toBe("app_new");
-    expect(stdoutChunks.join("")).toContain('Created "Fresh"');
+    expect(stdout()).toContain('Created "Fresh"');
   });
 
   it("prompts via the injected creator when no name is passed", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn();
     let createdBody: unknown;
     installFetch({
@@ -380,6 +376,7 @@ describe("app create", () => {
       {
         promptCreateApp: async () => ({ name: "Prompted" }),
       },
+      io,
     );
 
     expect(createdBody).toEqual({ name: "Prompted" });
@@ -387,19 +384,21 @@ describe("app create", () => {
   });
 
   it("exits with a hint when prompt is unavailable (non-TTY + no name)", async () => {
+    const { io, stderr } = createMemoryIO();
     await seedLoggedIn();
     installFetch({});
 
     await expect(
-      appCreateCommand({ profile: "default" }, { promptCreateApp: async () => null }),
+      appCreateCommand({ profile: "default" }, { promptCreateApp: async () => null }, io),
     ).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("non-TTY");
+    expect(stderr()).toContain("non-TTY");
   });
 
   it("requires login", async () => {
-    await expect(appCreateCommand({ profile: "default", name: "X" })).rejects.toBeInstanceOf(
-      ExitError,
-    );
-    expect(stderrChunks.join("")).toContain("not configured");
+    const { io, stderr } = createMemoryIO();
+    await expect(
+      appCreateCommand({ profile: "default", name: "X" }, {}, io),
+    ).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("not configured");
   });
 });

--- a/apps/cli/test/helpers/isolated-process.ts
+++ b/apps/cli/test/helpers/isolated-process.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Run a snippet in a child `bun` process that owns its own stdout/stderr.
+ *
+ * Used by the byte-for-byte comparisons in `io.test.ts` and `ui.test.ts`:
+ * `DEFAULT_IO` and the clack wrappers write to the *real* process streams by
+ * definition, and observing them is the one thing those tests must not do by
+ * reassigning this process's streams — that is the pattern issue #1180
+ * retires. A child owns a buffer no other suite can write to.
+ */
+
+import { join } from "node:path";
+
+/**
+ * The CLI package root (`apps/cli`), two levels up from `test/helpers/`.
+ *
+ * Pinned as the child's `cwd` because bare specifiers resolve against it:
+ * `@clack/prompts` lives in `apps/cli/node_modules` and is not hoisted to the
+ * workspace root. A child inherits the *parent's* cwd, which differs per CI
+ * job — the Unit job runs `bun test` with `working-directory: apps/cli`, the
+ * Integration job runs it from the repo root — so without this pin the child
+ * dies with "Cannot find module '@clack/prompts'" from the root and writes
+ * nothing at all. Absolute paths handed to the snippet resolve either way; it
+ * is the bare specifiers, in the snippet and inside the modules it imports,
+ * that need a cwd they can count on.
+ */
+const CLI_ROOT = join(import.meta.dir, "..", "..");
+
+export async function runIsolated(code: string) {
+  const proc = Bun.spawn([process.execPath, "-e", code], {
+    cwd: CLI_ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}

--- a/apps/cli/test/helpers/memory-io.ts
+++ b/apps/cli/test/helpers/memory-io.ts
@@ -7,12 +7,39 @@
  * `process.stdout.write` / `process.stderr.write` / `process.exit`. Because
  * `bun test` runs every package in one process, those buffers collected any
  * concurrent write in the repo and made `toBe("")` a coin flip — issue #1180.
- * A sink created here belongs to exactly one test, so its contents are
- * evidence about the command under test and nothing else.
+ *
+ * **What the buffer guarantees.** It is unshared and deterministic: only what
+ * the code under test writes *through this `io` object* can ever reach it. No
+ * other suite, no library, and not the runner itself holds a reference, so a
+ * failing assertion here always indicts the command it names. That is the
+ * whole of the guarantee — it is about *provenance*, not about which of the
+ * command's own writes end up in there.
  *
  * `exit` throws the shared `ExitError` from `process-exit.ts`, so the usual
  * `await expect(cmd(...)).rejects.toBeInstanceOf(ExitError)` unwind still
  * works and the exit code is still assertable.
+ *
+ * **Caveat: the exit unwind can add a line of its own.** Eight call sites (at
+ * the time of writing) invoke `io.exit(...)` from *inside* a `try` whose
+ * `catch` also handles errors — `src/commands/token.ts:57`, caught at `:114`,
+ * is the canonical shape. Under production `DEFAULT_IO` that `exit` never
+ * returns (the process is gone), so the `catch` is unreachable. Under this
+ * sink `exit` throws instead, and the command's own `catch` treats the
+ * `ExitError` like any other failure: it runs it through `formatError`, which
+ * falls through to `err.message` — for `ExitError` the literal string
+ * `"process.exit(<code>) called"` — and writes it out before exiting a second
+ * time. The line lands in whichever buffer that `catch` renders to: stderr
+ * when it writes `formatError(err)` itself (token.ts:115), stdout when it
+ * delegates to `exitWithError`, which goes through `cancel` (see below).
+ *
+ * That extra line is deterministic, not cross-suite pollution, and it is
+ * inherent to intercepting `exit` at all — the retired `captureIo()` produced
+ * it too. Fixing it would mean either restructuring eight `catch` blocks or
+ * teaching `src/` about a test-only error class, so it stays. The consequence
+ * for test authors: on those exit-inside-try branches assert with
+ * `toContain(...)`, never `toBe(...)`. Tightening one of them to an exact
+ * match will fail on a trailing `"process.exit(1) called\n"` that the command
+ * did not write.
  */
 
 import type { CommandIO } from "../../src/lib/io.ts";
@@ -25,9 +52,9 @@ import { ExitError } from "./process-exit.ts";
  */
 interface MemoryIO {
   io: CommandIO;
-  /** Everything written to stdout, in write order. */
+  /** Everything written to stdout, plus anything rendered through `cancel`. */
   stdout(): string;
-  /** Everything written to stderr, plus anything rendered through `cancel`. */
+  /** Everything written to stderr, in write order. */
   stderr(): string;
 }
 
@@ -53,11 +80,14 @@ export function createMemoryIO(): MemoryIO {
       exit: (code) => {
         throw new ExitError(code);
       },
-      // Production renders terminal errors with `clack.cancel` (styled, on
-      // stdout). Tests want the plain message in a predictable place, so it
-      // lands on stderr — assertions read the text, never the ANSI framing.
+      // Production renders terminal errors with `clack.cancel`, which writes
+      // to *stdout*. This sink keeps that channel and drops only the ANSI
+      // framing, so assertions read plain text on the stream the user really
+      // sees. Routing it to stderr instead (as this helper first did) made
+      // `expect(stdout()).toBe("")` pass on error paths where production
+      // prints the error on stdout — a green assertion about the wrong stream.
       cancel: (message) => {
-        err.push(`${message}\n`);
+        out.push(`${message}\n`);
       },
     },
     stdout: () => out.join(""),

--- a/apps/cli/test/helpers/memory-io.ts
+++ b/apps/cli/test/helpers/memory-io.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * In-memory `CommandIO` for CLI command tests.
+ *
+ * Replaces the `captureIo()` pattern that reassigned the *global*
+ * `process.stdout.write` / `process.stderr.write` / `process.exit`. Because
+ * `bun test` runs every package in one process, those buffers collected any
+ * concurrent write in the repo and made `toBe("")` a coin flip — issue #1180.
+ * A sink created here belongs to exactly one test, so its contents are
+ * evidence about the command under test and nothing else.
+ *
+ * `exit` throws the shared `ExitError` from `process-exit.ts`, so the usual
+ * `await expect(cmd(...)).rejects.toBeInstanceOf(ExitError)` unwind still
+ * works and the exit code is still assertable.
+ */
+
+import type { CommandIO } from "../../src/lib/io.ts";
+import { ExitError } from "./process-exit.ts";
+
+/**
+ * Not exported on purpose: knip fails the build on a type nothing imports,
+ * and `ReturnType<typeof createMemoryIO>` covers the rare caller that needs
+ * to name this shape.
+ */
+interface MemoryIO {
+  io: CommandIO;
+  /** Everything written to stdout, in write order. */
+  stdout(): string;
+  /** Everything written to stderr, plus anything rendered through `cancel`. */
+  stderr(): string;
+}
+
+export function createMemoryIO(): MemoryIO {
+  const out: string[] = [];
+  const err: string[] = [];
+  const decoder = new TextDecoder();
+  const text = (chunk: string | Uint8Array): string =>
+    typeof chunk === "string" ? chunk : decoder.decode(chunk);
+
+  return {
+    io: {
+      stdout: {
+        write(chunk) {
+          out.push(text(chunk));
+        },
+      },
+      stderr: {
+        write(chunk) {
+          err.push(text(chunk));
+        },
+      },
+      exit: (code) => {
+        throw new ExitError(code);
+      },
+      // Production renders terminal errors with `clack.cancel` (styled, on
+      // stdout). Tests want the plain message in a predictable place, so it
+      // lands on stderr — assertions read the text, never the ANSI framing.
+      cancel: (message) => {
+        err.push(`${message}\n`);
+      },
+    },
+    stdout: () => out.join(""),
+    stderr: () => err.join(""),
+  };
+}

--- a/apps/cli/test/io.test.ts
+++ b/apps/cli/test/io.test.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the `CommandIO` seam (`src/lib/io.ts`) and the
+ * `exitWithError` renderer that consumes it — issue #1180.
+ *
+ * These tests deliberately never assign to `process.stdout.write`,
+ * `process.stderr.write` or `process.exit`: that is the very pattern the seam
+ * exists to retire, and doing it here would reintroduce the cross-suite
+ * capture flake inside the test that is supposed to prove it gone. Where the
+ * real streams have to be observed — `DEFAULT_IO` writes to them by
+ * definition — a child `bun` process owns them, so the assertion is about a
+ * buffer this test alone can write to.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { CommandIO } from "../src/lib/io.ts";
+import { exitWithError } from "../src/lib/ui.ts";
+import { createMemoryIO } from "./helpers/memory-io.ts";
+import { ExitError } from "./helpers/process-exit.ts";
+
+const IO_MODULE = JSON.stringify(`${import.meta.dir}/../src/lib/io.ts`);
+const UI_MODULE = JSON.stringify(`${import.meta.dir}/../src/lib/ui.ts`);
+
+/** Run `code` in a child `bun` process that owns its own stdout/stderr. */
+async function runIsolated(code: string) {
+  const proc = Bun.spawn([process.execPath, "-e", code], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe("DEFAULT_IO", () => {
+  it("writes to the real process streams and exits with the given code", async () => {
+    const { stdout, stderr, exitCode } = await runIsolated(`
+      const { DEFAULT_IO } = await import(${IO_MODULE});
+      DEFAULT_IO.stdout.write("to-stdout");
+      DEFAULT_IO.stderr.write("to-stderr");
+      DEFAULT_IO.stdout.write(new TextEncoder().encode("-bytes"));
+      DEFAULT_IO.exit(3);
+    `);
+    expect(stdout).toBe("to-stdout-bytes");
+    expect(stderr).toBe("to-stderr");
+    expect(exitCode).toBe(3);
+  });
+
+  it("renders errors byte-for-byte as `clack.cancel` did before the seam", async () => {
+    // The guard on the "flake fix, not a UX change" constraint: the default
+    // path must keep clack's styling *and* its stdout destination.
+    const [before, after] = await Promise.all([
+      runIsolated(`
+        const clack = await import("@clack/prompts");
+        clack.cancel("boom");
+      `),
+      runIsolated(`
+        const { exitWithError } = await import(${UI_MODULE});
+        exitWithError(new Error("boom"));
+      `),
+    ]);
+    expect(after.stdout).toBe(before.stdout);
+    expect(after.stderr).toBe("");
+    expect(after.exitCode).toBe(1);
+  });
+});
+
+describe("createMemoryIO", () => {
+  it("keeps stdout and stderr in separate buffers", () => {
+    const { io, stdout, stderr } = createMemoryIO();
+    io.stdout.write("one");
+    io.stderr.write("two");
+    io.stdout.write("three");
+    expect(stdout()).toBe("onethree");
+    expect(stderr()).toBe("two");
+  });
+
+  it("decodes byte chunks so assertions read as text", () => {
+    const { io, stdout } = createMemoryIO();
+    io.stdout.write(new TextEncoder().encode("héllo"));
+    expect(stdout()).toBe("héllo");
+  });
+
+  it('starts empty, so `toBe("")` states something about this test only', () => {
+    const { stdout, stderr } = createMemoryIO();
+    expect(stdout()).toBe("");
+    expect(stderr()).toBe("");
+  });
+
+  it("throws ExitError carrying the code instead of terminating the runner", () => {
+    const { io } = createMemoryIO();
+    expect(() => io.exit(7)).toThrow(ExitError);
+    try {
+      io.exit(7);
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExitError);
+      expect((err as ExitError).code).toBe(7);
+    }
+  });
+});
+
+describe("exitWithError", () => {
+  it("routes the formatted message to the injected io and exits with the code", () => {
+    const { io, stdout, stderr } = createMemoryIO();
+    expect(() => exitWithError(new Error("nope"), io, 4)).toThrow(ExitError);
+    expect(stderr()).toBe("nope\n");
+    expect(stdout()).toBe("");
+  });
+
+  it("defaults to exit code 1", () => {
+    const { io } = createMemoryIO();
+    try {
+      exitWithError(new Error("nope"), io);
+      throw new Error("expected exitWithError to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ExitError);
+      expect((err as ExitError).code).toBe(1);
+    }
+  });
+
+  it("renders through `cancel` when the io supplies one", () => {
+    const rendered: string[] = [];
+    const io: CommandIO = {
+      stdout: { write: () => {} },
+      stderr: {
+        write: () => {
+          throw new Error("stderr must not be used when cancel is present");
+        },
+      },
+      exit: (code) => {
+        throw new ExitError(code);
+      },
+      cancel: (message) => {
+        rendered.push(message);
+      },
+    };
+    expect(() => exitWithError(new Error("styled"), io)).toThrow(ExitError);
+    // `cancel` owns its own framing, so the message arrives without a newline.
+    expect(rendered).toEqual(["styled"]);
+  });
+
+  it("falls back to stderr when the io supplies no `cancel`", () => {
+    const chunks: string[] = [];
+    const io: CommandIO = {
+      stdout: {
+        write: () => {
+          throw new Error("errors must not reach stdout on the fallback path");
+        },
+      },
+      stderr: { write: (chunk) => void chunks.push(String(chunk)) },
+      exit: (code) => {
+        throw new ExitError(code);
+      },
+    };
+    expect(() => exitWithError(new Error("plain"), io)).toThrow(ExitError);
+    expect(chunks.join("")).toBe("plain\n");
+  });
+
+  it("applies `formatError` before handing the message to the io", () => {
+    const { io, stderr } = createMemoryIO();
+    const err = Object.assign(new Error("bad input"), { hint: "pass --force" });
+    expect(() => exitWithError(err, io)).toThrow(ExitError);
+    expect(stderr()).toBe("bad input — pass --force\n");
+  });
+});

--- a/apps/cli/test/io.test.ts
+++ b/apps/cli/test/io.test.ts
@@ -18,23 +18,10 @@ import type { CommandIO } from "../src/lib/io.ts";
 import { exitWithError } from "../src/lib/ui.ts";
 import { createMemoryIO } from "./helpers/memory-io.ts";
 import { ExitError } from "./helpers/process-exit.ts";
+import { runIsolated } from "./helpers/isolated-process.ts";
 
 const IO_MODULE = JSON.stringify(`${import.meta.dir}/../src/lib/io.ts`);
 const UI_MODULE = JSON.stringify(`${import.meta.dir}/../src/lib/ui.ts`);
-
-/** Run `code` in a child `bun` process that owns its own stdout/stderr. */
-async function runIsolated(code: string) {
-  const proc = Bun.spawn([process.execPath, "-e", code], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  return { stdout, stderr, exitCode };
-}
 
 describe("DEFAULT_IO", () => {
   it("writes to the real process streams and exits with the given code", async () => {

--- a/apps/cli/test/io.test.ts
+++ b/apps/cli/test/io.test.ts
@@ -94,8 +94,10 @@ describe("exitWithError", () => {
   it("routes the formatted message to the injected io and exits with the code", () => {
     const { io, stdout, stderr } = createMemoryIO();
     expect(() => exitWithError(new Error("nope"), io, 4)).toThrow(ExitError);
-    expect(stderr()).toBe("nope\n");
-    expect(stdout()).toBe("");
+    // `createMemoryIO` renders through `cancel`, and production `cancel` is
+    // `clack.cancel` — a stdout writer. The sink keeps that channel.
+    expect(stdout()).toBe("nope\n");
+    expect(stderr()).toBe("");
   });
 
   it("defaults to exit code 1", () => {
@@ -148,9 +150,9 @@ describe("exitWithError", () => {
   });
 
   it("applies `formatError` before handing the message to the io", () => {
-    const { io, stderr } = createMemoryIO();
+    const { io, stdout } = createMemoryIO();
     const err = Object.assign(new Error("bad input"), { hint: "pass --force" });
     expect(() => exitWithError(err, io)).toThrow(ExitError);
-    expect(stderr()).toBe("bad input — pass --force\n");
+    expect(stdout()).toBe("bad input — pass --force\n");
   });
 });

--- a/apps/cli/test/io.test.ts
+++ b/apps/cli/test/io.test.ts
@@ -111,7 +111,7 @@ describe("exitWithError", () => {
     }
   });
 
-  it("renders through `cancel` when the io supplies one", () => {
+  it("routes the message through `cancel`, never through stderr", () => {
     const rendered: string[] = [];
     const io: CommandIO = {
       stdout: { write: () => {} },
@@ -130,23 +130,6 @@ describe("exitWithError", () => {
     expect(() => exitWithError(new Error("styled"), io)).toThrow(ExitError);
     // `cancel` owns its own framing, so the message arrives without a newline.
     expect(rendered).toEqual(["styled"]);
-  });
-
-  it("falls back to stderr when the io supplies no `cancel`", () => {
-    const chunks: string[] = [];
-    const io: CommandIO = {
-      stdout: {
-        write: () => {
-          throw new Error("errors must not reach stdout on the fallback path");
-        },
-      },
-      stderr: { write: (chunk) => void chunks.push(String(chunk)) },
-      exit: (code) => {
-        throw new ExitError(code);
-      },
-    };
-    expect(() => exitWithError(new Error("plain"), io)).toThrow(ExitError);
-    expect(chunks.join("")).toBe("plain\n");
   });
 
   it("applies `formatError` before handing the message to the io", () => {

--- a/apps/cli/test/login-org.test.ts
+++ b/apps/cli/test/login-org.test.ts
@@ -15,10 +15,15 @@
  *   - non-TTY + ≥2 orgs → leaves orgId unset, prints hint
  *   - failure listing orgs does not fail the login
  *
- * Follows the same stdout-capture + tmp-XDG + FakeKeyring pattern as
- * `whoami.test.ts`. We inject the interactive prompts via `LoginDeps`
- * rather than replacing `@clack/prompts` globally (CLAUDE.md bans
- * `mock.module`).
+ * Follows the same tmp-XDG + FakeKeyring pattern as `whoami.test.ts`.
+ * Everything the command needs from the outside world is injected, never
+ * swapped globally (CLAUDE.md bans `mock.module`): the interactive prompts
+ * arrive via `LoginDeps`, and stdout / stderr / exit via the `CommandIO`
+ * sink each test builds with `createMemoryIO()`. The sink matters for the
+ * same reason the prompt seam does — `bun test` runs every package in one
+ * process, so a test that reassigned `process.stdout.write` would collect
+ * writes from suites it has nothing to do with and assert on them
+ * (issue #1180). A per-test sink only ever holds this command's output.
  */
 
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
@@ -54,31 +59,11 @@ type FetchCall = { url: string; method: string | undefined; body?: string };
 let tmpDir: string;
 let originalXdg: string | undefined;
 const originalFetch = globalThis.fetch;
-const originalExit = process.exit;
-const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
 let fetchCalls: FetchCall[];
-let stdoutChunks: string[];
-let stderrChunks: string[];
 
 import { ExitError } from "./helpers/process-exit.ts";
-
-function captureIo(): void {
-  stdoutChunks = [];
-  stderrChunks = [];
-  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
-    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stderr.write;
-  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
-    throw new ExitError(code ?? 0);
-  }) as (code?: number) => never;
-}
+import { createMemoryIO } from "./helpers/memory-io.ts";
 
 /**
  * Build a JWT with `sub` + `email` claims so `decodeAccessTokenIdentity`
@@ -207,15 +192,11 @@ beforeEach(async () => {
   FakeKeyring.store.clear();
   _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
   fetchCalls = [];
-  captureIo();
 });
 
 afterEach(async () => {
   _setKeyringFactoryForTesting(null);
   globalThis.fetch = originalFetch;
-  process.stdout.write = originalStdoutWrite;
-  process.stderr.write = originalStderrWrite;
-  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -231,6 +212,7 @@ async function readPinnedAppId(profile = "default"): Promise<string | undefined>
 
 describe("login org-pin branch", () => {
   it("auto-pins the single org when the user belongs to exactly one", async () => {
+    const { io, stdout } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -243,18 +225,22 @@ describe("login org-pin branch", () => {
         ),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+      },
+      io,
+    );
 
     expect(await readPinnedOrgId()).toBe("org_only");
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain('to "Solo"');
     expect(out).toContain("org_only");
   });
 
   it("uses the injected picker and persists the chosen org when ≥2 orgs", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -271,16 +257,19 @@ describe("login org-pin branch", () => {
     });
 
     const orgsSeen: Org[][] = [];
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      deps: {
-        pickOrg: async (orgs) => {
-          orgsSeen.push(orgs);
-          return orgs[1]!;
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        deps: {
+          pickOrg: async (orgs) => {
+            orgsSeen.push(orgs);
+            return orgs[1]!;
+          },
         },
       },
-    });
+      io,
+    );
 
     expect(await readPinnedOrgId()).toBe("org_2");
     expect(orgsSeen).toHaveLength(1);
@@ -288,6 +277,7 @@ describe("login org-pin branch", () => {
   });
 
   it("inline-creates an org when the user has none and accepts the prompt", async () => {
+    const { io } = createMemoryIO();
     let createBody: unknown;
     installDefaultResponders({
       createOrg: (body) => {
@@ -305,19 +295,23 @@ describe("login org-pin branch", () => {
       },
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      deps: {
-        promptCreateOrg: async () => ({ name: "Fresh", slug: "fresh" }),
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        deps: {
+          promptCreateOrg: async () => ({ name: "Fresh", slug: "fresh" }),
+        },
       },
-    });
+      io,
+    );
 
     expect(createBody).toEqual({ name: "Fresh", slug: "fresh" });
     expect(await readPinnedOrgId()).toBe("org_new");
   });
 
   it("honors --org <slug> and pins the matching org non-interactively", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -333,22 +327,26 @@ describe("login org-pin branch", () => {
         ),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      org: "beta",
-      // Picker should NOT be called when --org is provided.
-      deps: {
-        pickOrg: async () => {
-          throw new Error("picker should not run");
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        org: "beta",
+        // Picker should NOT be called when --org is provided.
+        deps: {
+          pickOrg: async () => {
+            throw new Error("picker should not run");
+          },
         },
       },
-    });
+      io,
+    );
 
     expect(await readPinnedOrgId()).toBe("org_2");
   });
 
   it("honors --org <id> the same way as slug", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -364,16 +362,20 @@ describe("login org-pin branch", () => {
         ),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      org: "org_1",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        org: "org_1",
+      },
+      io,
+    );
 
     expect(await readPinnedOrgId()).toBe("org_1");
   });
 
   it("exits with an actionable error when --org <ref> does not match", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -387,17 +389,21 @@ describe("login org-pin branch", () => {
     });
 
     await expect(
-      loginCommand({
-        profile: "default",
-        instance: "https://app.example.com",
-        org: "does-not-exist",
-      }),
+      loginCommand(
+        {
+          profile: "default",
+          instance: "https://app.example.com",
+          org: "does-not-exist",
+        },
+        io,
+      ),
     ).rejects.toBeInstanceOf(ExitError);
 
     expect(await readPinnedOrgId()).toBeUndefined();
   });
 
   it("honors --create-org <name> without listing orgs first", async () => {
+    const { io } = createMemoryIO();
     let createBody: unknown;
     let listCalled = false;
     installDefaultResponders({
@@ -422,11 +428,14 @@ describe("login org-pin branch", () => {
       },
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      createOrg: "Forced",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        createOrg: "Forced",
+      },
+      io,
+    );
 
     expect(listCalled).toBe(false);
     expect(createBody).toEqual({ name: "Forced" });
@@ -434,6 +443,7 @@ describe("login org-pin branch", () => {
   });
 
   it("with --no-org skips the pin entirely, prints a hint, leaves orgId unset", async () => {
+    const { io, stdout } = createMemoryIO();
     let orgsCalled = false;
     installDefaultResponders({
       listOrgs: () => {
@@ -444,35 +454,43 @@ describe("login org-pin branch", () => {
       },
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      noOrg: true,
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        noOrg: true,
+      },
+      io,
+    );
 
     expect(orgsCalled).toBe(false);
     expect(await readPinnedOrgId()).toBeUndefined();
-    expect(stdoutChunks.join("")).toContain("No org pinned");
+    expect(stdout()).toContain("No org pinned");
   });
 
   it("tolerates a failing /api/orgs call — login succeeds unpinned", async () => {
+    const { io, stdout, stderr } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () => new Response("boom", { status: 500 }),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+      },
+      io,
+    );
 
     expect(await readPinnedOrgId()).toBeUndefined();
     const tokens = await loadTokens("default");
     expect(tokens?.accessToken).toBeTruthy();
-    expect(stderrChunks.join("")).toContain("Failed to list organizations");
-    expect(stdoutChunks.join("")).toContain("No org pinned");
+    expect(stderr()).toContain("Failed to list organizations");
+    expect(stdout()).toContain("No org pinned");
   });
 
   it("surfaces a POST /api/orgs failure when --create-org cannot proceed", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       createOrg: () =>
         new Response(JSON.stringify({ message: "slug_taken" }), {
@@ -482,11 +500,14 @@ describe("login org-pin branch", () => {
     });
 
     await expect(
-      loginCommand({
-        profile: "default",
-        instance: "https://app.example.com",
-        createOrg: "Acme",
-      }),
+      loginCommand(
+        {
+          profile: "default",
+          instance: "https://app.example.com",
+          createOrg: "Acme",
+        },
+        io,
+      ),
     ).rejects.toBeInstanceOf(ExitError);
 
     expect(await readPinnedOrgId()).toBeUndefined();
@@ -497,6 +518,7 @@ describe("login org-pin branch", () => {
   });
 
   it("preserves a prior orgId across a re-login when /api/orgs flakes (same user)", async () => {
+    const { io, stderr } = createMemoryIO();
     // First login — pin an org.
     installDefaultResponders({
       listOrgs: () =>
@@ -511,7 +533,7 @@ describe("login org-pin branch", () => {
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
     expect(await readPinnedOrgId()).toBe("org_first");
 
     // Second login — /api/orgs errors out. Without preservation we'd
@@ -519,13 +541,14 @@ describe("login org-pin branch", () => {
     installDefaultResponders({
       listOrgs: () => new Response("boom", { status: 500 }),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
 
     expect(await readPinnedOrgId()).toBe("org_first");
-    expect(stderrChunks.join("")).toContain("Failed to list organizations");
+    expect(stderr()).toContain("Failed to list organizations");
   });
 
   it("does NOT preserve orgId when re-logging-in as a different user", async () => {
+    const { io } = createMemoryIO();
     // First login — user A pins an org.
     installDefaultResponders({
       listOrgs: () =>
@@ -538,7 +561,7 @@ describe("login org-pin branch", () => {
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
     expect(await readPinnedOrgId()).toBe("org_A");
 
     // Second login — same profile name, DIFFERENT user. /api/orgs
@@ -559,12 +582,13 @@ describe("login org-pin branch", () => {
         ),
       listOrgs: () => new Response("boom", { status: 500 }),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
 
     expect(await readPinnedOrgId()).toBeUndefined();
   });
 
   it("writes orgId in addition to the pre-existing profile fields", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -577,10 +601,13 @@ describe("login org-pin branch", () => {
         ),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+      },
+      io,
+    );
 
     const cfg = await readConfig();
     const profile = cfg.profiles.default;
@@ -614,6 +641,7 @@ describe("login app-pin cascade", () => {
     );
 
   it("auto-pins the default application after org pin (one app)", async () => {
+    const { io, stdout } = createMemoryIO();
     installDefaultResponders({
       listOrgs: oneOrg,
       listApplications: () =>
@@ -626,18 +654,22 @@ describe("login app-pin cascade", () => {
         ),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+      },
+      io,
+    );
 
     expect(await readPinnedAppId()).toBe("app_only");
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain('/ app "Only"');
     expect(out).toContain("app_only");
   });
 
   it("pins the isDefault app when ≥2 applications exist", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: oneOrg,
       listApplications: () =>
@@ -653,12 +685,13 @@ describe("login app-pin cascade", () => {
         ),
     });
 
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
 
     expect(await readPinnedAppId()).toBe("app_default");
   });
 
   it("warns on stderr and leaves applicationId unset when ≥2 apps but no default", async () => {
+    const { io, stdout, stderr } = createMemoryIO();
     installDefaultResponders({
       listOrgs: oneOrg,
       listApplications: () =>
@@ -674,14 +707,15 @@ describe("login app-pin cascade", () => {
         ),
     });
 
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
 
     expect(await readPinnedAppId()).toBeUndefined();
-    expect(stderrChunks.join("")).toContain("none marked default");
-    expect(stdoutChunks.join("")).toContain("No app pinned");
+    expect(stderr()).toContain("none marked default");
+    expect(stdout()).toContain("No app pinned");
   });
 
   it("warns on stderr when the org has zero applications", async () => {
+    const { io, stderr } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -699,13 +733,14 @@ describe("login app-pin cascade", () => {
         }),
     });
 
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
 
     expect(await readPinnedAppId()).toBeUndefined();
-    expect(stderrChunks.join("")).toContain("No applications found");
+    expect(stderr()).toContain("No applications found");
   });
 
   it("honors --app <id> for non-interactive pinning", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -729,16 +764,20 @@ describe("login app-pin cascade", () => {
         ),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      app: "app_2",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        app: "app_2",
+      },
+      io,
+    );
 
     expect(await readPinnedAppId()).toBe("app_2");
   });
 
   it("exits with an actionable error when --app <id> does not match", async () => {
+    const { io } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -760,15 +799,19 @@ describe("login app-pin cascade", () => {
     });
 
     await expect(
-      loginCommand({
-        profile: "default",
-        instance: "https://app.example.com",
-        app: "app_does_not_exist",
-      }),
+      loginCommand(
+        {
+          profile: "default",
+          instance: "https://app.example.com",
+          app: "app_does_not_exist",
+        },
+        io,
+      ),
     ).rejects.toBeInstanceOf(ExitError);
   });
 
   it("honors --create-app <name> and skips the list fetch", async () => {
+    const { io } = createMemoryIO();
     let createBody: unknown;
     let listCalled = false;
     installDefaultResponders({
@@ -794,11 +837,14 @@ describe("login app-pin cascade", () => {
       },
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      createApp: "Forced",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        createApp: "Forced",
+      },
+      io,
+    );
 
     expect(listCalled).toBe(false);
     expect(createBody).toEqual({ name: "Forced" });
@@ -806,6 +852,7 @@ describe("login app-pin cascade", () => {
   });
 
   it("with --no-app skips the app cascade entirely (no fetch, no hint)", async () => {
+    const { io, stdout } = createMemoryIO();
     let appsCalled = false;
     installDefaultResponders({
       listApplications: () => {
@@ -814,19 +861,23 @@ describe("login app-pin cascade", () => {
       },
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      noApp: true,
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        noApp: true,
+      },
+      io,
+    );
 
     expect(appsCalled).toBe(false);
     expect(await readPinnedAppId()).toBeUndefined();
     // No "No app pinned" hint when the user opted out.
-    expect(stdoutChunks.join("")).not.toContain("No app pinned");
+    expect(stdout()).not.toContain("No app pinned");
   });
 
   it("skips the app cascade when no org was pinned (no X-Org-Id to fetch with)", async () => {
+    const { io, stdout } = createMemoryIO();
     let appsCalled = false;
     installDefaultResponders({
       listApplications: () => {
@@ -835,20 +886,24 @@ describe("login app-pin cascade", () => {
       },
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-      noOrg: true,
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+        noOrg: true,
+      },
+      io,
+    );
 
     expect(appsCalled).toBe(false);
     expect(await readPinnedAppId()).toBeUndefined();
     // The "No org pinned" hint fires; the app hint does not (skipped upstream).
-    expect(stdoutChunks.join("")).toContain("No org pinned");
-    expect(stdoutChunks.join("")).not.toContain("No app pinned");
+    expect(stdout()).toContain("No org pinned");
+    expect(stdout()).not.toContain("No app pinned");
   });
 
   it("tolerates a failing /api/applications call — login succeeds org-pinned but app-unpinned", async () => {
+    const { io, stderr } = createMemoryIO();
     installDefaultResponders({
       listOrgs: () =>
         new Response(
@@ -862,17 +917,21 @@ describe("login app-pin cascade", () => {
       listApplications: () => new Response("boom", { status: 500 }),
     });
 
-    await loginCommand({
-      profile: "default",
-      instance: "https://app.example.com",
-    });
+    await loginCommand(
+      {
+        profile: "default",
+        instance: "https://app.example.com",
+      },
+      io,
+    );
 
     expect(await readPinnedOrgId()).toBe("org_1");
     expect(await readPinnedAppId()).toBeUndefined();
-    expect(stderrChunks.join("")).toContain("Failed to list applications");
+    expect(stderr()).toContain("Failed to list applications");
   });
 
   it("preserves a prior applicationId across same-user re-login when /api/applications flakes", async () => {
+    const { io } = createMemoryIO();
     // First login — default-path cascade pins app_default via the
     // shared responder defaults.
     installDefaultResponders({
@@ -894,7 +953,7 @@ describe("login app-pin cascade", () => {
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
     expect(await readPinnedAppId()).toBe("app_pinned");
 
     // Second login — app fetch flakes. Without preservation we'd drop
@@ -911,12 +970,13 @@ describe("login app-pin cascade", () => {
         ),
       listApplications: () => new Response("boom", { status: 500 }),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
 
     expect(await readPinnedAppId()).toBe("app_pinned");
   });
 
   it("does NOT preserve applicationId when re-logging-in as a different user", async () => {
+    const { io } = createMemoryIO();
     // First login — user A pins.
     installDefaultResponders({
       listOrgs: () =>
@@ -937,7 +997,7 @@ describe("login app-pin cascade", () => {
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
     expect(await readPinnedAppId()).toBe("app_A");
 
     // Second login — different user, network flakes. Preservation must not kick in.
@@ -957,7 +1017,7 @@ describe("login app-pin cascade", () => {
       listOrgs: () => new Response("boom", { status: 500 }),
       listApplications: () => new Response("boom", { status: 500 }),
     });
-    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" }, io);
 
     expect(await readPinnedAppId()).toBeUndefined();
   });

--- a/apps/cli/test/openapi-command.test.ts
+++ b/apps/cli/test/openapi-command.test.ts
@@ -4,7 +4,7 @@
  * Integration tests for the `openapi` subcommands — exercise the full
  * resolve-profile → fetch (via stubbed global fetch) → format → stdout
  * path. Follows the `whoami.test.ts` harness pattern: fake keyring +
- * `XDG_*` tmpdirs + process stream / exit hijacking.
+ * `XDG_*` tmpdirs + a per-test injected `CommandIO`.
  *
  * The real `apiFetchRaw` is hit here (no injected fetcher), so this
  * also covers the profile + auth plumbing end-to-end. We deliberately
@@ -44,19 +44,27 @@ class FakeKeyring implements KeyringHandle {
   }
 }
 
+/**
+ * Every command invocation gets its own `createMemoryIO()` sink rather than
+ * a process-wide stream swap. `bun test` runs the whole repo in one process,
+ * so a global capture buffer also collected writes from other suites and
+ * made assertions like `toBe("")` non-deterministic (issue #1180). A fresh
+ * sink per invocation doubles as the segmentation the multi-command tests
+ * at the bottom of this file need: "what did the *second* command print?"
+ * is answered by that command's own sink, not by clearing a shared array.
+ *
+ * `io.exit` throws `ExitError`, so exit-code branches unwind without
+ * terminating the worker.
+ */
 import { ExitError } from "./helpers/process-exit.ts";
+import { createMemoryIO } from "./helpers/memory-io.ts";
 
 let tmpConfig: string;
 let tmpCache: string;
 let originalXdgConfig: string | undefined;
 let originalXdgCache: string | undefined;
 const originalFetch = globalThis.fetch;
-const originalExit = process.exit;
-const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
-let stdoutChunks: string[];
-let stderrChunks: string[];
 let fetchCalls: Array<{ url: string; method: string | undefined; headers: Record<string, string> }>;
 
 function installFetch(responder: (url: string, init?: RequestInit) => Promise<Response>): void {
@@ -67,22 +75,6 @@ function installFetch(responder: (url: string, init?: RequestInit) => Promise<Re
     return responder(url, init);
   };
   globalThis.fetch = stub as unknown as typeof fetch;
-}
-
-function captureIo(): void {
-  stdoutChunks = [];
-  stderrChunks = [];
-  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
-    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stderr.write;
-  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
-    throw new ExitError(code ?? 0);
-  }) as (code?: number) => never;
 }
 
 beforeAll(() => {
@@ -105,15 +97,11 @@ beforeEach(async () => {
   FakeKeyring.store.clear();
   _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
   fetchCalls = [];
-  captureIo();
 });
 
 afterEach(async () => {
   _setKeyringFactoryForTesting(null);
   globalThis.fetch = originalFetch;
-  process.stdout.write = originalStdoutWrite;
-  process.stderr.write = originalStderrWrite;
-  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
   await rm(tmpConfig, { recursive: true, force: true });
   await rm(tmpCache, { recursive: true, force: true });
 });
@@ -179,8 +167,9 @@ describe("openapi list", () => {
           headers: { "Content-Type": "application/json", ETag: '"v1"' },
         }),
     );
-    await openapiListCommand({ profile: "default" });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiListCommand({ profile: "default" }, io);
+    const out = stdout();
     expect(out).toContain("GET");
     expect(out).toContain("/api/runs");
     expect(out).toContain("POST");
@@ -200,8 +189,9 @@ describe("openapi list", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiListCommand({ profile: "default", tag: "RUNS" });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiListCommand({ profile: "default", tag: "RUNS" }, io);
+    const out = stdout();
     expect(out).toContain("/api/runs");
   });
 
@@ -214,8 +204,9 @@ describe("openapi list", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiListCommand({ profile: "default", json: true });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiListCommand({ profile: "default", json: true }, io);
+    const out = stdout();
     const parsed = JSON.parse(out);
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed[0]).toHaveProperty("method");
@@ -231,8 +222,9 @@ describe("openapi list", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiListCommand({ profile: "default", tag: "nonexistent" });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiListCommand({ profile: "default", tag: "nonexistent" }, io);
+    const out = stdout();
     expect(out).toMatch(/No operations match/);
   });
 
@@ -252,15 +244,16 @@ describe("openapi list", () => {
         headers: { "Content-Type": "application/json" },
       });
     });
+    const { io, stderr } = createMemoryIO();
     let code: number | undefined;
     try {
-      await openapiListCommand({ profile: "default" });
+      await openapiListCommand({ profile: "default" }, io);
     } catch (err) {
       if (err instanceof ExitError) code = err.code;
       else throw err;
     }
     expect(code).toBe(1);
-    const err = stderrChunks.join("");
+    const err = stderr();
     expect(err).toMatch(/appstrate login --profile default/);
   });
 });
@@ -275,8 +268,9 @@ describe("openapi show", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiShowCommand("createRun", undefined, { profile: "default" });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiShowCommand("createRun", undefined, { profile: "default" }, io);
+    const out = stdout();
     expect(out).toContain("POST /api/runs");
     expect(out).toContain("operationId: createRun");
     expect(out).toContain("Create a run");
@@ -292,8 +286,9 @@ describe("openapi show", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiShowCommand("GET", "/api/runs", { profile: "default" });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiShowCommand("GET", "/api/runs", { profile: "default" }, io);
+    const out = stdout();
     expect(out).toContain("GET /api/runs");
     expect(out).toContain("operationId: listRuns");
   });
@@ -307,8 +302,9 @@ describe("openapi show", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiShowCommand("createRun", undefined, { profile: "default", json: true });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiShowCommand("createRun", undefined, { profile: "default", json: true }, io);
+    const out = stdout();
     const parsed = JSON.parse(out);
     expect(parsed.method).toBe("POST");
     expect(parsed.path).toBe("/api/runs");
@@ -370,8 +366,9 @@ describe("openapi show", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiShowCommand("listCategories", undefined, { profile: "default", json: true });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiShowCommand("listCategories", undefined, { profile: "default", json: true }, io);
+    const out = stdout();
     const parsed = JSON.parse(out);
     expect(parsed.method).toBe("GET");
     expect(parsed.path).toBe("/api/categories");
@@ -390,15 +387,16 @@ describe("openapi show", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
+    const { io, stderr } = createMemoryIO();
     let code: number | undefined;
     try {
-      await openapiShowCommand("doesNotExist", undefined, { profile: "default" });
+      await openapiShowCommand("doesNotExist", undefined, { profile: "default" }, io);
     } catch (err) {
       if (err instanceof ExitError) code = err.code;
       else throw err;
     }
     expect(code).toBe(1);
-    expect(stderrChunks.join("")).toMatch(/No operation matches/);
+    expect(stderr()).toMatch(/No operation matches/);
   });
 });
 
@@ -413,8 +411,9 @@ describe("openapi export", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    await openapiExportCommand({ profile: "default" });
-    const out = stdoutChunks.join("");
+    const { io, stdout } = createMemoryIO();
+    await openapiExportCommand({ profile: "default" }, io);
+    const out = stdout();
     const parsed = JSON.parse(out);
     expect(parsed.openapi).toBe("3.1.0");
     expect(parsed.paths["/api/runs"].get.operationId).toBe("listRuns");
@@ -431,14 +430,15 @@ describe("openapi export", () => {
         }),
     );
     const target = join(tmpCache, "schema.json");
-    await openapiExportCommand({ profile: "default", output: target });
+    const { io, stdout, stderr } = createMemoryIO();
+    await openapiExportCommand({ profile: "default", output: target }, io);
     const written = await readFile(target, "utf-8");
     const parsed = JSON.parse(written);
     expect(parsed.openapi).toBe("3.1.0");
-    const err = stderrChunks.join("");
+    const err = stderr();
     expect(err).toMatch(/Wrote \d+ bytes/);
     // Nothing should leak to stdout when -o is set
-    expect(stdoutChunks.join("")).toBe("");
+    expect(stdout()).toBe("");
   });
 });
 
@@ -455,21 +455,22 @@ describe("openapi — ETag revalidation across commands", () => {
           headers: { "Content-Type": "application/json", ETag: '"v1"' },
         }),
     );
-    await openapiListCommand({ profile: "default" });
+    await openapiListCommand({ profile: "default" }, createMemoryIO().io);
     expect(fetchCalls).toHaveLength(1);
 
-    // Reset buffers and swap in a 304 responder
-    stdoutChunks = [];
-    stderrChunks = [];
+    // Second invocation gets its own sink, so what we assert below is the
+    // `show` output alone — the sink boundary is the segmentation that
+    // clearing a shared buffer used to provide.
     fetchCalls = [];
     installFetch(async (_url, init) => {
       const headers = (init?.headers ?? {}) as Record<string, string>;
       expect(headers["If-None-Match"]).toBe('"v1"');
       return new Response(null, { status: 304 });
     });
-    await openapiShowCommand("listRuns", undefined, { profile: "default" });
+    const { io: showIo, stdout: showStdout } = createMemoryIO();
+    await openapiShowCommand("listRuns", undefined, { profile: "default" }, showIo);
     expect(fetchCalls).toHaveLength(1);
-    expect(stdoutChunks.join("")).toContain("GET /api/runs");
+    expect(showStdout()).toContain("GET /api/runs");
   });
 
   it("--no-cache bypasses ETag revalidation entirely", async () => {
@@ -484,11 +485,11 @@ describe("openapi — ETag revalidation across commands", () => {
           headers: { "Content-Type": "application/json", ETag: '"v1"' },
         }),
     );
-    await openapiListCommand({ profile: "default" });
+    await openapiListCommand({ profile: "default" }, createMemoryIO().io);
 
-    // Reset + second invocation with --no-cache; server should NOT
-    // receive an If-None-Match header
-    stdoutChunks = [];
+    // Second invocation with --no-cache; server should NOT receive an
+    // If-None-Match header. A fresh sink keeps the two invocations'
+    // output separate without clearing shared state.
     fetchCalls = [];
     installFetch(async (_url, init) => {
       const headers = (init?.headers ?? {}) as Record<string, string>;
@@ -498,7 +499,7 @@ describe("openapi — ETag revalidation across commands", () => {
         headers: { "Content-Type": "application/json" },
       });
     });
-    await openapiListCommand({ profile: "default", noCache: true });
+    await openapiListCommand({ profile: "default", noCache: true }, createMemoryIO().io);
     expect(fetchCalls).toHaveLength(1);
   });
 });

--- a/apps/cli/test/org-command.test.ts
+++ b/apps/cli/test/org-command.test.ts
@@ -7,6 +7,12 @@
  * stubbed `fetch` — we don't go through commander, we call each
  * subcommand function directly so the injected `deps` (picker / create
  * prompt) aren't bypassed by non-TTY guards.
+ *
+ * Output is captured through a per-test `createMemoryIO()` sink passed as the
+ * command's trailing `io` argument. The suite used to reassign the *global*
+ * `process.stdout.write` / `process.stderr.write` / `process.exit`, which made
+ * every buffer assertion a claim about writes the test did not own — issue
+ * #1180.
  */
 
 import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
@@ -45,31 +51,11 @@ type FetchCall = { url: string; method: string | undefined; body?: string };
 let tmpDir: string;
 let originalXdg: string | undefined;
 const originalFetch = globalThis.fetch;
-const originalExit = process.exit;
-const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
 let fetchCalls: FetchCall[];
-let stdoutChunks: string[];
-let stderrChunks: string[];
 
 import { ExitError } from "./helpers/process-exit.ts";
-
-function captureIo(): void {
-  stdoutChunks = [];
-  stderrChunks = [];
-  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
-    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stderr.write;
-  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
-    throw new ExitError(code ?? 0);
-  }) as (code?: number) => never;
-}
+import { createMemoryIO } from "./helpers/memory-io.ts";
 
 interface Responders {
   listOrgs?: () => Response;
@@ -133,15 +119,11 @@ beforeEach(async () => {
   FakeKeyring.store.clear();
   _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
   fetchCalls = [];
-  captureIo();
 });
 
 afterEach(async () => {
   _setKeyringFactoryForTesting(null);
   globalThis.fetch = originalFetch;
-  process.stdout.write = originalStdoutWrite;
-  process.stderr.write = originalStderrWrite;
-  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -186,6 +168,7 @@ const twoOrgs = {
 
 describe("org list", () => {
   it("prints each org with a `*` marker on the pinned one", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn("org_2");
     installFetch({
       listOrgs: () =>
@@ -195,9 +178,9 @@ describe("org list", () => {
         }),
     });
 
-    await orgListCommand({ profile: "default" });
+    await orgListCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain("acme");
     expect(out).toContain("beta");
     // The pinned row is prefixed with `*`, the other with a space.
@@ -212,6 +195,7 @@ describe("org list", () => {
   });
 
   it("prints a friendly message when the profile has no orgs", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn();
     installFetch({
       listOrgs: () =>
@@ -221,13 +205,14 @@ describe("org list", () => {
         }),
     });
 
-    await orgListCommand({ profile: "default" });
-    expect(stdoutChunks.join("")).toContain("(no organizations)");
+    await orgListCommand({ profile: "default" }, io);
+    expect(stdout()).toContain("(no organizations)");
   });
 
   it("errors out when the profile is not logged in", async () => {
-    await expect(orgListCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("not configured");
+    const { io, stderr } = createMemoryIO();
+    await expect(orgListCommand({ profile: "default" }, io)).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("not configured");
   });
 });
 
@@ -235,20 +220,23 @@ describe("org list", () => {
 
 describe("org current", () => {
   it("prints the pinned org id to stdout", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn("org_42");
-    await orgCurrentCommand({ profile: "default" });
-    expect(stdoutChunks.join("").trim()).toBe("org_42");
+    await orgCurrentCommand({ profile: "default" }, io);
+    expect(stdout().trim()).toBe("org_42");
   });
 
   it("exits 1 with a hint when no org is pinned", async () => {
+    const { io, stderr } = createMemoryIO();
     await seedLoggedIn();
-    await expect(orgCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("No organization pinned");
+    await expect(orgCurrentCommand({ profile: "default" }, io)).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("No organization pinned");
   });
 
   it("exits 1 when the profile is unconfigured", async () => {
-    await expect(orgCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("Not logged in");
+    const { io, stderr } = createMemoryIO();
+    await expect(orgCurrentCommand({ profile: "default" }, io)).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("Not logged in");
   });
 });
 
@@ -256,6 +244,7 @@ describe("org current", () => {
 
 describe("org switch", () => {
   it("pins the org matching the positional arg (by id)", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn("org_1");
     installFetch({
       listOrgs: () =>
@@ -265,13 +254,14 @@ describe("org switch", () => {
         }),
     });
 
-    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+    await orgSwitchCommand({ profile: "default", ref: "org_2" }, {}, io);
 
     expect(await pinnedOrgId()).toBe("org_2");
-    expect(stdoutChunks.join("")).toContain('Pinned "Beta"');
+    expect(stdout()).toContain('Pinned "Beta"');
   });
 
   it("pins the org matching the positional arg (by slug)", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn("org_1");
     installFetch({
       listOrgs: () =>
@@ -281,11 +271,12 @@ describe("org switch", () => {
         }),
     });
 
-    await orgSwitchCommand({ profile: "default", ref: "beta" });
+    await orgSwitchCommand({ profile: "default", ref: "beta" }, {}, io);
     expect(await pinnedOrgId()).toBe("org_2");
   });
 
   it("uses the injected picker when no ref is passed", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn("org_1");
     installFetch({
       listOrgs: () =>
@@ -304,6 +295,7 @@ describe("org switch", () => {
           return orgs[1]!;
         },
       },
+      io,
     );
 
     expect(seenCurrent).toBe("org_1");
@@ -311,6 +303,7 @@ describe("org switch", () => {
   });
 
   it("exits 1 when no orgs exist", async () => {
+    const { io, stderr } = createMemoryIO();
     await seedLoggedIn("org_1");
     installFetch({
       listOrgs: () =>
@@ -320,11 +313,14 @@ describe("org switch", () => {
         }),
     });
 
-    await expect(orgSwitchCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
-    expect(stderrChunks.join("")).toContain("No organizations");
+    await expect(orgSwitchCommand({ profile: "default" }, {}, io)).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(stderr()).toContain("No organizations");
   });
 
   it("exits with an error when the ref does not match any org", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn("org_1");
     installFetch({
       listOrgs: () =>
@@ -334,9 +330,9 @@ describe("org switch", () => {
         }),
     });
 
-    await expect(orgSwitchCommand({ profile: "default", ref: "gamma" })).rejects.toBeInstanceOf(
-      ExitError,
-    );
+    await expect(
+      orgSwitchCommand({ profile: "default", ref: "gamma" }, {}, io),
+    ).rejects.toBeInstanceOf(ExitError);
     expect(await pinnedOrgId()).toBe("org_1"); // unchanged
   });
 });
@@ -345,6 +341,7 @@ describe("org switch", () => {
 
 describe("org create", () => {
   it("POSTs with the positional name + auto-pins", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn();
     let createdBody: unknown;
     installFetch({
@@ -363,14 +360,15 @@ describe("org create", () => {
       },
     });
 
-    await orgCreateCommand({ profile: "default", name: "Fresh" });
+    await orgCreateCommand({ profile: "default", name: "Fresh" }, {}, io);
 
     expect(createdBody).toEqual({ name: "Fresh" });
     expect(await pinnedOrgId()).toBe("org_new");
-    expect(stdoutChunks.join("")).toContain('Created "Fresh"');
+    expect(stdout()).toContain('Created "Fresh"');
   });
 
   it("forwards --slug through the request body", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn();
     let createdBody: unknown;
     installFetch({
@@ -389,11 +387,12 @@ describe("org create", () => {
       },
     });
 
-    await orgCreateCommand({ profile: "default", name: "Fresh", slug: "override" });
+    await orgCreateCommand({ profile: "default", name: "Fresh", slug: "override" }, {}, io);
     expect(createdBody).toEqual({ name: "Fresh", slug: "override" });
   });
 
   it("prompts via the injected creator when no name is passed", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn();
     let createdBody: unknown;
     installFetch({
@@ -417,6 +416,7 @@ describe("org create", () => {
       {
         promptCreateOrg: async () => ({ name: "Prompted", slug: "prompted" }),
       },
+      io,
     );
 
     expect(createdBody).toEqual({ name: "Prompted", slug: "prompted" });
@@ -424,10 +424,11 @@ describe("org create", () => {
   });
 
   it("requires login", async () => {
-    await expect(orgCreateCommand({ profile: "default", name: "X" })).rejects.toBeInstanceOf(
-      ExitError,
-    );
-    expect(stderrChunks.join("")).toContain("not configured");
+    const { io, stderr } = createMemoryIO();
+    await expect(
+      orgCreateCommand({ profile: "default", name: "X" }, {}, io),
+    ).rejects.toBeInstanceOf(ExitError);
+    expect(stderr()).toContain("not configured");
   });
 });
 
@@ -440,6 +441,7 @@ describe("org create", () => {
 
 describe("org switch — cascade: re-pins new org's default app", () => {
   it("pins the new org AND pins the new org's default app in one call", async () => {
+    const { io, stdout } = createMemoryIO();
     // Start pinned to org_1 with an app pin that only exists under org_1.
     await seedLoggedIn("org_1", "default", "app_stale_from_org_1");
     installFetch({
@@ -466,16 +468,17 @@ describe("org switch — cascade: re-pins new org's default app", () => {
         ),
     });
 
-    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+    await orgSwitchCommand({ profile: "default", ref: "org_2" }, {}, io);
 
     expect(await pinnedOrgId()).toBe("org_2");
     expect(await pinnedAppId()).toBe("app_for_org_2");
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain('Pinned "Beta"');
     expect(out).toContain('/ app "Org 2 Default"');
   });
 
   it("clears the stale app pin even when the new org has no default app", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn("org_1", "default", "app_stale");
     installFetch({
       listOrgs: () =>
@@ -490,7 +493,7 @@ describe("org switch — cascade: re-pins new org's default app", () => {
         }),
     });
 
-    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+    await orgSwitchCommand({ profile: "default", ref: "org_2" }, {}, io);
 
     expect(await pinnedOrgId()).toBe("org_2");
     // Crucially, the stale pin is gone even though no new default was found.
@@ -498,6 +501,7 @@ describe("org switch — cascade: re-pins new org's default app", () => {
   });
 
   it("tolerates a failing /api/applications call — org pin still commits", async () => {
+    const { io } = createMemoryIO();
     await seedLoggedIn("org_1", "default", "app_stale");
     installFetch({
       listOrgs: () =>
@@ -508,7 +512,7 @@ describe("org switch — cascade: re-pins new org's default app", () => {
       listApplications: () => new Response("boom", { status: 500 }),
     });
 
-    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+    await orgSwitchCommand({ profile: "default", ref: "org_2" }, {}, io);
 
     expect(await pinnedOrgId()).toBe("org_2");
     expect(await pinnedAppId()).toBeUndefined();
@@ -517,6 +521,7 @@ describe("org switch — cascade: re-pins new org's default app", () => {
 
 describe("org create — cascade: re-pins new org's default app", () => {
   it("pins the newly created org AND pins the auto-provisioned default app", async () => {
+    const { io, stdout } = createMemoryIO();
     await seedLoggedIn(undefined, "default", "app_stale");
     installFetch({
       createOrg: () =>
@@ -548,10 +553,10 @@ describe("org create — cascade: re-pins new org's default app", () => {
         ),
     });
 
-    await orgCreateCommand({ profile: "default", name: "Fresh" });
+    await orgCreateCommand({ profile: "default", name: "Fresh" }, {}, io);
 
     expect(await pinnedOrgId()).toBe("org_new");
     expect(await pinnedAppId()).toBe("app_new_default");
-    expect(stdoutChunks.join("")).toContain('/ app "Default"');
+    expect(stdout()).toContain('/ app "Default"');
   });
 });

--- a/apps/cli/test/run-remote-runner.test.ts
+++ b/apps/cli/test/run-remote-runner.test.ts
@@ -18,6 +18,7 @@ import {
   type RemoteRunRecord,
   type RemoteRunLog,
 } from "../src/commands/run/remote-runner.ts";
+import { runIsolated } from "./helpers/isolated-process.ts";
 
 // ---------------------------------------------------------------------------
 // Test harness — scripted fetch
@@ -1406,5 +1407,109 @@ describe("runRemote — record-poll resilience", () => {
         new AbortController().signal,
       ),
     ).rejects.toMatchObject({ name: "RemoteRunError", status: 500 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// writeStderr injection (issue #1180)
+// ---------------------------------------------------------------------------
+//
+// `runRemote` resolves `opts.writeStderr` for its own status lines, but the
+// console sink it builds also owns one stderr line: the `⚠` advisory rendered
+// for `appstrate.error`. Until this pair of tests existed no fixture emitted
+// that event, so the sink could be — and was — constructed with `writeStdout`
+// only, leaving the advisory on the sink's `process.stderr.write` default
+// while the caller believed it had captured every stream.
+
+/** A `system/adapter_error` log row is what `runLogToRunEvent` maps to `appstrate.error`. */
+const ADAPTER_ERROR_LOG = {
+  id: 1,
+  runId: "run_adv",
+  type: "system",
+  event: "adapter_error",
+  message: "adapter blew up",
+  level: "error",
+} satisfies RemoteRunLog;
+
+describe("runRemote — appstrate.error advisory routing", () => {
+  it("routes the ⚠ advisory through the injected writeStderr, not stdout", async () => {
+    const calls: FetchCall[] = [];
+    const fetchImpl = makeFetchImpl(
+      {
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_adv" } },
+        "GET /api/runs/run_adv/logs": {
+          status: 200,
+          body: { object: "list", data: [ADAPTER_ERROR_LOG], hasMore: false },
+        },
+        "GET /api/runs/run_adv": {
+          status: 200,
+          body: recordSummary({ id: "run_adv", status: "success" }),
+        },
+      },
+      calls,
+    );
+
+    await runToTerminal(
+      withCapturedWriters(buildBaseOpts({ fetchImpl })),
+      new AbortController().signal,
+    );
+
+    expect(writers.stderr.join("")).toContain("adapter blew up");
+    // Pins the neighbouring channel: the advisory must not leak into the
+    // stdout stream, which carries the `--json` JSONL contract.
+    expect(writers.stdout.join("")).not.toContain("adapter blew up");
+  });
+
+  it("writes nothing to the real stderr when writeStderr is injected", async () => {
+    // In-process assertions can only show the advisory reached the injected
+    // writer; they cannot show it did NOT also reach the global stream —
+    // observing that would mean reassigning `process.stderr.write`, the exact
+    // pattern issue #1180 retires. A child process owns a stderr no other
+    // suite writes to, so an empty one is real evidence. The `⚠ ` marker
+    // echoed back on stdout is the positive control: without it an empty
+    // child stderr would also be what a fixture that never emitted the event
+    // produced.
+    const runner = JSON.stringify(`${import.meta.dir}/../src/commands/run/remote-runner.ts`);
+    const log = JSON.stringify(ADAPTER_ERROR_LOG);
+    const record = JSON.stringify(recordSummary({ id: "run_adv", status: "success" }));
+    const child = await runIsolated(`
+      const { runRemote } = await import(${runner});
+      const json = (body, status) =>
+        new Response(JSON.stringify(body), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      const err = [];
+      await runRemote(
+        {
+          instance: "https://app.example.com",
+          bearerToken: "ask_test_key",
+          applicationId: "app_1",
+          orgId: "org_1",
+          scope: "@system",
+          name: "hello-world",
+          input: {},
+          json: false,
+          bundleLabel: "@system/hello-world",
+          pollIntervalMs: 1,
+          fetchImpl: (input, init) => {
+            const url = String(input);
+            if ((init?.method ?? "GET").toUpperCase() === "POST") return json({ id: "run_adv" }, 201);
+            if (url.includes("/logs"))
+              return json({ object: "list", data: [${log}], hasMore: false }, 200);
+            return json(${record}, 200);
+          },
+          writeStdout: () => {},
+          writeStderr: (chunk) => err.push(chunk),
+        },
+        new AbortController().signal,
+      );
+      process.stdout.write("CAPTURED:" + err.join(""));
+    `);
+
+    expect(child.exitCode).toBe(0);
+    expect(child.stdout).toContain("CAPTURED:");
+    expect(child.stdout).toContain("adapter blew up");
+    expect(child.stderr).toBe("");
   });
 });

--- a/apps/cli/test/run-sink.test.ts
+++ b/apps/cli/test/run-sink.test.ts
@@ -2,49 +2,68 @@
 
 /**
  * Tests for the run command's console EventSinks (JSONL + human).
- * Captures stdout/stderr writes via temporary patches — the sinks use
- * raw process.stdout/stderr.write so we intercept at that layer.
+ *
+ * Output is read back through the sink's own `writeStdout` / `writeStderr`
+ * injection points — never by reassigning the global `process.stdout.write`
+ * / `process.stderr.write`. That is issue #1180: `bun test` runs every
+ * package in one process, so a buffer installed on a global stream also
+ * collects writes from concurrent suites, and `expect(...).toBe("")` becomes
+ * a coin flip that names an innocent test when it fails. The buffers below
+ * belong to exactly one sink, so what they hold is evidence about that sink
+ * and nothing else.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach } from "bun:test";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { createConsoleSink } from "../src/commands/run/sink.ts";
+import type { EventSink } from "@appstrate/afps-runtime/interfaces";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import type { RunResult } from "@appstrate/afps-runtime/runner";
 
-interface CapturedStreams {
-  stdout: string;
-  stderr: string;
-  restore: () => void;
+/**
+ * `SinkOptions` is intentionally not exported from `sink.ts` (nothing outside
+ * needs to name it), so derive it from the factory instead of duplicating the
+ * shape here — it then tracks any future option for free.
+ */
+type SinkOptions = NonNullable<Parameters<typeof createConsoleSink>[0]>;
+
+interface MemoryStreams {
+  /** Everything this sink wrote to stdout, in write order. */
+  readonly stdout: string;
+  /** Everything this sink wrote to stderr, in write order. */
+  readonly stderr: string;
+  /**
+   * Build a sink wired to these buffers. Takes the sink's own options so a
+   * test reads exactly as it did against `createConsoleSink` — only the
+   * writers are supplied for it.
+   */
+  sink(opts?: Omit<SinkOptions, "writeStdout" | "writeStderr">): EventSink;
 }
 
-function captureStreams(): CapturedStreams {
-  const origOut = process.stdout.write.bind(process.stdout);
-  const origErr = process.stderr.write.bind(process.stderr);
-  let stdout = "";
-  let stderr = "";
-  (process.stdout as unknown as { write: (c: string | Uint8Array) => boolean }).write = (c) => {
-    stdout += typeof c === "string" ? c : new TextDecoder().decode(c);
-    return true;
-  };
-  (process.stderr as unknown as { write: (c: string | Uint8Array) => boolean }).write = (c) => {
-    stderr += typeof c === "string" ? c : new TextDecoder().decode(c);
-    return true;
-  };
+function memoryStreams(): MemoryStreams {
+  const out: string[] = [];
+  const err: string[] = [];
   return {
     get stdout() {
-      return stdout;
+      return out.join("");
     },
     get stderr() {
-      return stderr;
+      return err.join("");
     },
-    restore() {
-      (process.stdout as unknown as { write: typeof origOut }).write = origOut;
-      (process.stderr as unknown as { write: typeof origErr }).write = origErr;
+    sink(opts = {}) {
+      return createConsoleSink({
+        ...opts,
+        writeStdout: (chunk) => {
+          out.push(chunk);
+        },
+        writeStderr: (chunk) => {
+          err.push(chunk);
+        },
+      });
     },
-  } as CapturedStreams;
+  };
 }
 
 const RUN_ID = "run_sink_test";
@@ -62,14 +81,13 @@ function emptyResult(): RunResult {
 }
 
 describe("createConsoleSink — JSONL mode", () => {
-  let streams: CapturedStreams;
+  let streams: MemoryStreams;
   beforeEach(() => {
-    streams = captureStreams();
+    streams = memoryStreams();
   });
-  afterEach(() => streams.restore());
 
   it("emits one JSON line per event", async () => {
-    const sink = createConsoleSink({ json: true });
+    const sink = streams.sink({ json: true });
     await sink.handle(progressEvent("hello"));
     await sink.handle(progressEvent("world"));
 
@@ -83,7 +101,7 @@ describe("createConsoleSink — JSONL mode", () => {
   });
 
   it("emits a terminal appstrate.finalize envelope on finalize", async () => {
-    const sink = createConsoleSink({ json: true });
+    const sink = streams.sink({ json: true });
     const result = emptyResult();
     await sink.finalize(result);
 
@@ -97,7 +115,7 @@ describe("createConsoleSink — JSONL mode", () => {
   it("writes final result to outputPath when provided", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "sink-test-"));
     const out = path.join(dir, "result.json");
-    const sink = createConsoleSink({ json: true, outputPath: out });
+    const sink = streams.sink({ json: true, outputPath: out });
     await sink.finalize({ ...emptyResult(), output: { hello: true } });
     const read = await fs.readFile(out, "utf8");
     expect(read).toContain('"hello": true');
@@ -106,14 +124,13 @@ describe("createConsoleSink — JSONL mode", () => {
 });
 
 describe("createConsoleSink — human mode", () => {
-  let streams: CapturedStreams;
+  let streams: MemoryStreams;
   beforeEach(() => {
-    streams = captureStreams();
+    streams = memoryStreams();
   });
-  afterEach(() => streams.restore());
 
   it("writes progress text to stdout", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(progressEvent("doing stuff"));
     expect(streams.stdout).toContain("doing stuff");
   });
@@ -121,7 +138,7 @@ describe("createConsoleSink — human mode", () => {
   // The `report` runtime tool is gone; a stale emitter's event falls into the
   // sink's quiet default branch instead of printing anything.
   it("prints nothing for the retired report.appended event", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle({
       type: "report.appended",
       timestamp: 0,
@@ -132,13 +149,13 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("writes tool progress with tool name on stdout", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(progressEvent("Tool: read_file", { tool: "read_file" }));
     expect(streams.stdout).toContain("read_file");
   });
 
   it("writes args line when start event carries args (normal verbosity)", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool: read_file", {
         tool: "read_file",
@@ -152,7 +169,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("truncates args at the compact limit (200 chars)", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(progressEvent("Tool: t", { tool: "t", args: { data: "x".repeat(500) } }));
     // The truncation marker '...' must appear, and the line must not
     // contain the full 500-char string.
@@ -161,7 +178,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("writes a result line on tool_execution_end (success)", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool result: bash", {
         tool: "bash",
@@ -175,7 +192,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("writes a result line with ✗ glyph on tool error", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool error: bash", {
         tool: "bash",
@@ -189,7 +206,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("collapses multi-line results to a single line in normal mode", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool result: bash", {
         tool: "bash",
@@ -206,7 +223,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("preserves multi-line results in verbose mode (indented)", async () => {
-    const sink = createConsoleSink({ verbosity: "verbose" });
+    const sink = streams.sink({ verbosity: "verbose" });
     await sink.handle(
       progressEvent("Tool result: bash", {
         tool: "bash",
@@ -221,7 +238,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("pretty-prints args as multi-line JSON in verbose mode", async () => {
-    const sink = createConsoleSink({ verbosity: "verbose" });
+    const sink = streams.sink({ verbosity: "verbose" });
     await sink.handle(
       progressEvent("Tool: read_file", {
         tool: "read_file",
@@ -235,7 +252,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("suppresses tool name, args, and result in quiet mode", async () => {
-    const sink = createConsoleSink({ verbosity: "quiet" });
+    const sink = streams.sink({ verbosity: "quiet" });
     await sink.handle(
       progressEvent("Tool: read_file", {
         tool: "read_file",
@@ -253,7 +270,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("quiet mode still routes appstrate.error to stderr", async () => {
-    const sink = createConsoleSink({ verbosity: "quiet" });
+    const sink = streams.sink({ verbosity: "quiet" });
     await sink.handle({
       type: "appstrate.error",
       timestamp: 0,
@@ -264,14 +281,14 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("renders tool with no args and no result as just the name", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(progressEvent("Tool: ping", { tool: "ping" }));
     expect(streams.stdout).toContain("→ tool: ping");
     expect(streams.stdout.split("\n").filter(Boolean)).toHaveLength(1);
   });
 
   it("renders the bridge's truncation marker as a human-readable size", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool result: read_file", {
         tool: "read_file",
@@ -289,7 +306,7 @@ describe("createConsoleSink — human mode", () => {
     // terminal `[run failed]` is the only fatal indicator. Using ✗
     // here would visually contradict a successful finalize that
     // follows.
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle({
       type: "appstrate.error",
       timestamp: 0,
@@ -303,7 +320,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("renders MCP envelope results without leaking the JSON framing", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool result: log", {
         tool: "log",
@@ -317,7 +334,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("renders the bridge's truncation marker in human units", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool result: read_file", {
         tool: "read_file",
@@ -342,7 +359,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("shows short toolCallId suffix in normal mode for parallel correlation", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool: bash", {
         tool: "bash",
@@ -358,7 +375,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("omits toolCallId suffix entirely when Pi did not forward one", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle(
       progressEvent("Tool: bash", {
         tool: "bash",
@@ -370,7 +387,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("appends short toolCallId suffix (last 8 chars) in verbose mode", async () => {
-    const sink = createConsoleSink({ verbosity: "verbose" });
+    const sink = streams.sink({ verbosity: "verbose" });
     await sink.handle(
       progressEvent("Tool: bash", {
         tool: "bash",
@@ -385,7 +402,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("matches start and end events via toolCallId in verbose mode", async () => {
-    const sink = createConsoleSink({ verbosity: "verbose" });
+    const sink = streams.sink({ verbosity: "verbose" });
     await sink.handle(
       progressEvent("Tool: api_call", {
         tool: "api_call",
@@ -414,20 +431,20 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("prints run complete on successful finalize", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.finalize(emptyResult());
     expect(streams.stdout).toContain("run complete");
   });
 
   it("prints failure line when result has error", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.finalize({ ...emptyResult(), error: { message: "bad" } });
     expect(streams.stdout).toContain("bad");
     expect(streams.stdout).toContain("failed");
   });
 
   it("formats metric with token counts + cost", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle({
       type: "appstrate.metric",
       timestamp: 0,
@@ -441,7 +458,7 @@ describe("createConsoleSink — human mode", () => {
   });
 
   it("remains silent on unmapped events (no stdout, no stderr)", async () => {
-    const sink = createConsoleSink({});
+    const sink = streams.sink({});
     await sink.handle({
       type: "@my-org/audit.logged",
       timestamp: 0,
@@ -464,70 +481,74 @@ describe("createConsoleSink — human mode", () => {
 // bridge would re-aspirate them, dispatching every event twice. The
 // `writeStdout` injection lets `run.ts` route console output through
 // `bridge.writeRaw`, bypassing the interceptor.
+//
+// These three tests wire the two writers by hand rather than through
+// `memoryStreams()` — the injection itself is the subject here, so it has to
+// be visible at the call site. Each also pins the *neighbouring* channel:
+// a chunk that lands on the wrong stream would corrupt the JSONL contract
+// (stderr text inside `--json` output) or hide an advisory error in the
+// machine-readable stream.
 
 describe("createConsoleSink — writeStdout injection", () => {
   it("routes JSONL emissions through the injected writer (not process.stdout)", async () => {
     const captured: string[] = [];
-    const streams = captureStreams();
-    try {
-      const sink = createConsoleSink({
-        json: true,
-        writeStdout: (chunk) => {
-          captured.push(chunk);
-        },
-      });
-      await sink.handle(progressEvent("hello"));
-      await sink.finalize(emptyResult());
-      // Two writes captured by the injected writer; nothing leaked to
-      // the actual process.stdout (the captureStreams patch confirms it).
-      expect(captured).toHaveLength(2);
-      expect(captured[0]!.includes('"hello"')).toBe(true);
-      expect(captured[1]!.includes("appstrate.finalize")).toBe(true);
-      expect(streams.stdout).toBe("");
-    } finally {
-      streams.restore();
-    }
+    const stderrChunks: string[] = [];
+    const sink = createConsoleSink({
+      json: true,
+      writeStdout: (chunk) => {
+        captured.push(chunk);
+      },
+      writeStderr: (chunk) => {
+        stderrChunks.push(chunk);
+      },
+    });
+    await sink.handle(progressEvent("hello"));
+    await sink.finalize(emptyResult());
+    // Exactly two writes, both on the injected stdout writer: a third
+    // (or a missing) chunk is what a re-aspirating bridge would produce.
+    expect(captured).toHaveLength(2);
+    expect(captured[0]!.includes('"hello"')).toBe(true);
+    expect(captured[1]!.includes("appstrate.finalize")).toBe(true);
+    expect(stderrChunks.join("")).toBe("");
   });
 
   it("routes human-mode emissions through the injected writer", async () => {
     const captured: string[] = [];
-    const streams = captureStreams();
-    try {
-      const sink = createConsoleSink({
-        writeStdout: (chunk) => {
-          captured.push(chunk);
-        },
-      });
-      await sink.handle(progressEvent("doing stuff"));
-      await sink.finalize(emptyResult());
-      expect(captured.join("")).toContain("doing stuff");
-      expect(captured.join("")).toContain("run complete");
-      expect(streams.stdout).toBe("");
-    } finally {
-      streams.restore();
-    }
+    const stderrChunks: string[] = [];
+    const sink = createConsoleSink({
+      writeStdout: (chunk) => {
+        captured.push(chunk);
+      },
+      writeStderr: (chunk) => {
+        stderrChunks.push(chunk);
+      },
+    });
+    await sink.handle(progressEvent("doing stuff"));
+    await sink.finalize(emptyResult());
+    expect(captured.join("")).toContain("doing stuff");
+    expect(captured.join("")).toContain("run complete");
+    expect(stderrChunks.join("")).toBe("");
   });
 
-  it("keeps appstrate.error on real stderr (writeStdout is stdout-only)", async () => {
+  it("keeps appstrate.error on stderr (writeStdout is stdout-only)", async () => {
     const captured: string[] = [];
-    const streams = captureStreams();
-    try {
-      const sink = createConsoleSink({
-        writeStdout: (chunk) => {
-          captured.push(chunk);
-        },
-      });
-      await sink.handle({
-        type: "appstrate.error",
-        timestamp: 0,
-        runId: RUN_ID,
-        message: "boom",
-      } as RunEvent);
-      // The injected writer is stdout-scoped; errors still hit real stderr.
-      expect(captured).toHaveLength(0);
-      expect(streams.stderr).toContain("boom");
-    } finally {
-      streams.restore();
-    }
+    const stderrChunks: string[] = [];
+    const sink = createConsoleSink({
+      writeStdout: (chunk) => {
+        captured.push(chunk);
+      },
+      writeStderr: (chunk) => {
+        stderrChunks.push(chunk);
+      },
+    });
+    await sink.handle({
+      type: "appstrate.error",
+      timestamp: 0,
+      runId: RUN_ID,
+      message: "boom",
+    } as RunEvent);
+    // The stdout writer is stdout-scoped; errors take the stderr writer.
+    expect(captured).toHaveLength(0);
+    expect(stderrChunks.join("")).toContain("boom");
   });
 });

--- a/apps/cli/test/run-sink.test.ts
+++ b/apps/cli/test/run-sink.test.ts
@@ -490,7 +490,7 @@ describe("createConsoleSink — human mode", () => {
 // machine-readable stream.
 
 describe("createConsoleSink — writeStdout injection", () => {
-  it("routes JSONL emissions through the injected writer (not process.stdout)", async () => {
+  it("routes JSONL emissions through the injected writer, leaving stderr untouched", async () => {
     const captured: string[] = [];
     const stderrChunks: string[] = [];
     const sink = createConsoleSink({
@@ -512,7 +512,7 @@ describe("createConsoleSink — writeStdout injection", () => {
     expect(stderrChunks.join("")).toBe("");
   });
 
-  it("routes human-mode emissions through the injected writer", async () => {
+  it("routes human-mode emissions through the injected writer, leaving stderr untouched", async () => {
     const captured: string[] = [];
     const stderrChunks: string[] = [];
     const sink = createConsoleSink({

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -52,6 +52,7 @@ import {
   resolveUninstallDataDir,
   promoteStagedDaemon,
 } from "../src/commands/runner.ts";
+import { runIsolated } from "./helpers/isolated-process.ts";
 import type { RunnerExec, RunnerFs, RunnerHttp } from "../src/lib/runner/exec.ts";
 
 // ─── fakes ───────────────────────────────────────────────────────────────
@@ -753,6 +754,37 @@ describe("enableService", () => {
     await expect(enableService(deps(exec))).rejects.toThrow(
       /restart appstrate-runner failed: boom/,
     );
+  });
+
+  /**
+   * The failing path above used to leave the clack spinner running: its frames
+   * come from a `setInterval` that only `stop()` clears, and `stop()` sat after
+   * the `throw`. In the shipped CLI the leak is invisible (the error unwinds to
+   * `exitWithError` and the process exits), but `bun test` runs the whole repo
+   * in one process, so the frames kept painting into the global stdout for the
+   * rest of the run and failed whichever suite was reading it — that is the
+   * `Received: "◒  Enabling systemd unit..."` in issue #1180.
+   *
+   * Asserting "nothing paints after the rejection" means observing the real
+   * stdout, so a child process owns it: this suite must not touch the globals
+   * it is proving clean. The tail after MARKER is the window a leaked interval
+   * would paint into.
+   */
+  it("stops the spinner when the systemctl call fails (issue #1180)", async () => {
+    const { stdout } = await runIsolated(`
+      const { enableService } = await import(${JSON.stringify(`${import.meta.dir}/../src/commands/runner.ts`)});
+      const fail = async () => ({ ok: false, exitCode: 1, stdout: "", stderr: "boom" });
+      await enableService({ exec: { run: fail } }).catch(() => {});
+      process.stdout.write("MARKER");
+      await Bun.sleep(400);
+      process.stdout.write("END");
+    `);
+    const tail = stdout.split("MARKER")[1] ?? "";
+    expect(stdout).toContain("MARKER");
+    expect(tail).toContain("END");
+    // Spinner frame glyphs. A live interval paints one every ~80ms, so 400ms
+    // of silence is the falsifiable claim.
+    expect(tail).not.toMatch(/[◒◐◓◑]/);
   });
 });
 

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -52,7 +52,6 @@ import {
   resolveUninstallDataDir,
   promoteStagedDaemon,
 } from "../src/commands/runner.ts";
-import { runIsolated } from "./helpers/isolated-process.ts";
 import type { RunnerExec, RunnerFs, RunnerHttp } from "../src/lib/runner/exec.ts";
 
 // ─── fakes ───────────────────────────────────────────────────────────────
@@ -754,37 +753,6 @@ describe("enableService", () => {
     await expect(enableService(deps(exec))).rejects.toThrow(
       /restart appstrate-runner failed: boom/,
     );
-  });
-
-  /**
-   * The failing path above used to leave the clack spinner running: its frames
-   * come from a `setInterval` that only `stop()` clears, and `stop()` sat after
-   * the `throw`. In the shipped CLI the leak is invisible (the error unwinds to
-   * `exitWithError` and the process exits), but `bun test` runs the whole repo
-   * in one process, so the frames kept painting into the global stdout for the
-   * rest of the run and failed whichever suite was reading it — that is the
-   * `Received: "◒  Enabling systemd unit..."` in issue #1180.
-   *
-   * Asserting "nothing paints after the rejection" means observing the real
-   * stdout, so a child process owns it: this suite must not touch the globals
-   * it is proving clean. The tail after MARKER is the window a leaked interval
-   * would paint into.
-   */
-  it("stops the spinner when the systemctl call fails (issue #1180)", async () => {
-    const { stdout } = await runIsolated(`
-      const { enableService } = await import(${JSON.stringify(`${import.meta.dir}/../src/commands/runner.ts`)});
-      const fail = async () => ({ ok: false, exitCode: 1, stdout: "", stderr: "boom" });
-      await enableService({ exec: { run: fail } }).catch(() => {});
-      process.stdout.write("MARKER");
-      await Bun.sleep(400);
-      process.stdout.write("END");
-    `);
-    const tail = stdout.split("MARKER")[1] ?? "";
-    expect(stdout).toContain("MARKER");
-    expect(tail).toContain("END");
-    // Spinner frame glyphs. A live interval paints one every ~80ms, so 400ms
-    // of silence is the falsifiable claim.
-    expect(tail).not.toMatch(/[◒◐◓◑]/);
   });
 });
 

--- a/apps/cli/test/token.test.ts
+++ b/apps/cli/test/token.test.ts
@@ -17,7 +17,7 @@
  *      from the locally stored `expiresAt` by more than 2s.
  */
 
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -45,36 +45,19 @@ class FakeKeyring implements KeyringHandle {
 
 let tmpDir: string;
 let originalXdg: string | undefined;
-const originalExit = process.exit;
-const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
-let stdoutChunks: string[];
-let stderrChunks: string[];
-
+/**
+ * Every test injects its own sink instead of reassigning the process-wide
+ * streams. That matters most here: contract #1 is "no token plaintext ever
+ * reaches stdout or stderr", and a shared global buffer would have made the
+ * `toBe("")` checks below assertions about whatever else the single
+ * `bun test` process happened to write at that moment (issue #1180).
+ *
+ * `io.exit` throws `ExitError` so the error branches unwind without taking
+ * the test worker down with them.
+ */
 import { ExitError } from "./helpers/process-exit.ts";
-
-function captureIo(): void {
-  stdoutChunks = [];
-  stderrChunks = [];
-  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
-    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stderr.write;
-  process.exit = ((code: number) => {
-    throw new ExitError(code);
-  }) as typeof process.exit;
-}
-
-function restoreIo(): void {
-  process.stdout.write = originalStdoutWrite;
-  process.stderr.write = originalStderrWrite;
-  process.exit = originalExit;
-}
+import { createMemoryIO } from "./helpers/memory-io.ts";
 
 function makeJwt(payload: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString("base64url");
@@ -115,11 +98,6 @@ afterAll(async () => {
 
 beforeEach(() => {
   FakeKeyring.store.clear();
-  captureIo();
-});
-
-afterEach(() => {
-  restoreIo();
 });
 
 describe("token (happy path)", () => {
@@ -151,10 +129,11 @@ describe("token (happy path)", () => {
       refreshExpiresAt: refreshExp,
     });
 
-    await tokenCommand({ profile: "default" });
+    const { io, stdout, stderr } = createMemoryIO();
+    await tokenCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
-    expect(stderrChunks.join("")).toBe("");
+    const out = stdout();
+    expect(stderr()).toBe("");
 
     // Metadata present.
     expect(out).toContain("Profile:           default");
@@ -194,9 +173,10 @@ describe("token (happy path)", () => {
       refreshExpiresAt: refreshExp,
     });
 
-    await tokenCommand({ profile: "default" });
+    const { io, stdout } = createMemoryIO();
+    await tokenCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain("Status:          rotating-soon (< 30s remaining)");
   });
 
@@ -215,9 +195,10 @@ describe("token (happy path)", () => {
       refreshExpiresAt: refreshExp,
     });
 
-    await tokenCommand({ profile: "default" });
+    const { io, stdout } = createMemoryIO();
+    await tokenCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain("Status:          expired (next call will trigger rotation)");
     expect(out).toMatch(/Expires:\s+\d+m \d+s ago/);
     // Claims still render — the expiry status doesn't suppress diagnostics.
@@ -239,9 +220,10 @@ describe("token (happy path)", () => {
       refreshExpiresAt: refreshExp,
     });
 
-    await tokenCommand({ profile: "default" });
+    const { io, stdout } = createMemoryIO();
+    await tokenCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain("Status:          expiring-soon (< 24h remaining)");
   });
 
@@ -263,9 +245,10 @@ describe("token (happy path)", () => {
       refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
     });
 
-    await tokenCommand({ profile: "default" });
+    const { io, stdout } = createMemoryIO();
+    await tokenCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toMatch(/JWT `exp` and stored `expiresAt` differ by \d+s/);
   });
 
@@ -278,10 +261,11 @@ describe("token (happy path)", () => {
       refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
     });
 
-    await tokenCommand({ profile: "default" });
+    const { io, stdout, stderr } = createMemoryIO();
+    await tokenCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
-    expect(stderrChunks.join("")).toBe("");
+    const out = stdout();
+    expect(stderr()).toBe("");
     // TTL lines still render.
     expect(out).toContain("Access token");
     expect(out).toContain("Status:          fresh");
@@ -293,16 +277,17 @@ describe("token (happy path)", () => {
 
 describe("token (error paths)", () => {
   it("exits 1 with a clear hint when the profile is not configured", async () => {
+    const { io, stdout, stderr } = createMemoryIO();
     let exitCode: number | undefined;
     try {
-      await tokenCommand({ profile: "missing-profile" });
+      await tokenCommand({ profile: "missing-profile" }, io);
     } catch (err) {
       if (err instanceof ExitError) exitCode = err.code;
       else throw err;
     }
     expect(exitCode).toBe(1);
-    expect(stderrChunks.join("")).toContain(`Profile "missing-profile" not configured`);
-    expect(stdoutChunks.join("")).toBe("");
+    expect(stderr()).toContain(`Profile "missing-profile" not configured`);
+    expect(stdout()).toBe("");
   });
 
   it("exits 1 with a clear hint when the profile exists but has no stored tokens", async () => {
@@ -312,14 +297,15 @@ describe("token (error paths)", () => {
       email: "alice@example.com",
     });
 
+    const { io, stderr } = createMemoryIO();
     let exitCode: number | undefined;
     try {
-      await tokenCommand({ profile: "default" });
+      await tokenCommand({ profile: "default" }, io);
     } catch (err) {
       if (err instanceof ExitError) exitCode = err.code;
       else throw err;
     }
     expect(exitCode).toBe(1);
-    expect(stderrChunks.join("")).toContain(`No tokens stored for profile "default"`);
+    expect(stderr()).toContain(`No tokens stored for profile "default"`);
   });
 });

--- a/apps/cli/test/ui.test.ts
+++ b/apps/cli/test/ui.test.ts
@@ -49,12 +49,17 @@ describe("confirm non-TTY guard", () => {
 });
 
 describe("intro / outro / spinner io seam", () => {
-  it("renders the intro frame into the injected sink, not the real stdout", () => {
+  // Only the *injected* half is exercised in-process. The complementary
+  // property — an un-injected call still reaching the real stdout — cannot be
+  // observed from here without owning the process streams, which is exactly
+  // the pattern issue #1180 retires; asserting an un-injected call left this
+  // sink empty would be vacuous (the sink was created two lines earlier and is
+  // unreachable from a call that was never handed it), and the call itself
+  // would spray clack ANSI into the runner's own output. The un-injected path
+  // is covered instead by the byte-for-byte child-process comparisons at the
+  // bottom of this file, which own a stdout no other suite can write to.
+  it("renders the intro frame into the injected sink", () => {
     const { io, stdout, stderr } = createMemoryIO();
-    intro("Appstrate login");
-    // No `io` on that first call: it went to the real stream, so the sink
-    // this test owns is still empty — the property the whole seam exists for.
-    expect(stdout()).toBe("");
     intro("Appstrate login", io);
     expect(stdout()).toContain("Appstrate login");
     expect(stderr()).toBe("");
@@ -62,8 +67,6 @@ describe("intro / outro / spinner io seam", () => {
 
   it("renders the outro frame into the injected sink", () => {
     const { io, stdout, stderr } = createMemoryIO();
-    outro("Logged in as alice@example.com");
-    expect(stdout()).toBe("");
     outro("Logged in as alice@example.com", io);
     expect(stdout()).toContain("Logged in as alice@example.com");
     expect(stderr()).toBe("");

--- a/apps/cli/test/ui.test.ts
+++ b/apps/cli/test/ui.test.ts
@@ -22,26 +22,9 @@
 import { describe, it, expect } from "bun:test";
 import { askText, confirm, intro, outro, spinner } from "../src/lib/ui.ts";
 import { createMemoryIO } from "./helpers/memory-io.ts";
+import { runIsolated } from "./helpers/isolated-process.ts";
 
 const UI_MODULE = JSON.stringify(`${import.meta.dir}/../src/lib/ui.ts`);
-
-/**
- * Run `code` in a child `bun` process that owns its own stdout/stderr.
- *
- * Deliberately *not* shared with the identical helper in `io.test.ts`: the
- * point of both is that the test observes real process streams without
- * reassigning this process's own, and a shared helper in `test/helpers/`
- * would be a third file to keep in step for ten lines of `Bun.spawn`.
- */
-async function runIsolated(code: string) {
-  const proc = Bun.spawn([process.execPath, "-e", code], { stdout: "pipe", stderr: "pipe" });
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  await proc.exited;
-  return { stdout, stderr };
-}
 
 describe("askText non-TTY guard", () => {
   it("throws before clack when stdin is not a TTY", async () => {

--- a/apps/cli/test/ui.test.ts
+++ b/apps/cli/test/ui.test.ts
@@ -10,10 +10,38 @@
  * bun:test runs with `process.stdin.isTTY === false`, so any call to
  * the guarded helpers in this test file exercises the non-TTY branch.
  * The happy-path (TTY present) is covered by the e2e install smoke.
+ *
+ * Also covers the `CommandIO` parameter on the rendering wrappers
+ * (`intro` / `outro` / `spinner`) added for issue #1180: with a sink they
+ * render into it, and with no sink they must still produce byte-for-byte
+ * what bare clack produced before the seam existed. `io.test.ts` owns the
+ * `CommandIO`/`exitWithError` contract itself; what is asserted here is the
+ * clack-facing half of it, which lives only in these three wrappers.
  */
 
 import { describe, it, expect } from "bun:test";
-import { askText, confirm } from "../src/lib/ui.ts";
+import { askText, confirm, intro, outro, spinner } from "../src/lib/ui.ts";
+import { createMemoryIO } from "./helpers/memory-io.ts";
+
+const UI_MODULE = JSON.stringify(`${import.meta.dir}/../src/lib/ui.ts`);
+
+/**
+ * Run `code` in a child `bun` process that owns its own stdout/stderr.
+ *
+ * Deliberately *not* shared with the identical helper in `io.test.ts`: the
+ * point of both is that the test observes real process streams without
+ * reassigning this process's own, and a shared helper in `test/helpers/`
+ * would be a third file to keep in step for ten lines of `Bun.spawn`.
+ */
+async function runIsolated(code: string) {
+  const proc = Bun.spawn([process.execPath, "-e", code], { stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  await proc.exited;
+  return { stdout, stderr };
+}
 
 describe("askText non-TTY guard", () => {
   it("throws before clack when stdin is not a TTY", async () => {
@@ -34,5 +62,62 @@ describe("confirm non-TTY guard", () => {
 
   it("names the prompt message for identifiability", async () => {
     await expect(confirm("Install Bun now?")).rejects.toThrow(/Install Bun now\?/);
+  });
+});
+
+describe("intro / outro / spinner io seam", () => {
+  it("renders the intro frame into the injected sink, not the real stdout", () => {
+    const { io, stdout, stderr } = createMemoryIO();
+    intro("Appstrate login");
+    // No `io` on that first call: it went to the real stream, so the sink
+    // this test owns is still empty — the property the whole seam exists for.
+    expect(stdout()).toBe("");
+    intro("Appstrate login", io);
+    expect(stdout()).toContain("Appstrate login");
+    expect(stderr()).toBe("");
+  });
+
+  it("renders the outro frame into the injected sink", () => {
+    const { io, stdout, stderr } = createMemoryIO();
+    outro("Logged in as alice@example.com");
+    expect(stdout()).toBe("");
+    outro("Logged in as alice@example.com", io);
+    expect(stdout()).toContain("Logged in as alice@example.com");
+    expect(stderr()).toBe("");
+  });
+
+  it("gives the spinner the injected sink for both start and stop", () => {
+    const { io, stdout, stderr } = createMemoryIO();
+    const s = spinner(io);
+    s.start("Requesting device code");
+    s.stop("Code received");
+    expect(stdout()).toContain("Code received");
+    expect(stderr()).toBe("");
+  });
+
+  // The two comparisons below are the "flake fix, not a UX change" guard for
+  // the rendering wrappers: handing clack an explicit `output` must not move
+  // a byte or a colour. Each asserts non-empty output first — a child that
+  // fails to boot writes nothing, and two empty buffers compare equal.
+  it("renders intro byte-for-byte as bare clack did before the seam", async () => {
+    const message = JSON.stringify(`Appstrate login — profile "default"`);
+    const [before, after] = await Promise.all([
+      runIsolated(`const c = await import("@clack/prompts"); c.intro(${message});`),
+      runIsolated(`const u = await import(${UI_MODULE}); u.intro(${message});`),
+    ]);
+    expect(before.stdout).not.toBe("");
+    expect(after.stdout).toBe(before.stdout);
+    expect(after.stderr).toBe("");
+  });
+
+  it("renders outro byte-for-byte as bare clack did before the seam", async () => {
+    const message = JSON.stringify(`Logged in as alice@example.com to "Acme" (org_1)`);
+    const [before, after] = await Promise.all([
+      runIsolated(`const c = await import("@clack/prompts"); c.outro(${message});`),
+      runIsolated(`const u = await import(${UI_MODULE}); u.outro(${message});`),
+    ]);
+    expect(before.stdout).not.toBe("");
+    expect(after.stdout).toBe(before.stdout);
+    expect(after.stderr).toBe("");
   });
 });

--- a/apps/cli/test/ui.test.ts
+++ b/apps/cli/test/ui.test.ts
@@ -20,7 +20,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { askText, confirm, intro, outro, spinner } from "../src/lib/ui.ts";
+import { askText, confirm, intro, outro, spinner, withSpinner } from "../src/lib/ui.ts";
 import { createMemoryIO } from "./helpers/memory-io.ts";
 import { runIsolated } from "./helpers/isolated-process.ts";
 
@@ -96,5 +96,63 @@ describe("intro / outro / spinner io seam", () => {
     expect(before.stdout).not.toBe("");
     expect(after.stdout).toBe(before.stdout);
     expect(after.stderr).toBe("");
+  });
+});
+
+describe("withSpinner", () => {
+  it("returns the body's value and renders the stop frame into the injected sink", async () => {
+    const { io, stdout } = createMemoryIO();
+    const value = await withSpinner("Working", async () => 42, "Done", { io });
+    expect(value).toBe(42);
+    // Only the stop frame is asserted: a body that resolves immediately gives
+    // the paint interval no tick, so the start label never reaches the sink.
+    expect(stdout()).toContain("Done");
+  });
+
+  it("rethrows the body's error after closing the frame", async () => {
+    const { io, stdout } = createMemoryIO();
+    await expect(
+      withSpinner(
+        "Working",
+        async () => {
+          throw new Error("boom");
+        },
+        "Done",
+        { io, errorLabel: "Failed" },
+      ),
+    ).rejects.toThrow("boom");
+    expect(stdout()).toContain("Failed");
+    expect(stdout()).not.toContain("Done");
+  });
+
+  /**
+   * The defect this helper exists for. A clack spinner paints from a
+   * `setInterval` that only `stop()` clears; every site that hand-rolled
+   * start/await/stop leaked that interval when the body threw, and under
+   * `bun test` — one process for the whole repo — the frames kept landing in
+   * whatever suite ran next. That is the `Received: "◒  Enabling systemd
+   * unit..."` on an innocent `whoami` test in issue #1180.
+   *
+   * Observing "nothing paints after the throw" means observing a real stdout,
+   * so a child process owns it: this suite must not touch the globals it is
+   * proving clean. The window after MARKER is what a live interval would paint
+   * into. Control: the same snippet with a raw `clack.spinner()` fills that
+   * window with frames.
+   */
+  it("clears the paint interval when the body throws (issue #1180)", async () => {
+    const { stdout } = await runIsolated(`
+      const { withSpinner } = await import(${UI_MODULE});
+      await withSpinner("Working", async () => { throw new Error("boom"); }, "Done")
+        .catch(() => {});
+      process.stdout.write("MARKER");
+      await Bun.sleep(400);
+      process.stdout.write("END");
+    `);
+    const tail = stdout.split("MARKER")[1] ?? "";
+    expect(stdout).toContain("MARKER");
+    expect(tail).toContain("END");
+    // A live interval paints a frame every ~80ms, so 400ms of silence is the
+    // falsifiable claim.
+    expect(tail).not.toMatch(/[◒◐◓◑]/);
   });
 });

--- a/apps/cli/test/ui.test.ts
+++ b/apps/cli/test/ui.test.ts
@@ -81,26 +81,17 @@ describe("intro / outro / spinner io seam", () => {
     expect(stderr()).toBe("");
   });
 
-  // The two comparisons below are the "flake fix, not a UX change" guard for
-  // the rendering wrappers: handing clack an explicit `output` must not move
-  // a byte or a colour. Each asserts non-empty output first — a child that
-  // fails to boot writes nothing, and two empty buffers compare equal.
+  // The comparison below is the "flake fix, not a UX change" guard for the
+  // rendering wrappers: handing clack an explicit `output` must not move a
+  // byte or a colour. One wrapper is enough — `intro`, `outro` and `spinner`
+  // share the single `clackOutput` adapter, so the property is the adapter's,
+  // not each wrapper's. It asserts non-empty output first: a child that fails
+  // to boot writes nothing, and two empty buffers compare equal.
   it("renders intro byte-for-byte as bare clack did before the seam", async () => {
     const message = JSON.stringify(`Appstrate login — profile "default"`);
     const [before, after] = await Promise.all([
       runIsolated(`const c = await import("@clack/prompts"); c.intro(${message});`),
       runIsolated(`const u = await import(${UI_MODULE}); u.intro(${message});`),
-    ]);
-    expect(before.stdout).not.toBe("");
-    expect(after.stdout).toBe(before.stdout);
-    expect(after.stderr).toBe("");
-  });
-
-  it("renders outro byte-for-byte as bare clack did before the seam", async () => {
-    const message = JSON.stringify(`Logged in as alice@example.com to "Acme" (org_1)`);
-    const [before, after] = await Promise.all([
-      runIsolated(`const c = await import("@clack/prompts"); c.outro(${message});`),
-      runIsolated(`const u = await import(${UI_MODULE}); u.outro(${message});`),
     ]);
     expect(before.stdout).not.toBe("");
     expect(after.stdout).toBe(before.stdout);

--- a/apps/cli/test/whoami.test.ts
+++ b/apps/cli/test/whoami.test.ts
@@ -55,13 +55,8 @@ type FetchCall = { url: string; method: string | undefined; auth: string | null 
 let tmpDir: string;
 let originalXdg: string | undefined;
 const originalFetch = globalThis.fetch;
-const originalExit = process.exit;
-const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-const originalStderrWrite = process.stderr.write.bind(process.stderr);
 
 let fetchCalls: FetchCall[];
-let stdoutChunks: string[];
-let stderrChunks: string[];
 
 function installFetch(responder: (url: string, init?: RequestInit) => Promise<Response>): void {
   const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
@@ -78,32 +73,19 @@ function installFetch(responder: (url: string, init?: RequestInit) => Promise<Re
 }
 
 /**
- * Capture stdout + stderr without leaking to the test runner's output,
- * and turn `process.exit` into a throwable so we can assert the
- * exit-code path without killing the test worker. `whoamiCommand` only
- * uses `process.exit(1)` on error branches; the happy path returns
- * normally.
+ * Each test builds its own sink and injects it, so the captured bytes are
+ * the command's and nobody else's. The previous harness reassigned the
+ * process-wide streams; because `bun test` runs every package in one
+ * process, that buffer also collected concurrent writes from other suites
+ * and made `expect(...).toBe("")` a coin flip (issue #1180).
+ *
+ * `io.exit` throws `ExitError` instead of returning, so the rest of
+ * `whoamiCommand` doesn't execute after what would have been a fatal exit
+ * and the test worker survives. `whoamiCommand` only exits on its error
+ * branches; the happy path returns normally.
  */
 import { ExitError } from "./helpers/process-exit.ts";
-
-function captureIo(): void {
-  stdoutChunks = [];
-  stderrChunks = [];
-  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
-    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stdout.write;
-  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
-    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
-    return true;
-  }) as typeof process.stderr.write;
-  // `throw` instead of `return` so the rest of `whoamiCommand` doesn't
-  // execute after what would have been a fatal exit. This mirrors real
-  // process semantics closely enough for the assertions we care about.
-  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
-    throw new ExitError(code ?? 0);
-  }) as (code?: number) => never;
-}
+import { createMemoryIO } from "./helpers/memory-io.ts";
 
 beforeAll(() => {
   originalXdg = process.env.XDG_CONFIG_HOME;
@@ -120,15 +102,11 @@ beforeEach(async () => {
   FakeKeyring.store.clear();
   _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
   fetchCalls = [];
-  captureIo();
 });
 
 afterEach(async () => {
   _setKeyringFactoryForTesting(null);
   globalThis.fetch = originalFetch;
-  process.stdout.write = originalStdoutWrite;
-  process.stderr.write = originalStderrWrite;
-  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -167,16 +145,17 @@ describe("whoami (happy path)", () => {
       );
     });
 
-    await whoamiCommand({ profile: "default" });
+    const { io, stdout, stderr } = createMemoryIO();
+    await whoamiCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain("Profile:  default");
     expect(out).toContain("Instance: https://app.example.com");
     // Server-side identity wins over the stale cached email.
     expect(out).toContain("User:     alice@example.com");
     expect(out).not.toContain("stale@example.com");
     expect(out).toContain("Name:     Alice");
-    expect(stderrChunks.join("")).toBe("");
+    expect(stderr()).toBe("");
   });
 
   it("falls back to server `name` when `displayName` is null (fresh signup, no dashboard customization)", async () => {
@@ -200,9 +179,10 @@ describe("whoami (happy path)", () => {
         ),
     );
 
-    await whoamiCommand({ profile: "default" });
+    const { io, stdout } = createMemoryIO();
+    await whoamiCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain("Name:     Fresh User");
   });
 
@@ -222,9 +202,10 @@ describe("whoami (happy path)", () => {
         ),
     );
 
-    await whoamiCommand({ profile: "default" });
+    const { io, stdout } = createMemoryIO();
+    await whoamiCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).not.toContain("Name:");
     // User line is still present — email is the stronger identity.
     expect(out).toContain("User:     anon@example.com");
@@ -261,9 +242,10 @@ describe("whoami (happy path)", () => {
       return new Response("unknown", { status: 500 });
     });
 
-    await whoamiCommand({ profile: "default" });
+    const { io, stdout } = createMemoryIO();
+    await whoamiCommand({ profile: "default" }, io);
 
-    const out = stdoutChunks.join("");
+    const out = stdout();
     expect(out).toContain("Org:      Acme Corp (org_42)");
   });
 
@@ -291,8 +273,9 @@ describe("whoami (happy path)", () => {
       return new Response("unknown", { status: 500 });
     });
 
-    await whoamiCommand({ profile: "default" });
-    expect(stdoutChunks.join("")).toContain("Org:      org_gone");
+    const { io, stdout } = createMemoryIO();
+    await whoamiCommand({ profile: "default" }, io);
+    expect(stdout()).toContain("Org:      org_gone");
   });
 
   it("sends the stored Bearer token on /api/profile (JWT path, not cookies)", async () => {
@@ -305,7 +288,8 @@ describe("whoami (happy path)", () => {
         ),
     );
 
-    await whoamiCommand({ profile: "default" });
+    const { io } = createMemoryIO();
+    await whoamiCommand({ profile: "default" }, io);
 
     expect(fetchCalls).toHaveLength(1);
     expect(fetchCalls[0]!.auth).toBe("Bearer tok-abc");
@@ -331,34 +315,36 @@ describe("whoami (error paths)", () => {
       });
     });
 
+    const { io, stdout, stderr } = createMemoryIO();
     let exitCode: number | undefined;
     try {
-      await whoamiCommand({ profile: "default" });
+      await whoamiCommand({ profile: "default" }, io);
     } catch (err) {
       if (err instanceof ExitError) exitCode = err.code;
       else throw err;
     }
 
     expect(exitCode).toBe(1);
-    const err = stderrChunks.join("");
+    const err = stderr();
     // AuthError message from `apiFetch` — user-actionable re-login hint.
     expect(err).toMatch(/appstrate login/);
-    expect(stdoutChunks.join("")).toBe("");
+    expect(stdout()).toBe("");
   });
 
   it("exits 1 with a 'Profile ... not configured' message when the profile doesn't exist (no network)", async () => {
     installFetch(async () => new Response("should not be reached", { status: 500 }));
 
+    const { io, stderr } = createMemoryIO();
     let exitCode: number | undefined;
     try {
-      await whoamiCommand({ profile: "ghost" });
+      await whoamiCommand({ profile: "ghost" }, io);
     } catch (err) {
       if (err instanceof ExitError) exitCode = err.code;
       else throw err;
     }
 
     expect(exitCode).toBe(1);
-    expect(stderrChunks.join("")).toContain('Profile "ghost" not configured');
+    expect(stderr()).toContain('Profile "ghost" not configured');
     expect(fetchCalls).toHaveLength(0);
   });
 
@@ -368,16 +354,17 @@ describe("whoami (error paths)", () => {
       throw new TypeError("fetch failed");
     });
 
+    const { io, stderr } = createMemoryIO();
     let exitCode: number | undefined;
     try {
-      await whoamiCommand({ profile: "default" });
+      await whoamiCommand({ profile: "default" }, io);
     } catch (err) {
       if (err instanceof ExitError) exitCode = err.code;
       else throw err;
     }
 
     expect(exitCode).toBe(1);
-    const err = stderrChunks.join("");
+    const err = stderr();
     // `formatError` passes plain `Error` through as .message.
     expect(err).toContain("fetch failed");
   });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,40 @@ const API_BARREL_BAN = {
   message:
     "Use the typed OpenAPI client from src/api/client.ts ($api / client) — the legacy fetch helpers are gone.",
 };
+// Zod 4 string-format bans (single source of truth). Declared here because the
+// CLI-test block below re-declares `no-restricted-syntax` for a subset of the
+// same files — flat config replaces (not merges) a rule's options across
+// blocks, so a later block that forgot these would silently switch the Zod
+// guard off for `apps/cli/test/**`.
+const ZOD4_STRING_FORMAT_BANS = [
+  {
+    selector:
+      "CallExpression[callee.property.name='email'][callee.object.callee.object.name='z'][callee.object.callee.property.name='string']",
+    message: "Zod 4: use z.email() instead of z.string().email().",
+  },
+  {
+    selector:
+      "CallExpression[callee.property.name='url'][callee.object.callee.object.name='z'][callee.object.callee.property.name='string']",
+    message: "Zod 4: use z.url() instead of z.string().url().",
+  },
+  {
+    selector:
+      "CallExpression[callee.property.name='uuid'][callee.object.callee.object.name='z'][callee.object.callee.property.name='string']",
+    message: "Zod 4: use z.uuid() instead of z.string().uuid().",
+  },
+];
+
+// Assignments to the global process streams / exit, banned in CLI tests.
+// The selectors deliberately match through casts — the pattern this replaces
+// wrote `(process as unknown as { exit: … }).exit = original`, so anchoring on
+// `left.object.name === 'process'` alone would miss the exact code that caused
+// the bug. Matching a `process` node *inside* the assignment target catches the
+// plain form and every `as`-wrapped variant of it.
+const globalIoBan = (target, selector) => ({
+  selector,
+  message: `CLI tests must not assign to ${target}. \`bun test\` runs every package in one process, so a global capture buffer also collects what other suites, libraries and the runner write — the assertion then fails non-deterministically and names an innocent test (issue #1180). Pass the command an injected CommandIO instead: createMemoryIO() from test/helpers/memory-io.ts.`,
+});
+
 const AUTH_CLIENT_BAN = {
   // Matches "../lib/auth-client", "../../lib/auth-client" and
   // "@/lib/auth-client". Only hooks/use-auth.ts (the seam) may import it.
@@ -58,23 +92,39 @@ export default tseslint.config(
     // and must not creep back in.
     files: ["**/src/**/*.{ts,tsx}", "**/test/**/*.ts"],
     rules: {
+      "no-restricted-syntax": ["error", ...ZOD4_STRING_FORMAT_BANS],
+    },
+  },
+  {
+    // Global-stream capture guard (issue #1180): CLI tests used to assert on
+    // output by swapping the *global* `process.stdout.write` /
+    // `process.stderr.write` / `process.exit` for the duration of a test. The
+    // whole repo runs in one `bun test` process, so that buffer is not owned by
+    // the test writing to it — `expect(captured).toBe("")` was a coin flip that
+    // blamed whichever command happened to be running. Commands take a
+    // `CommandIO` (src/lib/io.ts); tests build a private sink with
+    // `createMemoryIO()` (test/helpers/memory-io.ts).
+    //
+    // This re-declares `no-restricted-syntax` for a subset of the block above,
+    // which fully REPLACES its options here — hence the explicit spread of the
+    // Zod 4 bans, so they keep firing in `apps/cli/test/**` too.
+    files: ["apps/cli/test/**/*.ts"],
+    rules: {
       "no-restricted-syntax": [
         "error",
-        {
-          selector:
-            "CallExpression[callee.property.name='email'][callee.object.callee.object.name='z'][callee.object.callee.property.name='string']",
-          message: "Zod 4: use z.email() instead of z.string().email().",
-        },
-        {
-          selector:
-            "CallExpression[callee.property.name='url'][callee.object.callee.object.name='z'][callee.object.callee.property.name='string']",
-          message: "Zod 4: use z.url() instead of z.string().url().",
-        },
-        {
-          selector:
-            "CallExpression[callee.property.name='uuid'][callee.object.callee.object.name='z'][callee.object.callee.property.name='string']",
-          message: "Zod 4: use z.uuid() instead of z.string().uuid().",
-        },
+        ...ZOD4_STRING_FORMAT_BANS,
+        globalIoBan(
+          "process.stdout.write",
+          "AssignmentExpression > MemberExpression.left[property.name='write'] MemberExpression[object.name='process'][property.name='stdout']",
+        ),
+        globalIoBan(
+          "process.stderr.write",
+          "AssignmentExpression > MemberExpression.left[property.name='write'] MemberExpression[object.name='process'][property.name='stderr']",
+        ),
+        globalIoBan(
+          "process.exit",
+          "AssignmentExpression > MemberExpression.left[property.name='exit'] Identifier[name='process']",
+        ),
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,6 +111,31 @@ export default tseslint.config(
     },
   },
   {
+    // Unguarded-spinner guard (issue #1180). A clack spinner paints from a
+    // `setInterval` that only `stop()` clears, so a `start()` whose body throws
+    // leaks a writer for the rest of the process — invisible in the shipped CLI
+    // (the error exits it), fatal under `bun test`, where one process runs every
+    // suite and the frames land in someone else's capture. `withSpinner`
+    // (src/lib/ui.ts) owns the start/stop pair; `ui.ts` itself is where the one
+    // remaining `clack.spinner()` call lives.
+    //
+    // Re-declares `no-restricted-syntax` for a subset of the Zod block above,
+    // which fully REPLACES its options here — hence the explicit spread.
+    files: ["apps/cli/src/**/*.ts"],
+    ignores: ["apps/cli/src/lib/ui.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        ...ZOD4_STRING_FORMAT_BANS,
+        {
+          selector: "CallExpression[callee.object.name='clack'][callee.property.name='spinner']",
+          message:
+            "Use `withSpinner` from lib/ui.ts — it stops the spinner on every exit path. A raw `clack.spinner()` leaks its paint interval when the body throws (issue #1180). For a conditional start, use `spinner()` from lib/ui.ts and stop it in a `finally`.",
+        },
+      ],
+    },
+  },
+  {
     // Global-stream capture guard (issue #1180): tests used to assert on output
     // by swapping the *global* `process.stdout.write` / `process.stderr.write`
     // / `process.exit` for the duration of a call. The whole repo runs in one

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,15 +42,30 @@ const ZOD4_STRING_FORMAT_BANS = [
   },
 ];
 
-// Assignments to the global process streams / exit, banned in CLI tests.
-// The selectors deliberately match through casts — the pattern this replaces
-// wrote `(process as unknown as { exit: … }).exit = original`, so anchoring on
-// `left.object.name === 'process'` alone would miss the exact code that caused
-// the bug. Matching a `process` node *inside* the assignment target catches the
-// plain form and every `as`-wrapped variant of it.
+// Global-stream capture, banned in CLI tests. Two shapes are matched:
+// assigning over `process.stdout.write` / `process.stderr.write` /
+// `process.exit`, and `spyOn`-ing the two stream writes (which reaches the
+// same global through a different door — the rule would be theatre without
+// it). All three assignment selectors match through casts: the pattern this
+// replaces wrote `(process as unknown as { exit: … }).exit = original`, so
+// anchoring on `left.object.name === 'process'` would miss the exact code that
+// caused the bug. They anchor on a `process` Identifier *descendant* of the
+// assignment target instead, which the cast cannot hide.
+//
+// NOT covered, and deliberately so — each would need a selector broad enough
+// to fire on innocent code, or type information ESLint's AST pass does not
+// have. They are documented so nobody reads a green lint as proof of absence:
+//   - aliasing:            `const p = process; p.stdout.write = fn`
+//   - computed access:     `process["stdout"].write = fn`
+//   - destructuring:       `const { stdout } = process; stdout.write = fn`
+//   - defineProperty:      `Object.defineProperty(process, "exit", …)`
+//   - a cast on the spy target: `spyOn(process.stdout as any, "write")`
+// `spyOn(process, "exit")` is also intentionally allowed: install.test.ts uses
+// it with a `finally` restore for the installer's terminal paths, which is a
+// different problem from capturing output.
 const globalIoBan = (target, selector) => ({
   selector,
-  message: `CLI tests must not assign to ${target}. \`bun test\` runs every package in one process, so a global capture buffer also collects what other suites, libraries and the runner write — the assertion then fails non-deterministically and names an innocent test (issue #1180). Pass the command an injected CommandIO instead: createMemoryIO() from test/helpers/memory-io.ts.`,
+  message: `CLI tests must not take over the global ${target} (by assignment or \`spyOn\`). \`bun test\` runs every package in one process, so a global capture buffer also collects what other suites, libraries and the runner write — the assertion then fails non-deterministically and names an innocent test (issue #1180). Pass the command an injected CommandIO instead: createMemoryIO() from test/helpers/memory-io.ts.`,
 });
 
 const AUTH_CLIENT_BAN = {
@@ -115,15 +130,23 @@ export default tseslint.config(
         ...ZOD4_STRING_FORMAT_BANS,
         globalIoBan(
           "process.stdout.write",
-          "AssignmentExpression > MemberExpression.left[property.name='write'] MemberExpression[object.name='process'][property.name='stdout']",
+          "AssignmentExpression > MemberExpression.left[property.name='write'] MemberExpression[property.name='stdout'] Identifier[name='process']",
         ),
         globalIoBan(
           "process.stderr.write",
-          "AssignmentExpression > MemberExpression.left[property.name='write'] MemberExpression[object.name='process'][property.name='stderr']",
+          "AssignmentExpression > MemberExpression.left[property.name='write'] MemberExpression[property.name='stderr'] Identifier[name='process']",
         ),
         globalIoBan(
           "process.exit",
           "AssignmentExpression > MemberExpression.left[property.name='exit'] Identifier[name='process']",
+        ),
+        globalIoBan(
+          "process.stdout.write",
+          "CallExpression[callee.name='spyOn'][arguments.0.object.name='process'][arguments.0.property.name='stdout'][arguments.1.value='write']",
+        ),
+        globalIoBan(
+          "process.stderr.write",
+          "CallExpression[callee.name='spyOn'][arguments.0.object.name='process'][arguments.0.property.name='stderr'][arguments.1.value='write']",
         ),
       ],
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -111,19 +111,23 @@ export default tseslint.config(
     },
   },
   {
-    // Global-stream capture guard (issue #1180): CLI tests used to assert on
-    // output by swapping the *global* `process.stdout.write` /
-    // `process.stderr.write` / `process.exit` for the duration of a test. The
-    // whole repo runs in one `bun test` process, so that buffer is not owned by
-    // the test writing to it — `expect(captured).toBe("")` was a coin flip that
-    // blamed whichever command happened to be running. Commands take a
-    // `CommandIO` (src/lib/io.ts); tests build a private sink with
-    // `createMemoryIO()` (test/helpers/memory-io.ts).
+    // Global-stream capture guard (issue #1180): tests used to assert on output
+    // by swapping the *global* `process.stdout.write` / `process.stderr.write`
+    // / `process.exit` for the duration of a call. The whole repo runs in one
+    // `bun test` process, so that buffer is not owned by the test writing to it
+    // — `expect(captured).toBe("")` was a coin flip that blamed whichever
+    // command happened to be running, and a reader that parses its capture
+    // (the sidecar's JSON log lines) got a hard `SyntaxError` instead.
+    //
+    // Every package, not just `apps/cli`: they share the one process, so a
+    // global capture anywhere is a capture of everything. Inject a sink the
+    // test owns — `createMemoryIO()` (apps/cli/test/helpers/memory-io.ts) for
+    // CLI commands, `_setLogSinkForTesting()` for the sidecar logger.
     //
     // This re-declares `no-restricted-syntax` for a subset of the block above,
     // which fully REPLACES its options here — hence the explicit spread of the
-    // Zod 4 bans, so they keep firing in `apps/cli/test/**` too.
-    files: ["apps/cli/test/**/*.ts"],
+    // Zod 4 bans, so they keep firing in `**/test/**` too.
+    files: ["**/test/**/*.ts"],
     rules: {
       "no-restricted-syntax": [
         "error",

--- a/runtime-pi/sidecar/logger.ts
+++ b/runtime-pi/sidecar/logger.ts
@@ -19,6 +19,28 @@ function envLevel(): Level {
   return "info";
 }
 
+/**
+ * Where emitted lines go. `null` is production: the real process streams.
+ *
+ * A test that wants to read what the logger emitted used to swap the *global*
+ * `process.stdout.write` for the duration of a call. `bun test` runs the whole
+ * repo in one process, so that buffer also collected whatever any other suite
+ * or library wrote in that window — and this logger's readers parse every
+ * captured line as JSON, so one foreign byte is a `SyntaxError`, not a soft
+ * assertion failure (issue #1180). Routing through a sink the test owns keeps
+ * the buffer to lines this logger actually produced.
+ */
+let testSink: ((level: Level, line: string) => void) | null = null;
+
+/**
+ * Redirect emitted lines to `sink`, or back to the process streams with
+ * `null`. Test-only — production never calls it, and the threshold check still
+ * runs first, so a sink observes exactly what would have been written.
+ */
+export function _setLogSinkForTesting(sink: ((level: Level, line: string) => void) | null): void {
+  testSink = sink;
+}
+
 function emit(level: Level, msg: string, data?: Record<string, unknown>): void {
   // Evaluated per-call (not captured at import) so `LOG_LEVEL` can be raised
   // to `debug` for diagnostics without a process restart, and so tests can
@@ -30,6 +52,10 @@ function emit(level: Level, msg: string, data?: Record<string, unknown>): void {
     msg,
     ...(data ?? {}),
   });
+  if (testSink) {
+    testSink(level, line + "\n");
+    return;
+  }
   if (level === "error" || level === "warn") {
     process.stderr.write(line + "\n");
   } else {

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect, mock } from "bun:test";
 import { executeApiCall, type ApiCallDeps } from "../credential-proxy.ts";
+import { _setLogSinkForTesting } from "../logger.ts";
 import type { CredentialsResponse } from "../helpers.ts";
 
 function makeDeps(overrides: Partial<ApiCallDeps> = {}): ApiCallDeps {
@@ -1325,9 +1326,17 @@ describe("executeApiCall — finalUrl exposure (#471)", () => {
 
 describe("executeApiCall — debug diagnostic envelope (#404)", () => {
   /**
-   * Capture stdout lines written by the sidecar logger during `fn`, restore
-   * the original writer afterwards, and return the parsed JSON log records.
-   * The diagnostic envelope is a `debug` line, so it lands on stdout.
+   * Capture the stdout-bound lines the sidecar logger emits during `fn` and
+   * return them parsed. The diagnostic envelope is a `debug` line, so it
+   * lands on stdout — `warn`/`error` go to stderr and are filtered out here,
+   * exactly as the previous stdout-only capture did.
+   *
+   * The sink belongs to this call (`_setLogSinkForTesting`), it is not the
+   * global `process.stdout.write`. `bun test` runs the whole repo in one
+   * process, so a global capture also collects what other suites, libraries
+   * and the runner write — and every captured line is `JSON.parse`d below, so
+   * one foreign frame would be a hard `SyntaxError` on an innocent test
+   * (issue #1180).
    */
   async function captureLogs(
     level: string | undefined,
@@ -1337,15 +1346,14 @@ describe("executeApiCall — debug diagnostic envelope (#404)", () => {
     if (level === undefined) delete process.env.LOG_LEVEL;
     else process.env.LOG_LEVEL = level;
     const lines: string[] = [];
-    const original = process.stdout.write.bind(process.stdout);
-    process.stdout.write = ((chunk: unknown): boolean => {
-      lines.push(String(chunk));
-      return true;
-    }) as typeof process.stdout.write;
+    _setLogSinkForTesting((lineLevel, line) => {
+      if (lineLevel === "warn" || lineLevel === "error") return;
+      lines.push(line);
+    });
     try {
       await fn();
     } finally {
-      process.stdout.write = original;
+      _setLogSinkForTesting(null);
       if (prevLevel === undefined) delete process.env.LOG_LEVEL;
       else process.env.LOG_LEVEL = prevLevel;
     }


### PR DESCRIPTION
Closes #1180.

## The defect

Six CLI suites captured a command's output by reassigning the **global** `process.stdout.write` / `process.stderr.write` / `process.exit`. `bun test` runs the whole repo in one process, so between `captureIo()` and its restore, any write from any other suite, any library, or the runner itself landed in the capture buffer and was attributed to the command under test.

`expect(stdoutChunks.join("")).toBe("")` is therefore an assertion about a buffer the test does not own. It passes only when nothing else happens to write during that window — a timing property of the machine, not of the code. Two things make it expensive: the failure is non-deterministic, and it names an **innocent** test, so the first instinct is to hunt a regression that does not exist.

## Two corrections to the issue

**1. The polluter is in this repository.** The issue says of `Enabling systemd unit`: *"no code in this repository produces it."* It is `apps/cli/src/commands/runner.ts:437`. `enableService` starts a clack spinner and never stops it on its error paths, so the spinner's `setInterval` keeps painting frames into global stdout for the rest of the process. A full `apps/cli` run shows those frames interleaved with output from the *lifecycle* and *tier0* suites. This also explains the issue's observation that the problem worsens as the suite grows: a leaked timer plus a longer run is a wider window. The leak is harmless in production (the error propagates to `exitWithError` and the process exits), which is why it went unnoticed — but it is the source of the bytes, so it is fixed here rather than deferred. See **The polluter, and the class it belongs to** below.

**2. The blast radius is eight suites, not six.** `apps/cli/test/run-sink.test.ts` does the same thing and carries **six** `toBe("")` assertions on the shared buffer — more than any of the six known suites. Neither the issue's list nor any grep found it, because its assignment is cast-wrapped:

```ts
(process.stdout as unknown as { write: (c: string | Uint8Array) => boolean }).write = …
```

The eslint rule in this PR is what surfaced it. That is the argument for having the rule at all: the pattern is grep-resistant, so "we fixed every occurrence we could find" was never going to be durable on its own.

The eighth is outside `apps/cli`: `runtime-pi/sidecar/test/credential-proxy.test.ts` swaps the global `process.stdout.write` to read the sidecar's JSON log lines. It has the worst failure mode of the eight — every captured line is `JSON.parse`d, so one foreign byte is a hard `SyntaxError` on an innocent test, not a soft assertion failure. It was invisible to the first pass because the guardrail was scoped to `apps/cli/test/**`; the whole repo shares one `bun test` process, so a global capture *anywhere* captures everything. The rule now covers `**/test/**/*.ts`, and the sidecar logger gained `_setLogSinkForTesting` — applied after the level threshold, so a sink observes exactly what would have been written.

## The fix

Dependency injection, as the issue prescribes, following two seams that already existed in this CLI — `ApiCommandIO` (`commands/api/types.ts`) and the `writeStdout` option of `commands/run/sink.ts`.

`src/lib/io.ts` defines `CommandIO`: `stdout`, `stderr`, `exit`, and an optional `cancel` for the styled terminal-error renderer. Every converted command takes a trailing `io: CommandIO = DEFAULT_IO`, so `src/cli.ts` needs no edit. Tests build a private sink with `createMemoryIO()`; `toBe("")` becomes a true statement about the command, and concurrent output from anywhere else is irrelevant.

Neither weaker alternative the issue lists for the record is used: no `toBe("")` was relaxed to `not.toContain(...)`, and the CLI suites still run in the same invocation.

Three things the seam had to reach that a command-by-command sweep would have missed:

- **`exitWithError`** called `process.exit` directly. Injection alone would still have killed the test worker.
- **`requireLoggedIn`** (`lib/config.ts`) writes its "not configured" message and exits *before* the command's `try` block, so six tests could not be fixed from the command files at all.
- **`intro` / `outro` / `spinner`** render to global stdout, and the login summary they print is asserted output, not decoration. The seam went into the `ui.ts` wrappers, so `ui.ts` stays the single owner of the clack coupling and no command file needs to import clack or cast a sink to make its own output testable.

## Production output is unchanged, and that is tested

`clackOutput` prototypes off `process.stdout` rather than handing clack the four-member sink directly, because clack asks its output for more than `write`:

- `spinner()` reads `output.columns` to wrap frames. A bare sink has none, and clack silently falls back to 80 — every spinner line would rewrap on a wider terminal. Measured: real stream 200, bare sink 80, prototype adapter 200.
- It hands the stream to `node:readline`, which passes a continuation to `write(chunk, cb)` and stalls its cursor bookkeeping if nobody calls it.

Only bytes are redirected; geometry, `isTTY` and readline interop are untouched. `ui.test.ts` and `io.test.ts` compare `intro`, `outro` and `exitWithError` byte-for-byte against bare clack in isolated child processes. The spinner is deliberately **not** byte-compared — it paints on an interval, so a child-process diff would be timing-dependent; what could diverge there was the wrapping width, which is what was measured instead.

## The guardrail

`no-restricted-syntax` under `apps/cli/test/**` bans assignment to the three globals, with a message naming `createMemoryIO()` and the issue. Selectors match a `process` node *inside* the assignment target rather than anchoring on `left.object.name`, so they catch the cast-wrapped forms — which is how the seventh suite turned up.

Flat config **replaces** rather than merges a rule's options across blocks, and the existing Zod 4 guard's glob (`**/test/**/*.ts`) covers these files, so a naive second block would have silently switched Zod off for `apps/cli/test/**`. The Zod selectors are hoisted to a shared const and spread into both. Verified by removing the spread and re-linting: Zod findings dropped 3 → 0.

Both directions were exercised: a scratch file with every banned form reports all of them (plain, both cast variants, and the restore direction), and `eslint .` is otherwise unchanged repo-wide.

## Assertions

Every expectation keeps its matcher and expected value across all eight suites. One deliberate exception, called out rather than buried: two of `run-sink`'s six `toBe("")` asserted that nothing leaked past the injected writer to the real stdout. Once both writers are injected, the sink cannot name a global stream, so that claim is true by construction and could only be re-tested by patching the global this PR removes. They now pin the neighbouring channel instead — a falsifiable claim, since a chunk on the wrong stream would corrupt the JSONL contract. The anti-recursion claim itself is still pinned by the unchanged `expect(captured).toHaveLength(2)`.

## What the review round changed

The branch was put through a blind adversarial review — the reviewer got the diff and the issue, and nothing about the reasoning behind any decision. It found five real defects, fixed in `bafeaea15`:

- **`ui.test.ts` asserted a property it could not observe.** Two routing tests created a sink, called `intro(...)` *without* it, and asserted `expect(stdout()).toBe("")` — which the un-injected call cannot reach, so it held regardless of what `intro` did. They also made those the only new writers to the process-global stdout on this branch, printing stray clack ANSI into the runner. Removed.
- **`remote-runner.ts` never wired the seam.** It declares `writeStderr?`, resolves it, and its suite injects it, but the sink was built with `writeStdout` alone. Latent because no fixture emitted `appstrate.error` — so the two new tests are the substance, and the forwarding is one line. Reverting it makes the child's real stderr show `⚠ adapter blew up`.
- **The lint rule did not match its own comment.** It claimed to catch every cast-wrapped variant — true for `process.exit`, false for the stream writers — and `spyOn` walked past all three. Both closed; the comment now names what it does *not* cover.
- **The memory sink rendered `cancel` on the wrong stream** (stderr, where production uses stdout), which would have let "nothing on stdout" pass on paths where production prints there.
- **The sink's docstring overclaimed.** Where `io.exit` sits inside a command's own `try`, the `ExitError` unwinds through that `catch` and its message lands in the buffer. Deterministic and pre-existing, and not the cross-suite pollution this branch fixes — so the control flow is left alone and the documentation is corrected instead, with the rule that those branches assert with `toContain`.

## The polluter, and the class it belongs to

Injecting the sink fixes *attribution* — a test can no longer assert on a buffer it does not own. It does not stop code from writing after its scope ends, and that is where the bytes came from.

A clack spinner paints from a `setInterval` that only `stop()` clears. Five sites in `commands/runner.ts` started one and stopped it only on the success path; `runner.test.ts` exercises exactly such a failing path, so the frames kept painting for the rest of the run. `withSpinner` now owns the start/stop pair, and it lives in `lib/ui.ts` next to the wrapper it replaces — the remaining eleven hand-rolled sites (install ×8, login ×2) go through it too.

None of those eleven was reachable from a test: `install.test.ts` injects stubs over the two functions carrying eight of them, `selfUpdateCommand` is never imported by a test, and every login fixture fails *after* both spinners have stopped. That is fixture accident, not a property — and post-seam a leaked login spinner is worse than before, because it paints into the injected memory sink: an array growing every 80ms with no visible frames to notice it by. `clack.spinner()` is now banned by eslint outside `lib/ui.ts`, which is the only file that still calls it.

`self-update` keeps a manual `spinner()`: its start is conditional on the first byte-tick, so wrapping it would paint a download line on updates that download nothing. It gained the `finally`-equivalent instead.

The leak test lives with the helper rather than at a call site — at `withSpinner` it proves the property all sixteen sites inherit. Control run both ways: a raw `clack.spinner()` fills the post-throw window with frames, the helper leaves 400ms silent.

## Audit of the neighbouring globals

The same failure needs shared mutable state plus something that outlives its scope. Both halves were swept repo-wide; everything below is already disciplined, so nothing else is touched:

| Shared global | Sites | State |
|---|---|---|
| `globalThis.fetch` | 27 test files | all capture and restore |
| `process.env.X = …` | 91 test files | all restore, or self-restore via the code under test |
| `spyOn(...)` | 12 test files | all `mockRestore()` |
| `_setXForTesting` | all callers | all reset to neutral |
| `setInterval` in `apps/api` | 10 sites | all `unref()` **and** `clearInterval` |
| stdout bridge (`run.ts`) | its suite | already injects a `FakeStdout` |

No other interval-painting UI library exists in the repo (`@clack/prompts` is imported only by `apps/cli`), so the spinner class is confined to the CLI and is now closed.

## What the second round changed

- **`CommandIO.cancel` is required, not optional.** Every producer supplied one — `DEFAULT_IO`, `ApiCommandIO` by spread, `createMemoryIO` — so the optional member bought `exitWithError` a fallback branch nothing but its own test could reach. Branch gone, test gone, the two hand-built `api` sinks gained the member.
- **`withSpinner` grew two shapes, each because a call site asked**: `stopLabel` may be a callback (the dev server quotes its pid, which a flat string dropped), and `errorLabel` names a failure that has its own word ("Docker not found").
- **The Docker probe had dead branching** — `if (err instanceof DockerMissingError) throw err; throw err;`. Removed with the import it orphaned.
- **One duplicate byte-for-byte test removed**: `intro`, `outro` and `spinner` share the single `clackOutput` adapter, so the property belongs to the adapter and one child-process spawn proves it.

## Verification

- `bun test` in `apps/cli`: **1312 pass, 0 fail** across 59 files (was 1304; all seven converted suites at their exact baseline counts).
- `bun test` in `runtime-pi/sidecar`: **694 pass, 0 fail**.
- Repo-root single-process (`TEST_TIER=0 bun test`): **10617 pass, 1 fail** — `llm-usage-settlement` times out at 5s under full-suite load and is green in isolation (15/15). Untouched by this branch.
- Both lint guards exercised in both directions: a probe file under `runtime-pi/sidecar/test/` reports all four capture forms (plain, both cast variants, restore), a probe under `apps/cli/src/commands/` reports the raw `clack.spinner()`, and `lib/ui.ts` stays clean.
- The repo-root single-process configuration — the one the flake actually lives in — is reproducible locally via the preload's `TEST_TIER=0` escape (tier 0 is PGlite, no Docker), and is green.
- `turbo typecheck --force`: 20/20, cache bypassed.
- `eslint .`: 0 errors. `prettier --check`: clean.
- CI is green on every job, including **Integration tests** — the single-process, repo-root job where this flake manifests and where three of these tests failed an earlier round.
- `bun run check` is 31/34 *locally*: `verify:dead-code` is a known fresh-worktree knip artifact — **exit 0 with zero findings on a normal checkout**, 451 in the worktree, and the counts (6 / 161 / 284) are identical before and after every commit here. It passes in CI.

## Commits

| | |
|---|---|
| `3ae304cde` | add the `CommandIO` seam; `ApiCommandIO` extends it |
| `54d3078fc` | whoami, token, openapi |
| `620ca973a` | org, app, and `requireLoggedIn` |
| `fd527df0d` | clack framing through the seam; login |
| `f9471e629` | the run sink's missing stderr seam; the seventh suite |
| `98b412678` | the eslint guardrail |
| `a22d2a6eb` | pin the child-process cwd so byte comparisons survive a repo-root run |
| `bafeaea15` | close the gaps an adversarial review found |
| `2dbecadda` | stop the runner spinners on every exit path — the polluter itself |
| `664f855fe` | the sidecar's log capture, on an owned sink (the eighth suite) |
| `1e0ec8dfa` | `CommandIO.cancel` required; the dead fallback branch removed |
| `0d4879502` | the capture ban widened to every package's tests |
| `30dd1abe8` | every spinner through `withSpinner`; raw `clack.spinner()` banned outside `ui.ts` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

