### PR TITLE
fix(errors): make an inference failure legible on every surface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -453,6 +453,25 @@ CONNECTION_ENCRYPTION_KEY=jChGxOEG1YjCtrkrTYhO7FFdIKaHpe/j1PBY/LqID6s=
 # LLM_PROXY_CACHE_MODE=off       # off | simple
 # LLM_PROXY_CACHE_MAX_AGE=3600   # per-entry TTL in seconds (ignored when mode=off)
 
+# ─── Optional: LLM upstream deadlines (self-hosted models) ───
+# Two bounds the platform proxy (/api/llm-proxy/*) puts on an inference
+# upstream. The defaults are sized for hosted vendors: a streaming call must
+# produce its response HEADERS in 60 s, and must not go silent for more than
+# 120 s between two body chunks. Both are exceeded routinely by a SELF-HOSTED
+# baseUrl provider (Ollama / llama.cpp / vLLM) doing a cold model load — raise
+# them there. Positive integers, milliseconds; unset => the compiled default.
+# LLM_PROXY_FIRST_RESPONSE_TIMEOUT_MS=60000    # default 60 s (headers, streaming calls)
+# LLM_PROXY_STREAM_IDLE_TIMEOUT_MS=120000      # default 120 s (inter-chunk silence)
+#
+# The sidecar applies the same two bounds to an agent run's /llm/* calls and has
+# its own knobs, read INSIDE the sidecar process. Loud-fail at sidecar boot if
+# invalid (no silent fallback). NOTE: under RUN_ADAPTER=docker/firecracker the
+# sidecar env is built from an allowlist (`SIDECAR_OPERATOR_ENV_KEYS` in
+# packages/runner-pi/src/container-env.ts) — these two must be listed there to
+# take effect on those adapters.
+# SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS=60000  # default 60 s (headers)
+# SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS=120000    # default 120 s (inter-chunk silence)
+
 # ─── Optional: Egress allowlist for internal hosts ───────────
 # Comma-separated hostnames the operator explicitly trusts on a PRIVATE address.
 # Exempts those hosts from the SSRF host blocklist ONLY (never from the redirect

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -23,7 +23,11 @@ import { logger } from "../../lib/logger.ts";
 import { invalidRequest } from "../../lib/errors.ts";
 import { getResponseCacheConfig } from "../../lib/llm-proxy-cache-config.ts";
 import { lookupResponse } from "./response-cache.ts";
-import { parseProxyRequest } from "./helpers.ts";
+import {
+  LLM_FIRST_RESPONSE_TIMEOUT_MS,
+  LLM_NON_STREAMING_TIMEOUT_MS,
+  parseProxyRequest,
+} from "./helpers.ts";
 import { forwardMeteredResponse } from "./metering.ts";
 import type { LlmProxyAdapter, LlmProxyPrincipal } from "./types.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
@@ -255,10 +259,21 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
     // redirect, and following one would replay the provider API key (in
     // `upstreamHeaders`) against whatever host the redirect names.
     //
-    // timeoutMs: 0 — disables the guard's 30 s first-byte default. A
-    // non-streaming completion legitimately holds the response headers past
-    // 30 s; the previous raw fetch here had no deadline either (behaviour
-    // preserved, the caller's disconnect remains the effective bound).
+    // timeoutMs — a real first-response (HEADERS) bound, chosen per request
+    // shape. The guard's timer is detached the moment the response returns, so
+    // it never touches a slow-but-healthy body; what it guarantees is that an
+    // upstream which never answers is reclaimed instead of hanging for as long
+    // as the caller keeps its socket open.
+    //
+    // This used to be `timeoutMs: 0` — no deadline at all — and the reason was
+    // sound: a NON-STREAMING completion legitimately holds its headers for the
+    // whole generation, so the guard's 30 s default would have cut off any
+    // completion longer than half a minute. That reason is preserved, not
+    // discarded: `stream: false` gets 10 min (the vendor SDKs' own
+    // non-streaming default), and only the streaming shape — which must emit
+    // its first SSE frame within seconds — gets the tight 60 s bound.
+    // Inter-chunk silence AFTER the headers is a different problem with a
+    // different instrument: see `guardSseTeardown` in `./metering.ts`.
     upstream = await egressGuardedFetch(
       upstreamUrl,
       {
@@ -268,7 +283,7 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
       },
       {
         maxRedirects: 0,
-        timeoutMs: 0,
+        timeoutMs: request.stream ? LLM_FIRST_RESPONSE_TIMEOUT_MS : LLM_NON_STREAMING_TIMEOUT_MS,
         logger,
         ...(inputs.fetchImpl ? { fetchImpl: inputs.fetchImpl } : {}),
       },

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -273,7 +273,10 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
     // non-streaming default), and only the streaming shape — which must emit
     // its first SSE frame within seconds — gets the tight 60 s bound.
     // Inter-chunk silence AFTER the headers is a different problem with a
-    // different instrument: see `guardSseTeardown` in `./metering.ts`.
+    // different instrument — the idle bound both `tee()` branches carry in
+    // `./metering.ts` (`guardSseTeardown` on the client branch, `tapSseUsage`
+    // on the metering one), which is what reclaims a stream that dies after
+    // its headers landed.
     upstream = await egressGuardedFetch(
       upstreamUrl,
       {

--- a/apps/api/src/services/llm-proxy/helpers.ts
+++ b/apps/api/src/services/llm-proxy/helpers.ts
@@ -27,6 +27,78 @@ import { parseSseFrames, parseSseJsonData } from "@appstrate/core/sse";
 import { invalidRequest } from "../../lib/errors.ts";
 
 /**
+ * Bound on how long an LLM upstream may take to produce its RESPONSE HEADERS
+ * on a STREAMING call. Passed as `guardedFetch`'s `timeoutMs`, whose contract
+ * is exactly this: it "covers the redirect chain up to the final response's
+ * HEADERS … the timer is detached once the response is returned", so a slow
+ * but healthy body is never aborted by it.
+ *
+ * 60 s: a provider asked for `stream: true` emits its first SSE frame within
+ * seconds; 60 s is roughly 10× the worst honest TTFB we have observed and
+ * still far inside a chat turn's patience. Before this, `timeoutMs` was 0 —
+ * no deadline at all, "the caller's disconnect remains the effective bound" —
+ * which meant a browser tab left open held a dead upstream connection
+ * indefinitely.
+ *
+ * Deliberately IDENTICAL to the sidecar's `LLM_FIRST_RESPONSE_TIMEOUT_MS`
+ * (`runtime-pi/sidecar/helpers.ts`): same concept, same number, so an operator
+ * reading a timeout in one log does not have to ask which proxy produced it.
+ * See {@link LLM_STREAM_IDLE_TIMEOUT_MS} for why the two files duplicate
+ * rather than share.
+ */
+export const LLM_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
+
+/**
+ * Bound on how long a NON-STREAMING upstream may take to produce its response
+ * headers. This is the case the previous `timeoutMs: 0` existed to protect:
+ * with `stream: false` the provider holds the headers for the ENTIRE
+ * generation, so the TTFB bound above would cut off any completion longer than
+ * a minute.
+ *
+ * 10 min matches the non-streaming default of the vendor SDKs themselves
+ * (OpenAI and Anthropic both default to a 600 s request timeout and warn above
+ * it), so nothing that a direct SDK call would have completed is refused here
+ * — while a genuinely dead connection still gets reclaimed instead of living
+ * as long as the caller's socket.
+ *
+ * The sidecar has no twin for this constant on purpose: its `/llm/*` clients
+ * are pi-ai provider adapters, which always send `stream: true`.
+ */
+export const LLM_NON_STREAMING_TIMEOUT_MS = 600_000;
+
+/**
+ * Bound on INTER-CHUNK silence once an SSE response is flowing: how long the
+ * upstream may say nothing between two body chunks before the proxy declares
+ * the stream dead. Enforced in `guardSseTeardown` (`./metering.ts`), because
+ * no fetch-level signal can express "silent for 2 min" without also capping
+ * the total duration.
+ *
+ * This is the bound that fixes the reported bug. Pi's SDK passes a `timeoutMs`
+ * down to its provider adapters, but four of the api shapes this platform maps
+ * ignore it entirely (`google-generative-ai`, `google-vertex`,
+ * `bedrock-converse-stream`, `pi-messages` — grep `timeoutMs` in
+ * `@earendil-works/pi-ai/dist/api/*.js`, they honour only `options.signal`).
+ * A stalled Gemini/Vertex/Bedrock stream was bounded by nothing at all on this
+ * path. An Appstrate-owned proxy is the only provider-agnostic place that
+ * covers all four shapes.
+ *
+ * 120 s, i.e. looser than the first-response bound: once a provider has
+ * started streaming, a long pause is a real (if rare) event — extended
+ * thinking and large parallel tool-call payloads routinely buy 15-45 s of
+ * silence.
+ *
+ * DUPLICATED, not shared, with `runtime-pi/sidecar/helpers.ts`. Both packages
+ * could import from `@appstrate/core`, but core is published to npm under a
+ * consumer-lockstep release gate — adding a subpath export there costs a
+ * version bump, a publish and a bump in every out-of-tree consumer, for two
+ * integers. The sidecar also deliberately keeps its transport timings local
+ * (`LLM_PROXY_TIMEOUT_MS`, `OUTBOUND_TIMEOUT_MS` live in its own `helpers.ts`)
+ * because it is boot-latency sensitive. Keep the two definitions in sync by
+ * hand; each names the other.
+ */
+export const LLM_STREAM_IDLE_TIMEOUT_MS = 120_000;
+
+/**
  * Parsed shape of an inbound `/api/llm-proxy/*` request body. Built
  * once at the start of the pipeline so the preset extraction, the
  * streaming detection, and the upstream model rewrite all share a

--- a/apps/api/src/services/llm-proxy/helpers.ts
+++ b/apps/api/src/services/llm-proxy/helpers.ts
@@ -24,6 +24,8 @@
  */
 
 import { parseSseFrames, parseSseJsonData } from "@appstrate/core/sse";
+import { getEnv } from "@appstrate/env";
+import { DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS } from "@appstrate/connect/proxy-primitives";
 import { invalidRequest } from "../../lib/errors.ts";
 
 /**
@@ -41,12 +43,17 @@ import { invalidRequest } from "../../lib/errors.ts";
  * indefinitely.
  *
  * Deliberately IDENTICAL to the sidecar's `LLM_FIRST_RESPONSE_TIMEOUT_MS`
- * (`runtime-pi/sidecar/helpers.ts`): same concept, same number, so an operator
+ * (`runtime-pi/sidecar/helpers.ts`): same concept, same default, so an operator
  * reading a timeout in one log does not have to ask which proxy produced it.
- * See {@link LLM_STREAM_IDLE_TIMEOUT_MS} for why the two files duplicate
- * rather than share.
+ *
+ * Operator-overridable via `LLM_PROXY_FIRST_RESPONSE_TIMEOUT_MS` (the sidecar's
+ * twin is `SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS`). The "first frame within
+ * seconds" reasoning above describes hosted vendors; an `org_models` row may
+ * point at a self-hosted `baseUrl` (Ollama / llama.cpp / vLLM) whose cold model
+ * load holds the headers for minutes, and self-hosting is a first-class
+ * deployment here — so 60 s is a default, not a law.
  */
-export const LLM_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
+export const LLM_FIRST_RESPONSE_TIMEOUT_MS = getEnv().LLM_PROXY_FIRST_RESPONSE_TIMEOUT_MS ?? 60_000;
 
 /**
  * Bound on how long a NON-STREAMING upstream may take to produce its response
@@ -69,34 +76,21 @@ export const LLM_NON_STREAMING_TIMEOUT_MS = 600_000;
 /**
  * Bound on INTER-CHUNK silence once an SSE response is flowing: how long the
  * upstream may say nothing between two body chunks before the proxy declares
- * the stream dead. Enforced in `guardSseTeardown` (`./metering.ts`), because
- * no fetch-level signal can express "silent for 2 min" without also capping
- * the total duration.
+ * the stream dead. Enforced in `guardSseTeardown` and `tapSseUsage`
+ * (`./metering.ts`) — both tee branches, since releasing only one leaves the
+ * upstream socket pinned — because no fetch-level signal can express "silent
+ * for 2 min" without also capping the total duration.
  *
- * This is the bound that fixes the reported bug. Pi's SDK passes a `timeoutMs`
- * down to its provider adapters, but four of the api shapes this platform maps
- * ignore it entirely (`google-generative-ai`, `google-vertex`,
- * `bedrock-converse-stream`, `pi-messages` — grep `timeoutMs` in
- * `@earendil-works/pi-ai/dist/api/*.js`, they honour only `options.signal`).
- * A stalled Gemini/Vertex/Bedrock stream was bounded by nothing at all on this
- * path. An Appstrate-owned proxy is the only provider-agnostic place that
- * covers all four shapes.
- *
- * 120 s, i.e. looser than the first-response bound: once a provider has
- * started streaming, a long pause is a real (if rare) event — extended
- * thinking and large parallel tool-call payloads routinely buy 15-45 s of
- * silence.
- *
- * DUPLICATED, not shared, with `runtime-pi/sidecar/helpers.ts`. Both packages
- * could import from `@appstrate/core`, but core is published to npm under a
- * consumer-lockstep release gate — adding a subpath export there costs a
- * version bump, a publish and a bump in every out-of-tree consumer, for two
- * integers. The sidecar also deliberately keeps its transport timings local
- * (`LLM_PROXY_TIMEOUT_MS`, `OUTBOUND_TIMEOUT_MS` live in its own `helpers.ts`)
- * because it is boot-latency sensitive. Keep the two definitions in sync by
- * hand; each names the other.
+ * The value and the reasoning behind it live with the shared default
+ * ({@link DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS} in
+ * `@appstrate/connect/proxy-primitives`), which the sidecar's `/llm/*` forward
+ * reads too — same instrument, one definition. What is local here is the
+ * operator override: `LLM_PROXY_STREAM_IDLE_TIMEOUT_MS`, for the self-hosted
+ * `baseUrl` providers whose inter-chunk gaps a hosted-vendor default does not
+ * describe.
  */
-export const LLM_STREAM_IDLE_TIMEOUT_MS = 120_000;
+export const LLM_STREAM_IDLE_TIMEOUT_MS =
+  getEnv().LLM_PROXY_STREAM_IDLE_TIMEOUT_MS ?? DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS;
 
 /**
  * Parsed shape of an inbound `/api/llm-proxy/*` request body. Built

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -36,6 +36,7 @@ import {
 import { stripUpstreamResponseHeaders } from "@appstrate/connect/proxy-primitives";
 import type { ResolvedModel } from "../org-models.ts";
 import { storeResponse } from "./response-cache.ts";
+import { LLM_STREAM_IDLE_TIMEOUT_MS } from "./helpers.ts";
 import type { LlmProxyAdapter, LlmProxyPrincipal, UpstreamUsage } from "./types.ts";
 
 /** Clone upstream response headers, dropping hop-by-hop + stale content encoding/length. */
@@ -324,6 +325,44 @@ interface MeteredForwardOptions {
   recordUsage?: (inputs: RecordUsageInputs) => Promise<void>;
 }
 
+/** Resolution marker for {@link withIdleBound} — a value, not a rejection, so
+ *  the genuine upstream-error path keeps its own `catch`. */
+const IDLE = Symbol("llm-sse-idle");
+
+/**
+ * Bound a PENDING `reader.read()` by an inter-chunk idle deadline.
+ *
+ * Takes the promise rather than the reader on purpose: the timer is created at
+ * the moment the read starts and cleared the moment it settles, so it measures
+ * only the window in which the consumer has asked for a chunk and the upstream
+ * has not produced one. See {@link guardSseTeardown} for why that distinction
+ * is the whole point.
+ *
+ * Returns {@link IDLE} on expiry (never rejects for it); a genuine read
+ * rejection still propagates untouched.
+ *
+ * Twin of the sidecar's `withIdleBound` (`runtime-pi/sidecar/app.ts`) — see
+ * `LLM_STREAM_IDLE_TIMEOUT_MS` in `./helpers.ts` for why the two proxies keep
+ * their own copies instead of sharing through `@appstrate/core`.
+ */
+async function withIdleBound<T>(read: Promise<T>, idleTimeoutMs: number): Promise<T | typeof IDLE> {
+  // If the timer wins the race, `read` is still pending; a later rejection
+  // would land as a process-level unhandled rejection with nobody left to
+  // catch it — the exact failure mode this module exists to prevent.
+  read.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      read,
+      new Promise<typeof IDLE>((resolve) => {
+        timer = setTimeout(() => resolve(IDLE), idleTimeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 /** `controller.close()` throws if the stream is already closed/errored (e.g. the
  * consumer cancelled mid-pull). That is not a teardown — swallow it. */
 function closeSafely(controller: ReadableStreamDefaultController<Uint8Array>): void {
@@ -357,24 +396,65 @@ function closeSafely(controller: ReadableStreamDefaultController<Uint8Array>): v
  * partial line on that clean close.
  *
  * `pull` is demand-driven, so backpressure is preserved and nothing is
- * buffered. `onTeardownError` fires only for a genuine upstream read rejection
- * — never for a consumer-cancel close race (those are swallowed).
+ * buffered. `onTeardownError` fires for a genuine upstream read rejection and
+ * for an inter-chunk idle timeout — never for a consumer-cancel close race
+ * (those are swallowed).
+ *
+ * IDLE BOUND — read before touching. `idleTimeoutMs` caps how long the UPSTREAM
+ * may stay silent between two chunks. Because `pull` is demand-driven, the
+ * timer must be armed against the PENDING `reader.read()` and cleared the
+ * moment it settles: that promise is pending exactly while the upstream is
+ * silent AND the consumer is waiting for a chunk. A stream-level watchdog, or
+ * any timer that keeps running between pulls, would instead kill a merely SLOW
+ * CONSUMER on a healthy upstream — a browser tab throttled in the background is
+ * enough to trip it. Do not "simplify" it into one long-lived timer.
+ *
+ * WHY EXPIRY IS A TEARDOWN-ERROR-AND-CLEAN-CLOSE, NOT A STREAM ERROR: the
+ * invariant this whole function exists to hold is that the guarded stream NEVER
+ * errors. It is wrapped BEFORE the alias-swap `pipeThrough`, and an erroring
+ * source there re-creates precisely the unhandled-rejection leak documented
+ * above — one tenant's stalled provider taking down a multi-tenant process.
+ * Erroring on idle would trade a bug for the same bug with a nicer message. The
+ * signal is not lost: `onTeardownError` logs it at the call site, and the
+ * caller sees the same truncated SSE stream an upstream reject already
+ * produces. That is the best achievable at this seam.
  */
 export function guardSseTeardown(
   source: ReadableStream<Uint8Array>,
   onTeardownError: (err: unknown) => void,
+  idleTimeoutMs: number = LLM_STREAM_IDLE_TIMEOUT_MS,
 ): ReadableStream<Uint8Array> {
   const reader = source.getReader();
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
-      let result: Awaited<ReturnType<typeof reader.read>>;
+      let result: Awaited<ReturnType<typeof reader.read>> | typeof IDLE;
       try {
-        result = await reader.read();
+        result = await withIdleBound(reader.read(), idleTimeoutMs);
       } catch (err) {
         // The only genuine teardown signal: the upstream/tee branch rejected
         // mid-flux. Report once, then close the client stream cleanly (the
         // caller sees a truncated SSE stream — the best achievable here).
         onTeardownError(err);
+        closeSafely(controller);
+        return;
+      }
+      if (result === IDLE) {
+        // Four of the ten api shapes this platform maps ignore pi-ai's own
+        // `timeoutMs`, so this proxy is the only provider-agnostic place a
+        // stalled stream can be caught at all.
+        //
+        // THE WORDING IS LOAD-BEARING: pi-ai classifies failures as transient
+        // by regex over the error text (`RETRYABLE_PROVIDER_ERROR_PATTERN` in
+        // `dist/utils/retry.js`, matching `timed? out` / `timeout`), and this
+        // message reaches it whenever a Pi-driven caller reads the log or the
+        // teardown surfaces upward. "went quiet" would be classified as a hard
+        // provider error. Do not reword.
+        onTeardownError(
+          new Error(`LLM upstream stream timed out: no data received for ${idleTimeoutMs}ms`),
+        );
+        // Release the upstream/tee branch, then close cleanly per the contract
+        // above. Swallow a cancel rejection so teardown can't itself escape.
+        void reader.cancel(new Error("llm-proxy: SSE idle timeout")).catch(() => {});
         closeSafely(controller);
         return;
       }

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -33,7 +33,11 @@ import {
   syntheticAliasErrorBody,
   LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "@appstrate/core/model-swap";
-import { stripUpstreamResponseHeaders } from "@appstrate/connect/proxy-primitives";
+import {
+  stripUpstreamResponseHeaders,
+  withIdleBound,
+  STREAM_IDLE,
+} from "@appstrate/connect/proxy-primitives";
 import type { ResolvedModel } from "../org-models.ts";
 import { storeResponse } from "./response-cache.ts";
 import { LLM_STREAM_IDLE_TIMEOUT_MS } from "./helpers.ts";
@@ -108,10 +112,21 @@ const MAX_TAP_BUFFER_BYTES = 1_000_000;
  * yield usage (probed via `adapter.parseSseUsage([frame])`) are retained, in
  * arrival order, and the adapter extracts the final result from that subset —
  * behaviour-identical to scanning every frame for either shipped adapter.
+ *
+ * IDLE BOUND — the same one {@link guardSseTeardown} applies to the CLIENT
+ * branch, and it has to be here too. `tee()` cancels its source only once BOTH
+ * branches are cancelled, so bounding the client branch alone left this tap
+ * holding a pending `read()` forever: the upstream socket, its body and this
+ * promise stayed pinned with no absolute deadline behind them (`guardedFetch`
+ * detaches its timer at the headers). It also broke the module's accounting
+ * invariant — a tap that never finishes never calls `meter`, so a stalled 2xx
+ * produced no ledger row at all. On expiry the tap returns what it managed to
+ * parse (usually `null`), which the caller meters as an unparsed-usage row.
  */
 export async function tapSseUsage(
   stream: ReadableStream<Uint8Array>,
   adapter: LlmProxyAdapter,
+  idleTimeoutMs: number = LLM_STREAM_IDLE_TIMEOUT_MS,
 ): Promise<UpstreamUsage | null> {
   const reader = stream.getReader();
   const decoder = new TextDecoder();
@@ -129,7 +144,17 @@ export async function tapSseUsage(
   };
   try {
     for (;;) {
-      const { value, done } = await reader.read();
+      const outcome = await withIdleBound(reader.read(), idleTimeoutMs);
+      if (outcome === STREAM_IDLE) {
+        logger.warn("llm-proxy: SSE usage tap idle timeout — metering what was parsed", {
+          idleTimeoutMs,
+        });
+        // Releasing THIS branch is half of what cancels the tee'd source; the
+        // client branch releases the other half in `guardSseTeardown`.
+        void reader.cancel(new Error("llm-proxy: SSE idle timeout")).catch(() => {});
+        break;
+      }
+      const { value, done } = outcome;
       if (done) break;
       if (value) buffer += decoder.decode(value, { stream: true });
       // Split on SSE frame delimiter (blank line). Keep the tail in the
@@ -325,44 +350,6 @@ interface MeteredForwardOptions {
   recordUsage?: (inputs: RecordUsageInputs) => Promise<void>;
 }
 
-/** Resolution marker for {@link withIdleBound} — a value, not a rejection, so
- *  the genuine upstream-error path keeps its own `catch`. */
-const IDLE = Symbol("llm-sse-idle");
-
-/**
- * Bound a PENDING `reader.read()` by an inter-chunk idle deadline.
- *
- * Takes the promise rather than the reader on purpose: the timer is created at
- * the moment the read starts and cleared the moment it settles, so it measures
- * only the window in which the consumer has asked for a chunk and the upstream
- * has not produced one. See {@link guardSseTeardown} for why that distinction
- * is the whole point.
- *
- * Returns {@link IDLE} on expiry (never rejects for it); a genuine read
- * rejection still propagates untouched.
- *
- * Twin of the sidecar's `withIdleBound` (`runtime-pi/sidecar/app.ts`) — see
- * `LLM_STREAM_IDLE_TIMEOUT_MS` in `./helpers.ts` for why the two proxies keep
- * their own copies instead of sharing through `@appstrate/core`.
- */
-async function withIdleBound<T>(read: Promise<T>, idleTimeoutMs: number): Promise<T | typeof IDLE> {
-  // If the timer wins the race, `read` is still pending; a later rejection
-  // would land as a process-level unhandled rejection with nobody left to
-  // catch it — the exact failure mode this module exists to prevent.
-  read.catch(() => {});
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      read,
-      new Promise<typeof IDLE>((resolve) => {
-        timer = setTimeout(() => resolve(IDLE), idleTimeoutMs);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 /** `controller.close()` throws if the stream is already closed/errored (e.g. the
  * consumer cancelled mid-pull). That is not a teardown — swallow it. */
 function closeSafely(controller: ReadableStreamDefaultController<Uint8Array>): void {
@@ -427,7 +414,7 @@ export function guardSseTeardown(
   const reader = source.getReader();
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
-      let result: Awaited<ReturnType<typeof reader.read>> | typeof IDLE;
+      let result: Awaited<ReturnType<typeof reader.read>> | typeof STREAM_IDLE;
       try {
         result = await withIdleBound(reader.read(), idleTimeoutMs);
       } catch (err) {
@@ -438,22 +425,34 @@ export function guardSseTeardown(
         closeSafely(controller);
         return;
       }
-      if (result === IDLE) {
+      if (result === STREAM_IDLE) {
         // Four of the ten api shapes this platform maps ignore pi-ai's own
         // `timeoutMs`, so this proxy is the only provider-agnostic place a
         // stalled stream can be caught at all.
         //
-        // THE WORDING IS LOAD-BEARING: pi-ai classifies failures as transient
-        // by regex over the error text (`RETRYABLE_PROVIDER_ERROR_PATTERN` in
-        // `dist/utils/retry.js`, matching `timed? out` / `timeout`), and this
-        // message reaches it whenever a Pi-driven caller reads the log or the
-        // teardown surfaces upward. "went quiet" would be classified as a hard
-        // provider error. Do not reword.
+        // THIS MESSAGE NEVER LEAVES THE SERVER: `onTeardownError` is a logger
+        // call at its only call site (`forwardMeteredResponse` below), and by
+        // this module's own contract the client stream closes CLEANLY rather
+        // than carrying an error. The caller sees a truncated SSE stream.
+        //
+        // That truncation is what a Pi-driven caller classifies on, and it
+        // classifies as retryable without help from this text: pi-ai's adapters
+        // throw on a premature end — `openai-completions.js` "Stream ended
+        // without finish_reason" (whenever `compat.supportsFinishReason`, its
+        // default), `google-generative-ai.js` "Google stream ended without a
+        // finish reason", `anthropic-messages.js` "Anthropic stream ended
+        // before message_stop" — and those match
+        // `RETRYABLE_PROVIDER_ERROR_PATTERN` (`dist/utils/retry.js`:
+        // `ended without`, `stream ended before message_stop`). So the wording
+        // below is free to change; keep it operator-legible.
         onTeardownError(
           new Error(`LLM upstream stream timed out: no data received for ${idleTimeoutMs}ms`),
         );
         // Release the upstream/tee branch, then close cleanly per the contract
         // above. Swallow a cancel rejection so teardown can't itself escape.
+        // This is only HALF the reclamation — `tee()` cancels its source once
+        // BOTH branches are cancelled, and the metering tap holds the other
+        // one; it carries the same idle bound for exactly that reason.
         void reader.cancel(new Error("llm-proxy: SSE idle timeout")).catch(() => {});
         closeSafely(controller);
         return;

--- a/apps/api/test/unit/llm-proxy-metering.test.ts
+++ b/apps/api/test/unit/llm-proxy-metering.test.ts
@@ -227,6 +227,87 @@ describe("guardSseTeardown", () => {
     expect(seen).toEqual([boom]);
   });
 
+  // --- inter-chunk idle bound ---
+  //
+  // `guardSseTeardown` also bounds how long the UPSTREAM may stay silent
+  // between two chunks (`LLM_STREAM_IDLE_TIMEOUT_MS`, 120 s in production;
+  // passed as a few ms here). Four of the ten api shapes this platform maps
+  // ignore pi-ai's own `timeoutMs`, so before this bound a stalled
+  // Gemini/Vertex/Bedrock stream on the chat path had no deadline at all.
+  //
+  // Two invariants are pinned below: expiry follows the module's
+  // never-error contract (report via `onTeardownError`, close cleanly), and a
+  // SLOW CONSUMER on a healthy upstream is not a timeout.
+
+  it("idle upstream: reports via onTeardownError and closes cleanly (never errors the stream)", async () => {
+    const enc = new TextEncoder();
+    // One frame, then permanent silence — the consumer keeps pulling, so the
+    // read stays pending and only the idle bound can end it.
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode("partial"));
+      },
+    });
+
+    const seen: unknown[] = [];
+    const guarded = guardSseTeardown(source, (e) => seen.push(e), 25);
+
+    // Resolves, does NOT reject: erroring here would re-open the
+    // unhandled-rejection leak this module exists to close (the guard is
+    // wrapped BEFORE the alias-swap `pipeThrough`).
+    expect(await readAll(guarded)).toBe("partial");
+    expect(seen).toHaveLength(1);
+    // Wording matches pi-ai's RETRYABLE_PROVIDER_ERROR_PATTERN (`timed? out`),
+    // so the stall is classified as transient rather than as a hard error.
+    expect((seen[0] as Error).message).toMatch(/timed out/i);
+  });
+
+  it("does NOT trip on a slow consumer reading a healthy upstream", async () => {
+    // REGRESSION CONTROL. `pull` is demand-driven: an idle timer that keeps
+    // running between pulls (or one hung off a "time since last chunk"
+    // counter) would kill a merely slow consumer on a perfectly healthy
+    // upstream. The upstream below answers every pull instantly; the consumer
+    // waits far longer than the idle bound between reads.
+    const enc = new TextEncoder();
+    const payloads = ["a", "b", "c", "d"];
+    let next = 0;
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (next >= payloads.length) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(enc.encode(payloads[next]!));
+        next += 1;
+      },
+    });
+
+    const idleTimeoutMs = 15;
+    const seen: unknown[] = [];
+    const guarded = guardSseTeardown(source, (e) => seen.push(e), idleTimeoutMs);
+
+    const consumerGapMs = idleTimeoutMs * 5;
+    const reader = guarded.getReader();
+    const dec = new TextDecoder();
+    let out = "";
+    const gaps: number[] = [];
+    for (;;) {
+      const before = Date.now();
+      await new Promise((r) => setTimeout(r, consumerGapMs));
+      const { done, value } = await reader.read();
+      gaps.push(Date.now() - before);
+      if (done) break;
+      out += dec.decode(value, { stream: true });
+    }
+
+    expect(out).toBe(payloads.join(""));
+    expect(seen).toEqual([]);
+    // Proof the control tests the right thing: every consumer gap really did
+    // exceed the idle bound, so any implementation timing the wrong interval
+    // would have reported a teardown above.
+    expect(Math.min(...gaps)).toBeGreaterThan(idleTimeoutMs);
+  });
+
   it("full forward path: upstream errors mid-flux under alias-swap → body completes, no escape", async () => {
     // End-to-end through `forwardMeteredResponse` (tee + tap + pipeThrough swap
     // + guard). The upstream emits one frame then errors. With the guard wired

--- a/apps/api/test/unit/llm-proxy-metering.test.ts
+++ b/apps/api/test/unit/llm-proxy-metering.test.ts
@@ -143,6 +143,48 @@ describe("tapSseUsage (anthropic-messages)", () => {
     const frames = `event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n`;
     expect(await tapSseUsage(streamFrom([frames]), anthropicMessagesAdapter)).toBeNull();
   });
+
+  it("an idle upstream ends the tap with what it parsed, instead of hanging", async () => {
+    // Without a bound here the tap kept a pending `read()` forever: the ledger
+    // row for a paid 2xx was never written (the module's accounting invariant),
+    // and the tee branch it holds kept the upstream socket pinned.
+    const enc = new TextEncoder();
+    const seed = `event: message_start\ndata: {"type":"message_start","message":{"id":"m","usage":{"input_tokens":11,"output_tokens":1}}}\n\n`;
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode(seed));
+        // Never closes, never speaks again.
+      },
+    });
+    const usage = await tapSseUsage(source, anthropicMessagesAdapter, 25);
+    expect(usage?.inputTokens).toBe(11);
+  });
+
+  it("idle stall releases BOTH tee branches, so the upstream source is cancelled", async () => {
+    // `tee()` cancels its source only once BOTH branches are cancelled. The
+    // client branch alone was not enough: the metering tap held the other one,
+    // and `guardedFetch` has already detached its timer at the headers — so a
+    // stream that died after its headers landed stayed pinned with no deadline
+    // behind it at all.
+    const enc = new TextEncoder();
+    let cancelled = false;
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(enc.encode('data: {"type":"x"}\n\n'));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    const [clientBranch, tapBranch] = source.tee();
+    const seen: unknown[] = [];
+    const guarded = guardSseTeardown(clientBranch, (e) => seen.push(e), 25);
+    await Promise.all([tapSseUsage(tapBranch, anthropicMessagesAdapter, 25), readAll(guarded)]);
+    // Both cancels are fired as detached promises; let them settle.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(cancelled).toBe(true);
+    expect(seen).toHaveLength(1);
+  });
 });
 
 async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
@@ -257,8 +299,11 @@ describe("guardSseTeardown", () => {
     // wrapped BEFORE the alias-swap `pipeThrough`).
     expect(await readAll(guarded)).toBe("partial");
     expect(seen).toHaveLength(1);
-    // Wording matches pi-ai's RETRYABLE_PROVIDER_ERROR_PATTERN (`timed? out`),
-    // so the stall is classified as transient rather than as a hard error.
+    // The message is a SERVER-SIDE signal only (`onTeardownError` is a logger
+    // call at the real call site, and the client stream closes cleanly), so
+    // this pins that the stall is reported and named — not that the wording
+    // reaches the caller. See the branch in `metering.ts` for what the caller
+    // actually classifies on.
     expect((seen[0] as Error).message).toMatch(/timed out/i);
   });
 

--- a/packages/afps-runtime/src/runner/finalize-thrown-failure.ts
+++ b/packages/afps-runtime/src/runner/finalize-thrown-failure.ts
@@ -109,12 +109,21 @@ export async function finalizeThrownFailure(opts: FinalizeThrownFailureOptions):
     }));
   const resultError = buildError(message, err);
 
-  // 2. Surface the failure as a live event.
+  // 2. Surface the failure as a live event. `buildError`'s structured
+  //    `context` rides along as the event's `data` when there is one: the
+  //    finalize body's RunError is persisted by its `message` alone (the
+  //    platform's `runs.error` is a text column), so this event is the ONLY
+  //    path by which structured failure context reaches durable storage —
+  //    `appstrate.error` already carries an optional `data` object and the
+  //    platform already writes it to `run_logs.data` (jsonb). Spread
+  //    conditionally so a runner whose `buildError` produced no context (the
+  //    default one, among others) emits the event byte-identical to before.
   const errorEvent: RunEvent = {
     type: "appstrate.error",
     timestamp: now(),
     runId,
     message: resultError.message,
+    ...(resultError.context !== undefined ? { data: resultError.context } : {}),
   };
   await emit(errorEvent);
 

--- a/packages/connect/src/proxy-primitives.ts
+++ b/packages/connect/src/proxy-primitives.ts
@@ -7,6 +7,14 @@
  * same wire protocol (X-Integration-Id/X-Target/Set-Cookie passthrough) and
  * share the AFPS spec-compliant URL allowlist matcher so drift is
  * impossible by construction.
+ *
+ * The same argument brings the LLM-stream idle bound here
+ * ({@link withIdleBound}, {@link STREAM_IDLE},
+ * {@link DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS}): the platform LLM gateway
+ * (`apps/api/src/services/llm-proxy/metering.ts`) and the sidecar's `/llm/*`
+ * forward are the same instrument applied twice, and a private workspace
+ * package both already import is the cheapest place to keep them one
+ * implementation.
  */
 
 import {
@@ -280,4 +288,79 @@ export function filterHeaders(
     out[key] = value;
   }
   return out;
+}
+
+/**
+ * Default bound on INTER-CHUNK silence once an LLM stream is flowing: how long
+ * the upstream may say nothing between two body chunks before a proxy declares
+ * the stream dead. Both LLM proxies start from this value and each exposes its
+ * own operator override on top (`SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS` in the
+ * sidecar, `LLM_PROXY_STREAM_IDLE_TIMEOUT_MS` on the platform).
+ *
+ * This is the bound that fixes the reported bug. Pi's SDK passes a `timeoutMs`
+ * down to its provider adapters, but four of the api shapes this platform maps
+ * ignore it entirely (`google-generative-ai`, `google-vertex`,
+ * `bedrock-converse-stream`, `pi-messages` — grep `timeoutMs` in
+ * `@earendil-works/pi-ai/dist/api/*.js`, they honour only `options.signal`). A
+ * stalled Gemini/Vertex/Bedrock stream was therefore bounded by nothing tighter
+ * than each proxy's absolute cap, and runs died on their wall-clock watchdog
+ * with no error to show the user. An Appstrate-owned proxy is the only
+ * provider-agnostic place that covers all four shapes.
+ *
+ * 120 s, i.e. deliberately looser than either proxy's first-response (TTFB)
+ * bound: once a provider has started streaming, a long pause is a real (if
+ * rare) event — extended-thinking blocks and large parallel tool-call payloads
+ * routinely buy 15-45 s of silence, and a provider-side retry can stretch that.
+ * 120 s is ~3x the worst honest gap while still leaving the shortest run budget
+ * (300 s) room to report the failure and for the agent to retry once.
+ */
+export const DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS = 120_000;
+
+/**
+ * Resolution marker for {@link withIdleBound} — a value, not a rejection, so
+ * the caller's genuine upstream-error path keeps its own `catch`.
+ */
+export const STREAM_IDLE = Symbol("llm-stream-idle");
+
+/**
+ * Bound a PENDING stream read by an inter-chunk idle deadline.
+ *
+ * Takes the promise rather than the reader/iterator on purpose: the timer must
+ * be created at the moment the read starts and cleared the moment it settles,
+ * so it measures only the window in which the consumer has asked for a chunk
+ * and the upstream has not produced one. Callers must therefore invoke it from
+ * inside `pull` (or per loop turn), never install it as a stream-level
+ * watchdog: a timer that keeps running between pulls would kill a merely SLOW
+ * CONSUMER on a perfectly healthy upstream.
+ *
+ * Any pending promise of that shape works — `reader.read()` on a
+ * `ReadableStream`, `iterator.next()` on an async generator.
+ *
+ * Returns {@link STREAM_IDLE} on expiry (never rejects for it); a genuine read
+ * rejection still propagates untouched.
+ *
+ * What each caller does ON expiry deliberately differs — the sidecar errors its
+ * client stream, the platform gateway must close cleanly to keep its
+ * never-throw invariant — so that decision stays at the call sites and this
+ * helper only reports the fact.
+ */
+export async function withIdleBound<T>(
+  read: Promise<T>,
+  idleTimeoutMs: number,
+): Promise<T | typeof STREAM_IDLE> {
+  // If the timer wins the race, `read` is still pending; a later rejection
+  // would land as a process-level unhandled rejection with nobody left to
+  // catch it. Attach a no-op handler now — the value is already discarded.
+  read.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      read,
+      new Promise<typeof STREAM_IDLE>((resolve) => {
+        timer = setTimeout(() => resolve(STREAM_IDLE), idleTimeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -122,6 +122,16 @@ them, it only names them in docblocks.
 
 ### Added
 
+- **`./model-error`** — `classifyModelError`, `ModelErrorCategory`,
+  `ModelErrorInput`, `ModelErrorClassification` and
+  `MODEL_ERROR_RETRYABLE_BY_CATEGORY`. THE rules that turn a raw provider
+  failure string into a provider-neutral verdict, moved out of the chat module
+  so the run surface classifies with the same ones. `ChatTurnErrorCategory`
+  (`./chat-turn-metadata`) is now an alias of `ModelErrorCategory` — same five
+  values, same persisted field, no behaviour change for any input.
+  `retryable` is derived from the category alone, so every path that rebuilds
+  one (live classification, stream marker, persisted turn) reaches the same
+  answer.
 - **Alias-opacity surface** (`./model-swap`, #1202) — `ALIAS_CLIENT_API_SHAPE`,
   `AliasBackingApiShape`, `isAliasBackingShape`, `isAliasClientShape`,
   `isAliasInferenceCall`, `syntheticAliasErrorMessage`, and `ModelSwapBacking`

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -90,6 +90,7 @@
     "./chat-contract": "./src/chat-contract.ts",
     "./file-uri": "./src/file-uri.ts",
     "./chat-turn-metadata": "./src/chat-turn-metadata.ts",
+    "./model-error": "./src/model-error.ts",
     "./bearer": "./src/bearer.ts",
     "./oauth-bearer-swap": "./src/oauth-bearer-swap.ts",
     "./url": "./src/url.ts",

--- a/packages/core/src/chat-turn-metadata.ts
+++ b/packages/core/src/chat-turn-metadata.ts
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-export type ChatTurnErrorCategory =
-  | "credential_unavailable"
-  | "rate_limited"
-  | "upstream_unavailable"
-  | "invalid_request"
-  | "unknown";
+import type { ModelErrorCategory } from "./model-error.ts";
+
+/**
+ * The chat surface's name for {@link ModelErrorCategory} — an ALIAS, not a
+ * second vocabulary. It stays because the values are persisted under this name
+ * (`AppstrateTurnMetadata.errorCategory`, on immutable chat messages) and
+ * because out-of-tree readers import it; the rules that produce them live in
+ * `./model-error.ts`, shared with the run surface.
+ */
+export type ChatTurnErrorCategory = ModelErrorCategory;
 
 /**
  * `deadline` is Appstrate's own reason (no provider emits it): the turn was cut

--- a/packages/core/src/model-error.ts
+++ b/packages/core/src/model-error.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * THE classifier for a failed model call — one rule set, every surface.
+ *
+ * The chat surface and the run surface both have to say what a provider
+ * failure means. They used to answer with two different bodies of code (a
+ * private cascade in the chat module; nothing at all on the run side, which
+ * stamped raw text under a single `adapter_error`). These are those rules,
+ * moved out so there is one.
+ *
+ * The agent SDK also classifies failed turns — `isRetryableAssistantError`,
+ * two substring lists in `@earendil-works/pi-ai` — but it is NOT an input
+ * here, and deliberately so. It answers a different question: "will the SDK's
+ * own in-turn retry loop try again?", which is settled and over by the time
+ * anything reads this classification. What this module's `retryable` means is
+ * "if a human presses retry, might a NEW turn succeed?" — a 503 the SDK gave
+ * up on after one attempt is often worth a manual retry a minute later.
+ *
+ * The two verdicts must still not drift into contradiction, so they are pinned
+ * by a test rather than by a runtime handoff:
+ * `packages/runner-pi/test/model-error-divergence.test.ts` runs both over a
+ * corpus of real provider failure text and fails if a vendor bump moves a
+ * pattern out from under these rules. Core cannot hold that test itself —
+ * `@appstrate/core` may not import the agent SDK (`no-restricted-imports`, see
+ * `docs/architecture/SUPPLY_CHAIN.md`), which is also why this module has no
+ * vendor input to reconcile.
+ */
+
+/**
+ * Stable, provider-neutral class for a failed model call.
+ *
+ * These five are the whole vocabulary and adding a sixth is a contract change:
+ * the values are PERSISTED (chat history carries them in
+ * `AppstrateTurnMetadata.errorCategory`) and a reader that meets an unknown
+ * one has no sentence for it. In particular there is no separate class for an
+ * account the provider refuses to serve — `credential_unavailable` already
+ * covers "the provider account is dead", whatever made it dead, and its
+ * user-facing sentence already says so.
+ */
+export type ModelErrorCategory =
+  | "credential_unavailable"
+  | "rate_limited"
+  | "upstream_unavailable"
+  | "invalid_request"
+  | "unknown";
+
+/**
+ * "Can a fresh attempt succeed without changing the request?", answered from
+ * the category alone.
+ *
+ * The category is the ONLY input on purpose. Every path that produces a
+ * `retryable` — classifying a live failure, rebuilding one from a transient
+ * stream marker, reading one back off a persisted turn — has the category and
+ * nothing else in common, so deriving the flag from anything richer would let
+ * those paths disagree about the same failed turn. Exported for exactly those
+ * rebuild paths, and because its keys are the category set — the one place
+ * membership can be tested at runtime.
+ */
+export const MODEL_ERROR_RETRYABLE_BY_CATEGORY: Record<ModelErrorCategory, boolean> = {
+  credential_unavailable: false,
+  rate_limited: true,
+  upstream_unavailable: true,
+  invalid_request: false,
+  unknown: true,
+};
+
+export interface ModelErrorInput {
+  /**
+   * Raw provider text. Never leaves the server on the chat surface — only the
+   * classification derived from it does.
+   */
+  message: string;
+  /**
+   * HTTP status, when the caller unwrapped one from the error envelope. Absent
+   * callers lose nothing: a `[45]xx` in {@link message} is read as a fallback.
+   */
+  status?: number;
+}
+
+export interface ModelErrorClassification {
+  category: ModelErrorCategory;
+  retryable: boolean;
+  /** Public platform request id, when the upstream envelope exposed one. */
+  requestId?: string;
+}
+
+/** Status the message text admits to, when the caller did not supply one. */
+function statusFromMessage(message: string): number | undefined {
+  const matched = /\b([45]\d\d)\b/.exec(message);
+  return matched ? Number(matched[1]) : undefined;
+}
+
+/**
+ * Classify one failed model call.
+ *
+ * The cascade is ordered by how much the caller can DO about the failure, not
+ * by status: an explicit 400 must beat the generic "upstream model error"
+ * wrapper the platform puts around proxied failures, or every proxied
+ * bad-request would read as a transient outage.
+ */
+export function classifyModelError(input: ModelErrorInput): ModelErrorClassification {
+  const message = input.message.trim();
+  const normalized = message.toLowerCase();
+  const status = input.status ?? statusFromMessage(message);
+  const requestId = /\b(req_[A-Za-z0-9_-]+)\b/.exec(message)?.[1];
+
+  let category: ModelErrorCategory;
+  if (
+    status === 401 ||
+    status === 402 ||
+    status === 403 ||
+    // Provider wording for an account the provider will no longer serve. It
+    // lands on `credential_unavailable` with the auth failures on purpose:
+    // both mean "this connection is dead until the operator acts on it", and
+    // one class means one sentence to write and one branch to maintain.
+    normalized.includes("insufficient balance") ||
+    normalized.includes("insufficient credit") ||
+    normalized.includes("billing") ||
+    normalized.includes("api key") ||
+    normalized.includes("authentication") ||
+    normalized.includes("unauthorized") ||
+    normalized.includes("forbidden") ||
+    normalized.includes("credential")
+  ) {
+    category = "credential_unavailable";
+  } else if (status === 429 || normalized.includes("rate limit")) {
+    category = "rate_limited";
+  } else if (status === 400 || normalized.includes("invalid request")) {
+    category = "invalid_request";
+  } else if (
+    (status !== undefined && status >= 500) ||
+    normalized.includes("upstream model error")
+  ) {
+    category = "upstream_unavailable";
+  } else {
+    category = "unknown";
+  }
+
+  return {
+    category,
+    retryable: MODEL_ERROR_RETRYABLE_BY_CATEGORY[category],
+    ...(requestId ? { requestId } : {}),
+  };
+}

--- a/packages/core/test/model-error.test.ts
+++ b/packages/core/test/model-error.test.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The classification rules, tested where they now live.
+ *
+ * Every case came verbatim from the chat module's own
+ * `chat-error-classification.test.ts` — moving the rules must not move a single
+ * verdict, so both fields here are what was asserted before the move.
+ *
+ * The agent SDK's own retry verdict is deliberately absent: it is not an input
+ * to these rules (see the module header), and core may not import the SDK
+ * anyway. The test that pins the two against each other over real provider text
+ * is `packages/runner-pi/test/model-error-divergence.test.ts`.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { classifyModelError, MODEL_ERROR_RETRYABLE_BY_CATEGORY } from "../src/model-error.ts";
+
+describe("classifyModelError", () => {
+  it("turns an aliased 402 into actionable provider-neutral metadata", () => {
+    expect(
+      classifyModelError({
+        message: "Upstream model error (status 402). Request ID req_public_123",
+      }),
+    ).toEqual({
+      category: "credential_unavailable",
+      retryable: false,
+      requestId: "req_public_123",
+    });
+  });
+
+  it("classifies throttling as retryable", () => {
+    expect(classifyModelError({ message: "429 rate limit from hidden-backend" })).toEqual({
+      category: "rate_limited",
+      retryable: true,
+    });
+  });
+
+  it("lets an explicit 400 win over the generic upstream wrapper", () => {
+    expect(classifyModelError({ message: "Upstream model error (status 400)" })).toEqual({
+      category: "invalid_request",
+      retryable: false,
+    });
+  });
+
+  it("classifies 5xx and unclassifiable failures", () => {
+    expect(classifyModelError({ message: "provider secret dump status 503" })).toEqual({
+      category: "upstream_unavailable",
+      retryable: true,
+    });
+    expect(classifyModelError({ message: "private opaque backend details" })).toEqual({
+      category: "unknown",
+      retryable: true,
+    });
+  });
+
+  it("prefers an envelope status over the one the text admits to", () => {
+    // The message names a 503; the envelope says 429. A caller that unwrapped a
+    // real status did better than a regex over prose, so it wins.
+    expect(
+      classifyModelError({ message: "gateway said 503 somewhere", status: 429 }).category,
+    ).toBe("rate_limited");
+  });
+
+  it("derives `retryable` from the category and nothing else", () => {
+    // The table is the ONLY source of the flag, and the only runtime
+    // description of the category set. A drift here silently changes what a
+    // recovered category (stream marker, persisted turn) rebuilds into — and
+    // any input that could move `retryable` independently of the category would
+    // let those rebuild paths disagree with this one.
+    expect(MODEL_ERROR_RETRYABLE_BY_CATEGORY).toEqual({
+      credential_unavailable: false,
+      rate_limited: true,
+      upstream_unavailable: true,
+      invalid_request: false,
+      unknown: true,
+    });
+  });
+
+  it("agrees with the category table on every category", () => {
+    const byCategory = {
+      credential_unavailable: "401 unauthorized",
+      rate_limited: "429 rate limit",
+      upstream_unavailable: "503 upstream",
+      invalid_request: "400 invalid request",
+      unknown: "opaque",
+    } as const;
+    for (const [category, message] of Object.entries(byCategory)) {
+      const classified = classifyModelError({ message });
+      expect(classified.category).toBe(category as keyof typeof byCategory);
+      expect(classified.retryable).toBe(
+        MODEL_ERROR_RETRYABLE_BY_CATEGORY[category as keyof typeof byCategory],
+      );
+    }
+  });
+});

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -503,6 +503,21 @@ const envSchema = z
      * when cache is off.
      */
     LLM_PROXY_CACHE_MAX_AGE: z.coerce.number().int().nonnegative().default(3600),
+    /**
+     * Operator overrides for the two `/api/llm-proxy/*` upstream deadlines.
+     * Unset → the compiled defaults in
+     * `apps/api/src/services/llm-proxy/helpers.ts` (60 s to the response
+     * HEADERS on a streaming call, 120 s of inter-chunk silence once it flows),
+     * which are sized for hosted vendors. An `org_models` row may instead point
+     * at a self-hosted `baseUrl` (Ollama / llama.cpp / vLLM) whose cold model
+     * load blocks the headers — and sometimes the next chunk — far longer than
+     * that. `optional()` rather than `default()` so the number lives in exactly
+     * one place: the sidecar's twin knobs share the same idle default from
+     * `@appstrate/connect/proxy-primitives`, which cannot be imported here
+     * (that package depends on this one).
+     */
+    LLM_PROXY_FIRST_RESPONSE_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
+    LLM_PROXY_STREAM_IDLE_TIMEOUT_MS: z.coerce.number().int().positive().optional(),
     // Global request body size cap enforced by the Hono `bodyLimit` middleware.
     // Per-route caps (LLM proxy, signed-token upload sink) still apply on top.
     API_BODY_LIMIT_BYTES: z.coerce

--- a/packages/module-chat/src/pi-chat/ui-stream-mapper.ts
+++ b/packages/module-chat/src/pi-chat/ui-stream-mapper.ts
@@ -165,7 +165,23 @@ export class PiChatUiStreamMapper {
         this.captureFailure(e.message);
         return [];
       case "agent_end":
-        for (const m of e.messages ?? []) this.captureFailure(m);
+        // Verdict on the LAST assistant message of the run, never on every
+        // entry in the list. `agent_end.messages` is the run's `newMessages` —
+        // everything it just produced — so replaying all of them through
+        // `captureFailure` re-asserts a failure a later call already recovered
+        // from, one event AFTER `captureMessageEnd` retired it, and drags
+        // `finishReason` back to "error" with it.
+        //
+        // Last-assistant is the rule this stack already states in two places,
+        // not a third one invented here: Pi's own retry decision scans back to
+        // the last assistant message (`AgentSession._willRetryAfterAgentEnd`),
+        // and the runner's terminal verdict is documented as "derived from the
+        // LAST assistant turn … a transient error the agent recovered from
+        // before a later clean turn" returns undefined (`getTerminalError` in
+        // `@appstrate/runner-pi`). It also keeps the reason this branch exists:
+        // a `handleRunFailure` message that never got a `message_end` is the
+        // only assistant entry in its list, so it is still captured.
+        this.captureFailure(lastAssistantMessage(e.messages ?? []));
         return [];
       default:
         return [];
@@ -269,6 +285,25 @@ export class PiChatUiStreamMapper {
     if (!m) return;
     if (m.usage) this.addUsage(m.usage);
     this.finishReason = mapStopReason(m.stopReason);
+    // A model call that SETTLED retires the previous failure. Pi retries inside
+    // one turn, so an early 503 the next call recovered from is no longer this
+    // turn's cause — and `lastError`, which used to be write-once, kept being
+    // reported as one. That is now visible: the client surfaces the persisted
+    // category on a DEADLINE turn too, so a stale text would name a cause that
+    // no longer applies for a turn that simply ran out of clock.
+    //
+    // Two stop reasons deliberately do NOT clear:
+    //  - "error": the call failed; `captureFailure` records it right below.
+    //  - "aborted": a stop / the deadline cut the call mid-flight, so it
+    //    settled nothing — an earlier failure is still the last thing that
+    //    actually went wrong and must keep reaching the user.
+    //
+    // Nothing genuine is silenced on the `error`-chunk path in `engine.ts`
+    // (`meta.errorText ?? (finishReason === "error" ? … )`): the two fields move
+    // together here — the same `message_end` that clears the text also moves
+    // `finishReason` off "error", so a turn still reporting "error" always has
+    // its text (or falls back to "unknown model error").
+    if (m.stopReason !== "error" && m.stopReason !== "aborted") this.lastError = undefined;
     this.captureFailure(message);
   }
 
@@ -331,6 +366,19 @@ function assistantView(message: unknown): PiAssistantView | null {
   if (!message || typeof message !== "object") return null;
   const m = message as { role?: string } & PiAssistantView;
   return m.role === "assistant" ? m : null;
+}
+
+/**
+ * The run's terminal assistant message: the last one in arrival order, or
+ * `undefined` when the list holds none. Scanning back past the tail is what
+ * keeps trailing non-assistant entries (tool results, injected steering
+ * messages) from masking the message that actually decided the run.
+ */
+function lastAssistantMessage(messages: readonly unknown[]): unknown {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (assistantView(messages[i])) return messages[i];
+  }
+  return undefined;
 }
 
 interface PiToolCallBlock {

--- a/packages/module-chat/src/turn-error.ts
+++ b/packages/module-chat/src/turn-error.ts
@@ -6,6 +6,7 @@
  * cross the stream/persistence boundary.
  */
 
+import { classifyModelError, MODEL_ERROR_RETRYABLE_BY_CATEGORY } from "@appstrate/core/model-error";
 import type { ChatTurnErrorCategory } from "@appstrate/core/chat-turn-metadata";
 
 export interface ClientTurnError {
@@ -16,71 +17,50 @@ export interface ClientTurnError {
 
 const ERROR_MARKER_PREFIX = "appstrate:chat-turn-error:";
 
-const RETRYABLE_BY_CATEGORY: Record<ChatTurnErrorCategory, boolean> = {
-  credential_unavailable: false,
-  rate_limited: true,
-  upstream_unavailable: true,
-  invalid_request: false,
-  unknown: true,
-};
-
 function messageFromError(error: unknown): string {
   if (error instanceof Error) return error.message;
   return typeof error === "string" ? error : "";
 }
 
-function statusFromError(error: unknown, message: string): number | undefined {
+/**
+ * Status the error ENVELOPE carries, if any. Only the object shapes live here;
+ * digging a status out of the message text is a classification rule and
+ * belongs with the others in `@appstrate/core/model-error`.
+ */
+function statusFromError(error: unknown): number | undefined {
   if (error && typeof error === "object") {
     const value = error as { status?: unknown; statusCode?: unknown };
     const status = value.statusCode ?? value.status;
     if (typeof status === "number" && Number.isInteger(status)) return status;
   }
-  const matched = /\b([45]\d\d)\b/.exec(message);
-  return matched ? Number(matched[1]) : undefined;
+  return undefined;
 }
 
 export function clientTurnErrorForCategory(category: ChatTurnErrorCategory): ClientTurnError {
-  return { category, retryable: RETRYABLE_BY_CATEGORY[category] };
+  return { category, retryable: MODEL_ERROR_RETRYABLE_BY_CATEGORY[category] };
 }
 
+/**
+ * Classify a thrown/streamed turn failure for the CLIENT.
+ *
+ * The rules are not here — they are `classifyModelError`'s, shared with the run
+ * surface so one provider string cannot get two verdicts. What is left is the
+ * chat-specific part: unwrapping the error object, and keeping the raw text
+ * server-side (only the category and the retry flag cross the boundary).
+ *
+ * It must stay verdict-identical to {@link clientTurnErrorFromMarker}: the UI
+ * reads a failed turn through whichever of the two arrived first (persisted
+ * metadata, or the transient stream marker), and only the category survives
+ * the marker. Anything this path knew that the category does not would make
+ * one failed turn offer a retry on one render and refuse it on the next.
+ */
 export function classifyClientTurnError(error: unknown): ClientTurnError {
   const message = messageFromError(error).trim();
-  const normalized = message.toLowerCase();
-  const status = statusFromError(error, message);
-  const requestId = /\b(req_[A-Za-z0-9_-]+)\b/.exec(message)?.[1];
-
-  let category: ChatTurnErrorCategory;
-  if (
-    status === 401 ||
-    status === 402 ||
-    status === 403 ||
-    normalized.includes("insufficient balance") ||
-    normalized.includes("insufficient credit") ||
-    normalized.includes("billing") ||
-    normalized.includes("api key") ||
-    normalized.includes("authentication") ||
-    normalized.includes("unauthorized") ||
-    normalized.includes("forbidden") ||
-    normalized.includes("credential")
-  ) {
-    category = "credential_unavailable";
-  } else if (status === 429 || normalized.includes("rate limit")) {
-    category = "rate_limited";
-  } else if (status === 400 || normalized.includes("invalid request")) {
-    category = "invalid_request";
-  } else if (
-    (status !== undefined && status >= 500) ||
-    normalized.includes("upstream model error")
-  ) {
-    category = "upstream_unavailable";
-  } else {
-    category = "unknown";
-  }
-
-  return {
-    ...clientTurnErrorForCategory(category),
-    ...(requestId ? { requestId } : {}),
-  };
+  const status = statusFromError(error);
+  return classifyModelError({
+    message,
+    ...(status !== undefined ? { status } : {}),
+  });
 }
 
 /** Safe string carried by transient AI-SDK error chunks. */
@@ -92,7 +72,7 @@ export function clientTurnErrorMarker(error: ClientTurnError): string {
 export function clientTurnErrorFromMarker(value: unknown): ClientTurnError | undefined {
   if (typeof value !== "string" || !value.startsWith(ERROR_MARKER_PREFIX)) return undefined;
   const category = value.slice(ERROR_MARKER_PREFIX.length) as ChatTurnErrorCategory;
-  return Object.prototype.hasOwnProperty.call(RETRYABLE_BY_CATEGORY, category)
+  return Object.prototype.hasOwnProperty.call(MODEL_ERROR_RETRYABLE_BY_CATEGORY, category)
     ? clientTurnErrorForCategory(category)
     : undefined;
 }

--- a/packages/module-chat/src/ui/turn-error-state.ts
+++ b/packages/module-chat/src/ui/turn-error-state.ts
@@ -75,9 +75,30 @@ export function turnErrorState(
   t: ChatTranslate,
 ): TurnErrorState | null {
   const turn = turnMetadataFromMessage(sourceMessage(message));
-  if (turn?.finishReason === "error") {
+  // A turn cut by the wall-clock ceiling can ALSO have been failing upstream
+  // the whole time: `closePiTurn` classifies and persists the cause whatever
+  // the finish reason, and reading the category only under `"error"` left the
+  // user with "time limit reached" and NOTHING about the 503s or the dead
+  // credential behind it.
+  //
+  // The two sentences COMPOSE rather than replace each other, with no new i18n
+  // key: the deadline notice is a REAL persisted text part (`turnNoticeChunks`)
+  // rendered in the message body, and this alert sits under it — so the cause
+  // is added below the notice, never a second copy of the notice itself.
+  //
+  // A deadline with NO category adds nothing: nothing failed, and the generic
+  // "generation failed" sentence would contradict a notice that says the turn
+  // was cut mid-work. Hence the category is required for that branch, while the
+  // `"error"` branch keeps degrading a legacy category-less turn to `unknown`.
+  if (
+    turn?.finishReason === "error" ||
+    (turn?.finishReason === "deadline" && turn.errorCategory !== undefined)
+  ) {
     return {
       text: t(TURN_ERROR_KEY[turn.errorCategory ?? "unknown"]),
+      // Retry is a property of the CAUSE, not of the ceiling: a deadline turn
+      // whose cause was rate limiting is retryable, one whose credential is
+      // dead is not. Read the persisted verdict either way.
       retryable: turn.errorRetryable !== false,
       requestId: turn.requestId,
     };

--- a/packages/module-chat/test/chat-error-classification.test.ts
+++ b/packages/module-chat/test/chat-error-classification.test.ts
@@ -62,6 +62,9 @@ describe("classifyClientTurnError", () => {
     const classified = classifyClientTurnError("private opaque backend details");
     const marker = clientTurnErrorMarker(classified);
     expect(marker).not.toContain("private opaque backend details");
+    // Pinned as a literal, because `toEqual(classified)` alone passes trivially
+    // for any input that produces no `requestId`.
+    expect(clientTurnErrorFromMarker(marker)).toEqual({ category: "unknown", retryable: true });
     // The marker carries the CATEGORY only, and the two paths must still agree:
     // the UI reads a failed turn through whichever arrived first.
     expect(clientTurnErrorFromMarker(marker)).toEqual(classified);

--- a/packages/module-chat/test/chat-error-classification.test.ts
+++ b/packages/module-chat/test/chat-error-classification.test.ts
@@ -8,6 +8,12 @@ import {
   refusalCode,
 } from "../src/turn-error.ts";
 
+/**
+ * The RULES moved to `@appstrate/core/model-error` (tested there, case for
+ * case). What is left here is the chat-specific wrapper: unwrapping the error
+ * object, handing the engine's own retry verdict to the shared classifier, and
+ * the marker round-trip that keeps raw provider text server-side.
+ */
 describe("classifyClientTurnError", () => {
   it("turns an aliased 402 into actionable provider-neutral metadata", () => {
     expect(
@@ -46,11 +52,19 @@ describe("classifyClientTurnError", () => {
     });
   });
 
+  it("reads the status off the error envelope, not only out of the prose", () => {
+    expect(
+      classifyClientTurnError(Object.assign(new Error("backend refused"), { status: 429 })),
+    ).toMatchObject({ category: "rate_limited" });
+  });
+
   it("round-trips only the stable category through transient stream markers", () => {
     const classified = classifyClientTurnError("private opaque backend details");
     const marker = clientTurnErrorMarker(classified);
     expect(marker).not.toContain("private opaque backend details");
-    expect(clientTurnErrorFromMarker(marker)).toEqual({ category: "unknown", retryable: true });
+    // The marker carries the CATEGORY only, and the two paths must still agree:
+    // the UI reads a failed turn through whichever arrived first.
+    expect(clientTurnErrorFromMarker(marker)).toEqual(classified);
   });
 });
 

--- a/packages/module-chat/test/pi-chat-ui-stream-mapper.test.ts
+++ b/packages/module-chat/test/pi-chat-ui-stream-mapper.test.ts
@@ -213,6 +213,90 @@ describe("PiChatUiStreamMapper", () => {
     expect(meta.errorText).toBe("context overflow");
   });
 
+  it("retires a failure a later model call recovered from", () => {
+    // pi retries inside one turn. A 503 followed by a clean call is no longer
+    // the turn's cause — leaving it standing made a turn that later died of the
+    // wall-clock deadline report a cause that no longer applied.
+    const { mapper } = run([
+      {
+        type: "message_end",
+        message: { role: "assistant", stopReason: "error", errorMessage: "upstream 503" },
+      },
+      { type: "message_end", message: { role: "assistant", stopReason: "stop" } },
+    ]);
+    const meta = mapper.result();
+    expect(meta.finishReason).toBe("stop");
+    expect(meta.errorText).toBeUndefined();
+  });
+
+  it("retires it across the whole pi auto-retry shape, agent_end included", () => {
+    // The real event sequence for one chat turn that pi retried once (chat runs
+    // with `retry: { enabled: true, maxRetries: 1 }`). Each internal run closes
+    // with its OWN turn_end + agent_end, and agent_end replays that run's
+    // message list — so the retired failure must not come back on the way out.
+    const { mapper } = run([
+      {
+        type: "message_end",
+        message: { role: "assistant", stopReason: "error", errorMessage: "upstream 503" },
+      },
+      {
+        type: "turn_end",
+        message: { role: "assistant", stopReason: "error", errorMessage: "upstream 503" },
+        toolResults: [],
+      },
+      {
+        type: "agent_end",
+        messages: [
+          { role: "user" },
+          { role: "assistant", stopReason: "error", errorMessage: "upstream 503" },
+        ],
+      },
+      { type: "message_end", message: { role: "assistant", stopReason: "stop" } },
+      { type: "turn_end", message: { role: "assistant", stopReason: "stop" }, toolResults: [] },
+      { type: "agent_end", messages: [{ role: "assistant", stopReason: "stop" }] },
+    ]);
+    const meta = mapper.result();
+    expect(meta.finishReason).toBe("stop");
+    expect(meta.errorText).toBeUndefined();
+  });
+
+  it("reads agent_end's verdict off the LAST assistant message, not the whole list", () => {
+    // Same invariant the runner states for `getTerminalError` and pi itself
+    // uses to decide a retry: an errored message followed by a clean one is a
+    // recovery, whatever order the list happens to carry them in. Capturing
+    // every entry would resurrect the failure from inside a single event.
+    const { mapper } = run([
+      {
+        type: "agent_end",
+        messages: [
+          { role: "user" },
+          { role: "assistant", stopReason: "error", errorMessage: "upstream 503" },
+          { role: "assistant", stopReason: "stop" },
+          { role: "toolResult" },
+        ],
+      },
+    ]);
+    const meta = mapper.result();
+    expect(meta.finishReason).not.toBe("error");
+    expect(meta.errorText).toBeUndefined();
+  });
+
+  it("keeps a failure the turn was cut on (aborted settles nothing)", () => {
+    // Stop / deadline abort mid-flight: the last call decided nothing, so the
+    // earlier failure is still the last thing that went wrong and must reach
+    // the user — this is exactly the deadline-with-a-cause turn.
+    const { mapper } = run([
+      {
+        type: "message_end",
+        message: { role: "assistant", stopReason: "error", errorMessage: "upstream 503" },
+      },
+      { type: "message_end", message: { role: "assistant", stopReason: "aborted" } },
+    ]);
+    const meta = mapper.result();
+    expect(meta.finishReason).toBe("other");
+    expect(meta.errorText).toBe("upstream 503");
+  });
+
   it("does not flag an explicit stop (aborted) as an error", () => {
     const { mapper } = run([
       {

--- a/packages/module-chat/test/turn-error-state.test.ts
+++ b/packages/module-chat/test/turn-error-state.test.ts
@@ -57,6 +57,47 @@ describe("turnErrorState", () => {
     ).toMatchObject({ text: "turn.error.unknown" });
   });
 
+  it("surfaces the cause of a deadline turn that was failing all along", () => {
+    // The deadline notice is a real persisted text part rendered above this
+    // alert, so the user reads BOTH: "this turn hit its time limit" and why it
+    // was going nowhere. Retry follows the cause, not the ceiling.
+    expect(
+      turnErrorState(
+        message(
+          turn({
+            finishReason: "deadline",
+            errorCategory: "upstream_unavailable",
+            errorRetryable: true,
+            requestId: "req_slow1",
+          }),
+        ),
+        t,
+      ),
+    ).toEqual({ text: "turn.error.upstreamUnavailable", retryable: true, requestId: "req_slow1" });
+  });
+
+  it("takes retryable from the cause on a deadline turn, not from the deadline", () => {
+    expect(
+      turnErrorState(
+        message(
+          turn({
+            finishReason: "deadline",
+            errorCategory: "credential_unavailable",
+            errorRetryable: false,
+          }),
+        ),
+        t,
+      ),
+    ).toMatchObject({ text: "turn.error.credentialUnavailable", retryable: false });
+  });
+
+  it("adds no sentence to a deadline turn that carried no cause", () => {
+    // Nothing failed — the turn simply ran out of clock, and the notice already
+    // says so. A generic "generation failed" here would contradict it and read
+    // as a second, different verdict on the same turn.
+    expect(turnErrorState(message(turn({ finishReason: "deadline" })), t)).toBeNull();
+  });
+
   it("localizes an in-stream failure from its marker", () => {
     expect(
       turnErrorState(

--- a/packages/runner-pi/src/container-env.ts
+++ b/packages/runner-pi/src/container-env.ts
@@ -297,13 +297,18 @@ export const SIDECAR_OPERATOR_ENV_KEYS = [
   // Per-call MCP tool timeout, read on BOTH legs of a tool call (sidecar-side and
   // agent-side), so one operator knob widens both. Absent → the MCP SDK default.
   "APPSTRATE_MCP_TOOL_TIMEOUT_MS",
-  // The four below are read INSIDE the sidecar process. Under
+  // The six below are read INSIDE the sidecar process. Under
   // RUN_ADAPTER=docker/firecracker its env is built from `pickOperatorSidecarEnv()`
   // alone rather than inherited, so a key missing here is silently ignored there.
   "LOG_LEVEL",
   "SIDECAR_API_CALL_CONCURRENCY",
   "SIDECAR_INLINE_TOOL_OUTPUT_TOKENS",
   "SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS",
+  // LLM upstream deadlines. Self-hosted backings (a local Ollama/vLLM doing a cold
+  // model load) legitimately exceed the compiled defaults, which is the whole reason
+  // these are tunable — so they must reach the container, not just `RUN_ADAPTER=process`.
+  "SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS",
+  "SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS",
 ] as const;
 
 export type SidecarOperatorEnvKey = (typeof SIDECAR_OPERATOR_ENV_KEYS)[number];
@@ -316,7 +321,7 @@ const logger = createLogger(process.env.LOG_LEVEL ?? "info");
  * The operator keys parsed as a positive integer somewhere on the boot path, and
  * would throw on. The rest are used verbatim or already degrade safely.
  *
- * Four of the five are parsed by the sidecar itself. `SIDECAR_MAX_REQUEST_BODY_BYTES`
+ * Six of the seven are parsed by the sidecar itself. `SIDECAR_MAX_REQUEST_BODY_BYTES`
  * is not any more — see {@link pickOperatorSidecarEnv} — but it belongs in the set
  * all the same: it is still parsed strictly, just earlier and by another module.
  */
@@ -326,6 +331,8 @@ const NUMERIC_SIDECAR_ENV_KEYS = new Set<SidecarOperatorEnvKey>([
   "SIDECAR_API_CALL_CONCURRENCY",
   "SIDECAR_INLINE_TOOL_OUTPUT_TOKENS",
   "SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS",
+  "SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS",
+  "SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS",
 ]);
 
 /**
@@ -342,8 +349,8 @@ function isPositiveIntegerEnvValue(value: string): boolean {
  * to spread into a container env; empty and undefined values are omitted.
  *
  * Omitting MALFORMED numeric values is load-bearing, not defensive, for four of the
- * five {@link NUMERIC_SIDECAR_ENV_KEYS}: `SIDECAR_MAX_MCP_ENVELOPE_BYTES`,
- * `SIDECAR_API_CALL_CONCURRENCY` and the two token budgets. The sidecar parses those
+ * seven {@link NUMERIC_SIDECAR_ENV_KEYS}: `SIDECAR_MAX_MCP_ENVELOPE_BYTES`,
+ * `SIDECAR_API_CALL_CONCURRENCY`, the two token budgets and the two LLM deadlines. The sidecar parses those
  * with `readPositiveIntEnv` (`runtime-pi/sidecar/helpers.ts`), which THROWS at module
  * scope on the boot path, inside no `try`. One stale `=0` reaching the container would
  * kill the sidecar process and fail every run; dropping it here keeps runs alive on the

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -1393,9 +1393,10 @@ function isProviderNormalizedAbort(errorMessage: string | undefined): boolean {
  * True when a terminal `aborted` (or provider-normalized abort) turn is the
  * runner's OWN early-stop rather than a failure: the run already produced a
  * successful terminal tool, and `onTerminalTool` aborted the SDK loop to stop
- * paying for turns nobody will read. Extracted so `getTerminalError()` and the
- * sticky upstream recorder apply one definition instead of two copies that can
- * drift apart — they must agree on what is NOT a failure.
+ * paying for turns nobody will read. Extracted so all three readers — the live
+ * `appstrate.error` emit, `getTerminalError()` and the sticky upstream recorder
+ * — apply one definition instead of copies that can drift apart: they must
+ * agree on what is NOT a failure.
  */
 function isRunnerEarlyStopAbort(
   stopReason: string | undefined,
@@ -1635,14 +1636,20 @@ export function installSessionBridge(
         // status stay consistent).
         if (
           isTerminalErrorStop(last.stopReason) &&
-          !(
-            terminalToolCompleted &&
-            (last.stopReason === "aborted" || isProviderNormalizedAbort(last.errorMessage))
-          )
+          !isRunnerEarlyStopAbort(last.stopReason, last.errorMessage, terminalToolCompleted)
         ) {
-          fire(
-            buildError({ runId, timestamp: Date.now() }, terminalErrorMessage(last.errorMessage)),
-          );
+          // The classification rides the event's `data`, which the platform
+          // writes to `run_logs.data` (jsonb) — the same route the watchdog's
+          // `upstream` block takes, and the ONLY one that reaches durable
+          // storage: the finalize body's `RunError` is parsed by a closed
+          // schema and persisted by its `message` alone. Keys are snake_case
+          // because this is data on the wire.
+          const errorMessage = terminalErrorMessage(last.errorMessage);
+          const classified = classifyModelError({ message: errorMessage });
+          fire({
+            ...buildError({ runId, timestamp: Date.now() }, errorMessage),
+            data: { error_category: classified.category, error_retryable: classified.retryable },
+          });
         }
 
         // Full assistant text (for progress display)
@@ -1802,23 +1809,11 @@ export function installSessionBridge(
       // `message` stays the RAW provider text: the run surface is a debugging
       // surface and the operator reading `runs.error` wants the upstream
       // sentence verbatim (the chat surface deliberately does the opposite and
-      // ships only the class). The classification is additive supplementary
-      // data, so a sink matching on `code` or `message` sees nothing new.
-      //
-      // Same rules as the chat turn classifier (`@appstrate/core/model-error`),
-      // so one provider string cannot get two answers depending on which
-      // surface met it. Keys inside `context` are snake_case — it is data on
-      // the wire, riding the `appstrate.error` event's `data` into `run_logs`,
-      // exactly like the watchdog's `upstream` block above.
-      const classified = classifyModelError({ message });
-      return {
-        code: "adapter_error",
-        message,
-        context: {
-          error_category: classified.category,
-          error_retryable: classified.retryable,
-        },
-      };
+      // ships only the class). The CLASSIFICATION of this same turn travels the
+      // `appstrate.error` event emitted above, never this `RunError`: the
+      // finalize body is parsed by a closed schema (`message`/`stack`/`code`),
+      // so a `context` here would be dropped at ingestion and reach no reader.
+      return { code: "adapter_error", message };
     },
     getLastUpstreamError(): { stopReason: string; message: string } | undefined {
       if (lastUpstreamStopReason === undefined) return undefined;

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -346,6 +346,44 @@ export function derivePiCompactionSettings(
   return { compaction: { enabled: true, reserveTokens, keepRecentTokens }, contextWindow };
 }
 
+/**
+ * Two caps on the SAME provider failure string, because the timeout watchdog
+ * puts it on two channels with very different budgets. Kept adjacent, and the
+ * second derived from the first, so the relationship is structural rather than
+ * two unexplained numbers a reader has to reconcile.
+ *
+ * A provider failure string is data we do not control: an HTML error page or a
+ * JSON stack dump runs to hundreds of KiB, so both channels must be bounded.
+ *
+ * - `UPSTREAM_MESSAGE_MAX_CHARS` bounds the ARCHIVAL copy in
+ *   `RunError.context` — the structured channel, documented as bounded ("sinks
+ *   may truncate large payloads"), which lands in a `run_logs.data` jsonb.
+ *   2000 chars is well past any real provider error.
+ * - `UPSTREAM_SUMMARY_MAX_CHARS` bounds the HUMAN copy appended to
+ *   `RunError.message` — a tenth of the archival budget, because that channel
+ *   is ONE line of a log-viewer row and the `runs.error` text column, not an
+ *   archive. The full-length copy always remains in `context.upstream.message`,
+ *   so tightening this loses nothing.
+ */
+const UPSTREAM_MESSAGE_MAX_CHARS = 2000;
+const UPSTREAM_SUMMARY_MAX_CHARS = UPSTREAM_MESSAGE_MAX_CHARS / 10;
+
+/**
+ * Collapse a provider failure string to ONE bounded line for the human
+ * channel. The collapse is not cosmetic: the log viewer renders a row's
+ * message with `whitespace-pre-wrap` (apps/web/src/components/log-viewer.tsx),
+ * so an embedded newline becomes a real line break — a multi-line JSON error
+ * body would turn one log row into forty — and the viewer's copy/export path
+ * joins entries by line, which a multi-line message would desynchronise.
+ * Collapsing runs of whitespace (not just newlines) also strips the indentation
+ * of a pretty-printed JSON body, which is what makes 200 chars enough to carry
+ * the meaningful part. Collapse BEFORE slicing so the cap counts visible
+ * characters rather than indentation.
+ */
+function summarizeUpstreamMessage(message: string): string {
+  return message.replace(/\s+/g, " ").trim().slice(0, UPSTREAM_SUMMARY_MAX_CHARS).trimEnd();
+}
+
 // Compile error if appstrate ever declares an apiShape Pi does not know.
 type _ApiShapeSubsetOfPi = ModelApiShape extends KnownApi ? true : never;
 const _assertApiShapeSubsetOfPi: _ApiShapeSubsetOfPi = true;
@@ -456,10 +494,55 @@ export class PiRunner implements Runner {
           eventSink,
           usage: bridge?.getUsage() ?? { input_tokens: 0, output_tokens: 0 },
           terminalStatus: "timeout",
-          buildError: () => ({
-            code: "timeout",
-            message: `Run timed out after ${timeoutSeconds}s`,
-          }),
+          buildError: () => {
+            // The watchdog knows only that the budget ran out; the BRIDGE
+            // knows why the run was making no headway. Ask it for the last
+            // failed model turn so a run that spent its whole budget on
+            // provider 503s stops finalizing as a bare `timeout` with no
+            // cause the user can act on. Deliberately NOT `getTerminalError()`:
+            // that is the verdict on the FINAL turn and returns undefined for
+            // exactly the shape seen here — a run cut off mid-retry-loop,
+            // whose last turn never settled into a terminal error.
+            const upstream = bridge?.getLastUpstreamError();
+            // The cause has to travel the HUMAN channel too, not just
+            // `context`. `RunError.message` is the only field that reaches
+            // both the `runs.error` text column and the log viewer without a
+            // schema migration — `context` is durable (it rides the
+            // `appstrate.error` event into `run_logs.data`) but nothing on
+            // screen projects an unknown `data` key, so a cause carried only
+            // there leaves the user reading a bare "timed out" exactly as
+            // before. The existing sentence stays as the PREFIX, verbatim:
+            // it is the run's own verdict and readers may match on it, so a
+            // run with no upstream cause produces a byte-identical message.
+            // The wording names the provider explicitly so a non-expert reads
+            // "something upstream broke", not "my agent is buggy".
+            const cause = upstream
+              ? ` — the model provider returned an error during the run: ${summarizeUpstreamMessage(upstream.message)}`
+              : "";
+            return {
+              // Unchanged on purpose: `timeout` is the documented stable
+              // branch key sinks and webhooks match on. The cause is additive
+              // supplementary data, never a new code.
+              code: "timeout",
+              message: `Run timed out after ${timeoutSeconds}s${cause}`,
+              // Omitted ENTIRELY when no turn ever errored — an empty
+              // `context` would read as "we looked upstream and it was fine",
+              // which is not what "we never saw a failed turn" means. Keys
+              // inside `context` are snake_case: this is data on the wire (it
+              // rides the finalize body and the `appstrate.error` event into a
+              // `run_logs.data` jsonb), not a TS-internal shape.
+              ...(upstream
+                ? {
+                    context: {
+                      upstream: {
+                        stop_reason: upstream.stopReason,
+                        message: upstream.message.slice(0, UPSTREAM_MESSAGE_MAX_CHARS),
+                      },
+                    },
+                  }
+                : {}),
+            };
+          },
           stamp: (result) => {
             if (bridge) result.cost = bridge.getCost();
             result.durationMs = Date.now() - runStart;
@@ -1086,6 +1169,21 @@ export interface SessionBridgeHandle {
    * `RunResult.status`.
    */
   getTerminalError(): RunError | undefined;
+  /**
+   * The last assistant turn that FAILED at ANY point in the run — not
+   * necessarily the final one — or `undefined` if none ever did.
+   *
+   * Deliberately distinct from {@link getTerminalError}, and the two answer
+   * different questions. That one is the terminal VERDICT on the FINAL turn:
+   * an errored turn the agent later recovered from is invisible to it, and
+   * must be, because the run went on to succeed. This one survives that
+   * recovery. It exists for the paths that cut the run off BEFORE it can
+   * settle into a verdict — the wall-clock watchdog above all, where the loop
+   * may have burnt the whole budget retrying provider 503s and the turn it
+   * happened to be mid-way through says nothing at all. Without it such a run
+   * finalizes as a bare `timeout` carrying zero cause.
+   */
+  getLastUpstreamError(): { stopReason: string; message: string } | undefined;
 }
 
 /**
@@ -1290,6 +1388,24 @@ function isProviderNormalizedAbort(errorMessage: string | undefined): boolean {
   return normalized === "the operation was aborted" || normalized === "this operation was aborted";
 }
 
+/**
+ * True when a terminal `aborted` (or provider-normalized abort) turn is the
+ * runner's OWN early-stop rather than a failure: the run already produced a
+ * successful terminal tool, and `onTerminalTool` aborted the SDK loop to stop
+ * paying for turns nobody will read. Extracted so `getTerminalError()` and the
+ * sticky upstream recorder apply one definition instead of two copies that can
+ * drift apart — they must agree on what is NOT a failure.
+ */
+function isRunnerEarlyStopAbort(
+  stopReason: string | undefined,
+  errorMessage: string | undefined,
+  terminalToolCompleted: boolean,
+): boolean {
+  return (
+    terminalToolCompleted && (stopReason === "aborted" || isProviderNormalizedAbort(errorMessage))
+  );
+}
+
 interface SessionBridgeOptions {
   /**
    * Tool names whose first successful `tool_execution_end` marks the run
@@ -1361,6 +1477,17 @@ export function installSessionBridge(
   let lastAssistantStopReason: string | undefined;
   let lastAssistantErrorMessage: string | undefined;
 
+  // Last FAILED assistant turn — kept separate from the two fields above on
+  // purpose, not folded into them. Those are overwritten on every
+  // `message_end`, so a single clean turn after an errored one erases the
+  // cause; that is correct for the terminal verdict (the agent recovered, the
+  // run succeeded) and exactly wrong for a run the watchdog cuts short, where
+  // the errored turns ARE the story. These two are written only on a terminal
+  // error stop and never cleared, so `getLastUpstreamError()` can still name
+  // the provider failure after any number of intervening clean turns.
+  let lastUpstreamStopReason: string | undefined;
+  let lastUpstreamErrorMessage: string | undefined;
+
   // Pending fire-and-forget emits. `fire()` dispatches each sink.emit
   // call without awaiting (the Pi SDK callback is synchronous), and
   // pushes the resulting promise here so `drainPending()` can await
@@ -1428,6 +1555,25 @@ export function installSessionBridge(
         // loop settles (mirrors the SDK's own `_lastAssistantMessage`).
         lastAssistantStopReason = last.stopReason;
         lastAssistantErrorMessage = last.errorMessage;
+
+        // Sticky record of the last FAILED turn (see the declaration). Gated
+        // on `isTerminalErrorStop` — the same predicate the live
+        // `appstrate.error` emit and `getTerminalError()` use — so a clean
+        // turn leaves it standing instead of blanking it.
+        // Also skips the runner's own early-stop abort, mirroring
+        // `getTerminalError()`: that turn is a success artefact, and latching
+        // it would make a watchdog firing afterwards (a terminal tool ran, then
+        // the output re-prompt hung) blame a provider that never failed. The
+        // suppression is applied HERE, at latch time, not at read time: a
+        // benign abort must not be recorded, but neither may it ERASE a real
+        // 503 latched earlier in the run — which a read-time guard would do.
+        if (
+          isTerminalErrorStop(last.stopReason) &&
+          !isRunnerEarlyStopAbort(last.stopReason, last.errorMessage, terminalToolCompleted)
+        ) {
+          lastUpstreamStopReason = last.stopReason;
+          lastUpstreamErrorMessage = last.errorMessage;
+        }
 
         // Accumulate this turn's token usage into the run totals.
         const u = last.usage;
@@ -1640,9 +1786,11 @@ export function installSessionBridge(
       // A trailing "aborted" turn AFTER a successful terminal tool is the
       // runner's own early-stop, not a failure.
       if (
-        terminalToolCompleted &&
-        (lastAssistantStopReason === "aborted" ||
-          isProviderNormalizedAbort(lastAssistantErrorMessage))
+        isRunnerEarlyStopAbort(
+          lastAssistantStopReason,
+          lastAssistantErrorMessage,
+          terminalToolCompleted,
+        )
       ) {
         return undefined;
       }
@@ -1650,6 +1798,16 @@ export function installSessionBridge(
         return undefined;
       }
       return { code: "adapter_error", message: terminalErrorMessage(lastAssistantErrorMessage) };
+    },
+    getLastUpstreamError(): { stopReason: string; message: string } | undefined {
+      if (lastUpstreamStopReason === undefined) return undefined;
+      // Same message resolution as the terminal verdict (`terminalErrorMessage`
+      // is shared) so the two can never describe one failed turn with two
+      // different strings.
+      return {
+        stopReason: lastUpstreamStopReason,
+        message: terminalErrorMessage(lastUpstreamErrorMessage),
+      };
     },
     async drainPending(): Promise<void> {
       // Snapshot the current pending set: events fired AFTER drainPending

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -45,6 +45,7 @@ import {
   type ModelReasoningLevel,
 } from "@appstrate/core/model-generation";
 import { deriveResponseReserveTokens } from "@appstrate/core/token-budget";
+import { classifyModelError } from "@appstrate/core/model-error";
 import type { RunEvent, ExecutionContext } from "@appstrate/afps-runtime/types";
 import {
   buildError,
@@ -1797,7 +1798,27 @@ export function installSessionBridge(
       if (!isTerminalErrorStop(lastAssistantStopReason)) {
         return undefined;
       }
-      return { code: "adapter_error", message: terminalErrorMessage(lastAssistantErrorMessage) };
+      const message = terminalErrorMessage(lastAssistantErrorMessage);
+      // `message` stays the RAW provider text: the run surface is a debugging
+      // surface and the operator reading `runs.error` wants the upstream
+      // sentence verbatim (the chat surface deliberately does the opposite and
+      // ships only the class). The classification is additive supplementary
+      // data, so a sink matching on `code` or `message` sees nothing new.
+      //
+      // Same rules as the chat turn classifier (`@appstrate/core/model-error`),
+      // so one provider string cannot get two answers depending on which
+      // surface met it. Keys inside `context` are snake_case — it is data on
+      // the wire, riding the `appstrate.error` event's `data` into `run_logs`,
+      // exactly like the watchdog's `upstream` block above.
+      const classified = classifyModelError({ message });
+      return {
+        code: "adapter_error",
+        message,
+        context: {
+          error_category: classified.category,
+          error_retryable: classified.retryable,
+        },
+      };
     },
     getLastUpstreamError(): { stopReason: string; message: string } | undefined {
       if (lastUpstreamStopReason === undefined) return undefined;

--- a/packages/runner-pi/test/container-env.test.ts
+++ b/packages/runner-pi/test/container-env.test.ts
@@ -529,6 +529,33 @@ describe("pickOperatorSidecarEnv", () => {
     );
   });
 
+  // The LLM deadline knobs exist BECAUSE a self-hosted backing legitimately
+  // exceeds the compiled defaults, so an operator who sets them under
+  // `RUN_ADAPTER=docker`/`firecracker` must actually get them: the container's
+  // env is built from this allowlist alone. They are also parsed sidecar-side by
+  // `readPositiveIntEnv`, which throws at module scope, so a malformed value has
+  // to be dropped here rather than forwarded — both halves asserted together
+  // because forwarding without the numeric gate would kill every run.
+  it("forwards the LLM deadline knobs, and drops malformed ones", () => {
+    withEnv(
+      {
+        SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS: "90000",
+        SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS: "300000",
+      },
+      () => {
+        expect(pickOperatorSidecarEnv()).toEqual({
+          SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS: "90000",
+          SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS: "300000",
+        });
+      },
+    );
+    for (const bad of ["0", "-1", "abc", "12.5"]) {
+      withEnv({ SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS: bad }, () => {
+        expect(pickOperatorSidecarEnv().SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS).toBeUndefined();
+      });
+    }
+  });
+
   // The gate must be no stricter than the sidecar's own parse, or it would
   // silently drop values the sidecar would have honoured. `Number` trims, so
   // padded input is valid on BOTH sides — asserted here because the two live

--- a/packages/runner-pi/test/model-error-divergence.test.ts
+++ b/packages/runner-pi/test/model-error-divergence.test.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * NON-DIVERGENCE guard between the two classifiers that judge one model
+ * failure.
+ *
+ * The agent SDK's `isRetryableAssistantError` decides whether its own in-turn
+ * retry loop tries again. Appstrate's `classifyModelError` decides what the
+ * user is told and whether a retry is offered. The two answer different
+ * questions — by the time a human reads the error the SDK's loop has already
+ * finished, and a user retry starts a NEW turn — which is why the vendor
+ * verdict is NOT a runtime input to the platform's classifier.
+ *
+ * But nothing structurally pins them together either: they are two independent
+ * pattern lists, in two repos, moving on two release cadences. Without this
+ * test a `@earendil-works/pi-ai` bump could move a pattern from one list to the
+ * other and no test anywhere would fail — the engine would quietly stop
+ * retrying something the UI still advertised as retryable, or keep retrying
+ * something the UI had already declared dead. A test is the right pin
+ * precisely BECAUSE a runtime handoff is not: it makes the drift loud without
+ * letting the vendor's answer to its own question leak into ours.
+ *
+ * The corpus is real provider failure text, not synthetic strings, because
+ * both classifiers are substring matchers and only real wording exercises the
+ * overlaps that actually bite.
+ *
+ * IF THIS TEST FAILS, nothing here is wrong — the VENDOR moved. Read the
+ * failure message, then reconcile deliberately: either Appstrate's rules in
+ * `packages/core/src/model-error.ts` follow the vendor, or the corpus entry
+ * records a disagreement we accept and says why.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  classifyModelError,
+  MODEL_ERROR_RETRYABLE_BY_CATEGORY,
+  type ModelErrorCategory,
+} from "@appstrate/core/model-error";
+// Straight from the vendor, not through `src/pi-sdk.ts`. The barrel's header is
+// explicit that nothing test-only belongs in it — two re-exports were removed
+// from it for exactly that reason — and its `no-restricted-imports` guard never
+// covered `packages/*/test/**`. Nothing in production consults this predicate,
+// so a barrel member would have been a dead export whose only reader is this
+// file.
+import { isRetryableAssistantError, type AssistantMessage } from "@earendil-works/pi-ai";
+
+/**
+ * The vendor's verdict on a bare error string. It takes a whole
+ * `AssistantMessage` and reads exactly two fields off it (`stopReason`,
+ * `errorMessage`), which is all a corpus entry has.
+ */
+function vendorRetryable(message: string): boolean {
+  return isRetryableAssistantError({
+    stopReason: "error",
+    errorMessage: message,
+  } as AssistantMessage);
+}
+
+interface Case {
+  /** What a provider actually returns. */
+  name: string;
+  message: string;
+  status?: number;
+  category: ModelErrorCategory;
+  /** What the SDK's retry loop does with it today. */
+  vendorRetryable: boolean;
+}
+
+const CORPUS: Case[] = [
+  {
+    name: "OpenAI 429 with an exhausted account (the case that motivated all this)",
+    message:
+      "429 You exceeded your current quota, please check your plan and billing details. " +
+      '{"error":{"message":"You exceeded your current quota","type":"insufficient_quota",' +
+      '"code":"insufficient_quota"}}',
+    // Not `rate_limited`, even though it IS a 429: the wording names an account
+    // the provider will not serve, and that is the actionable half.
+    category: "credential_unavailable",
+    // The SDK's non-retryable list wins over its own "429" retryable pattern.
+    vendorRetryable: false,
+  },
+  {
+    name: "Gemini 503 UNAVAILABLE under load",
+    message:
+      "[503 Service Unavailable] The model is overloaded because of high demand. " +
+      "Please try again later. status: UNAVAILABLE",
+    category: "upstream_unavailable",
+    vendorRetryable: true,
+  },
+  {
+    name: "OpenAI 401 with a bad key",
+    message:
+      "401 Incorrect API key provided: sk-***. You can find your API key at " +
+      "https://platform.openai.com/account/api-keys.",
+    category: "credential_unavailable",
+    vendorRetryable: false,
+  },
+  {
+    name: "bare transport failure (undici)",
+    message: "fetch failed",
+    category: "unknown",
+    vendorRetryable: true,
+  },
+  {
+    name: "context overflow",
+    message:
+      "This model's maximum context length is 128000 tokens. However, your messages " +
+      "resulted in 131072 tokens. Please reduce the length of the messages.",
+    status: 400,
+    category: "invalid_request",
+    vendorRetryable: false,
+  },
+];
+
+describe("model-error classification does not diverge from the agent SDK", () => {
+  it("has a corpus (positive control — an empty one passes vacuously)", () => {
+    expect(CORPUS.length).toBeGreaterThanOrEqual(5);
+  });
+
+  for (const entry of CORPUS) {
+    it(`agrees on: ${entry.name}`, () => {
+      const vendor = vendorRetryable(entry.message);
+      expect(
+        vendor,
+        `The agent SDK's retry verdict for this provider text moved: expected ` +
+          `${entry.vendorRetryable}, got ${vendor}. A @earendil-works/pi-ai bump ` +
+          `changed NON_RETRYABLE_PROVIDER_LIMIT_ERROR_PATTERN or ` +
+          `RETRYABLE_PROVIDER_ERROR_PATTERN (dist/utils/retry.js). The engine now ` +
+          `retries this failure differently than it did, so Appstrate's rules in ` +
+          `packages/core/src/model-error.ts must be re-reconciled against it — ` +
+          `do not just update this number.\n  ${entry.message}`,
+      ).toBe(entry.vendorRetryable);
+
+      const classified = classifyModelError({
+        message: entry.message,
+        ...(entry.status !== undefined ? { status: entry.status } : {}),
+      });
+      expect(classified.category).toBe(entry.category);
+
+      // THE invariant. On real provider text the two classifiers reach the same
+      // conclusion about retrying — Appstrate's, read off the category alone,
+      // and the SDK's, read off its own pattern lists. They are not wired
+      // together, so this agreement is a fact about the two rule sets, not a
+      // tautology. A failure means one moved under the other, which is exactly
+      // the silent drift this file exists to make loud.
+      expect(
+        classified.retryable,
+        `Appstrate would ${MODEL_ERROR_RETRYABLE_BY_CATEGORY[entry.category] ? "" : "not "}` +
+          `retry this (category "${entry.category}") while the agent SDK would ` +
+          `${vendor ? "" : "not "}. The two classifiers have drifted apart on real ` +
+          `provider text; one of the two pattern lists must be corrected.`,
+      ).toBe(MODEL_ERROR_RETRYABLE_BY_CATEGORY[entry.category]);
+    });
+  }
+});

--- a/packages/runner-pi/test/model-error-divergence.test.ts
+++ b/packages/runner-pi/test/model-error-divergence.test.ts
@@ -1,28 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * NON-DIVERGENCE guard between the two classifiers that judge one model
- * failure.
+ * DRIFT guard over the two classifiers that judge one model failure.
  *
  * The agent SDK's `isRetryableAssistantError` decides whether its own in-turn
  * retry loop tries again. Appstrate's `classifyModelError` decides what the
  * user is told and whether a retry is offered. The two answer different
  * questions — by the time a human reads the error the SDK's loop has already
  * finished, and a user retry starts a NEW turn — which is why the vendor
- * verdict is NOT a runtime input to the platform's classifier.
+ * verdict is NOT a runtime input to the platform's classifier, and why the two
+ * are NOT required to agree. The last corpus entry below is a standing example
+ * of a disagreement that is correct on both sides.
  *
- * But nothing structurally pins them together either: they are two independent
- * pattern lists, in two repos, moving on two release cadences. Without this
- * test a `@earendil-works/pi-ai` bump could move a pattern from one list to the
- * other and no test anywhere would fail — the engine would quietly stop
- * retrying something the UI still advertised as retryable, or keep retrying
- * something the UI had already declared dead. A test is the right pin
- * precisely BECAUSE a runtime handoff is not: it makes the drift loud without
- * letting the vendor's answer to its own question leak into ours.
+ * What this file pins, per corpus entry, is each rule set's answer read side by
+ * side: the vendor's retry verdict and Appstrate's category. Neither is
+ * structurally anchored to the other — two independent pattern lists, in two
+ * repos, moving on two release cadences — so without this test a
+ * `@earendil-works/pi-ai` bump could move a pattern from one list to the other
+ * and no test anywhere would fail. This makes the vendor's move loud at the
+ * moment it lands, so the disagreements we accept stay deliberate instead of
+ * going silent. It does NOT prove the two agree.
  *
- * The corpus is real provider failure text, not synthetic strings, because
- * both classifiers are substring matchers and only real wording exercises the
- * overlaps that actually bite.
+ * The corpus is real provider failure text — plus the one string the platform
+ * manufactures itself — not synthetic strings, because both classifiers are
+ * substring matchers and only real wording exercises the overlaps that actually
+ * bite.
  *
  * IF THIS TEST FAILS, nothing here is wrong — the VENDOR moved. Read the
  * failure message, then reconcile deliberately: either Appstrate's rules in
@@ -31,11 +33,7 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import {
-  classifyModelError,
-  MODEL_ERROR_RETRYABLE_BY_CATEGORY,
-  type ModelErrorCategory,
-} from "@appstrate/core/model-error";
+import { classifyModelError, type ModelErrorCategory } from "@appstrate/core/model-error";
 // Straight from the vendor, not through `src/pi-sdk.ts`. The barrel's header is
 // explicit that nothing test-only belongs in it — two re-exports were removed
 // from it for exactly that reason — and its `no-restricted-imports` guard never
@@ -110,15 +108,31 @@ const CORPUS: Case[] = [
     category: "invalid_request",
     vendorRetryable: false,
   },
+  {
+    // Not provider text: the sidecar manufactures this for EVERY failure on an
+    // aliased model (`syntheticAliasErrorMessage`, `packages/core/src/model-swap.ts`)
+    // so no provider name leaks to the agent — which means it reaches both
+    // classifiers exactly like real provider text, and belongs in the corpus.
+    name: 'platform-manufactured alias error, no status ("Upstream model error")',
+    message: 'Upstream model error (model "my-alias")',
+    category: "upstream_unavailable",
+    // The two verdicts differ HERE, and both are right: the SDK finds no
+    // retryable pattern in this deliberately neutral prose and stops trying
+    // within the turn, while Appstrate reads "upstream" and offers the user a
+    // fresh attempt — a NEW turn, not the one the SDK gave up on. Adding a
+    // status hint (`, status 503`) flips the vendor to true; the platform's
+    // category is unchanged either way.
+    vendorRetryable: false,
+  },
 ];
 
-describe("model-error classification does not diverge from the agent SDK", () => {
+describe("model-error classification stays pinned against the agent SDK", () => {
   it("has a corpus (positive control — an empty one passes vacuously)", () => {
     expect(CORPUS.length).toBeGreaterThanOrEqual(5);
   });
 
   for (const entry of CORPUS) {
-    it(`agrees on: ${entry.name}`, () => {
+    it(`pins both verdicts for: ${entry.name}`, () => {
       const vendor = vendorRetryable(entry.message);
       expect(
         vendor,
@@ -136,20 +150,6 @@ describe("model-error classification does not diverge from the agent SDK", () =>
         ...(entry.status !== undefined ? { status: entry.status } : {}),
       });
       expect(classified.category).toBe(entry.category);
-
-      // THE invariant. On real provider text the two classifiers reach the same
-      // conclusion about retrying — Appstrate's, read off the category alone,
-      // and the SDK's, read off its own pattern lists. They are not wired
-      // together, so this agreement is a fact about the two rule sets, not a
-      // tautology. A failure means one moved under the other, which is exactly
-      // the silent drift this file exists to make loud.
-      expect(
-        classified.retryable,
-        `Appstrate would ${MODEL_ERROR_RETRYABLE_BY_CATEGORY[entry.category] ? "" : "not "}` +
-          `retry this (category "${entry.category}") while the agent SDK would ` +
-          `${vendor ? "" : "not "}. The two classifiers have drifted apart on real ` +
-          `provider text; one of the two pattern lists must be corrected.`,
-      ).toBe(MODEL_ERROR_RETRYABLE_BY_CATEGORY[entry.category]);
     });
   }
 });

--- a/packages/runner-pi/test/session-bridge.test.ts
+++ b/packages/runner-pi/test/session-bridge.test.ts
@@ -1197,10 +1197,6 @@ describe("installSessionBridge — terminal tools (early stop on output)", () =>
     expect(bridge.getTerminalError()).toEqual({
       code: "adapter_error",
       message: "provider exploded",
-      // Nothing in this text names a class, so `unknown` — which stays
-      // retryable. See `test/model-error-divergence.test.ts` for the contract
-      // that keeps these rules honest against the vendor's own.
-      context: { error_category: "unknown", error_retryable: true },
     });
   });
 
@@ -1224,10 +1220,6 @@ describe("installSessionBridge — terminal tools (early stop on output)", () =>
     expect(bridge.getTerminalError()).toEqual({
       code: "adapter_error",
       message: "Request was aborted",
-      // Nothing in this text names a class, so `unknown` — which stays
-      // retryable. See `test/model-error-divergence.test.ts` for the contract
-      // that keeps these rules honest against the vendor's own.
-      context: { error_category: "unknown", error_retryable: true },
     });
   });
 });

--- a/packages/runner-pi/test/session-bridge.test.ts
+++ b/packages/runner-pi/test/session-bridge.test.ts
@@ -1197,6 +1197,10 @@ describe("installSessionBridge — terminal tools (early stop on output)", () =>
     expect(bridge.getTerminalError()).toEqual({
       code: "adapter_error",
       message: "provider exploded",
+      // Nothing in this text names a class, so `unknown` — which stays
+      // retryable. See `test/model-error-divergence.test.ts` for the contract
+      // that keeps these rules honest against the vendor's own.
+      context: { error_category: "unknown", error_retryable: true },
     });
   });
 
@@ -1220,6 +1224,10 @@ describe("installSessionBridge — terminal tools (early stop on output)", () =>
     expect(bridge.getTerminalError()).toEqual({
       code: "adapter_error",
       message: "Request was aborted",
+      // Nothing in this text names a class, so `unknown` — which stays
+      // retryable. See `test/model-error-divergence.test.ts` for the contract
+      // that keeps these rules honest against the vendor's own.
+      context: { error_category: "unknown", error_retryable: true },
     });
   });
 });

--- a/packages/runner-pi/test/terminal-error.test.ts
+++ b/packages/runner-pi/test/terminal-error.test.ts
@@ -14,9 +14,21 @@
 
 import { describe, it, expect } from "bun:test";
 import { installSessionBridge } from "../src/pi-runner.ts";
-import { createFakeSession, createInternalCapture } from "./helpers.ts";
+import {
+  createCaptureSink,
+  createFakeSession,
+  createInternalCapture,
+  makeBundlePackage,
+  makeContext,
+  makeTestBundle,
+  ScriptedPiRunner,
+  type FakeSession,
+} from "./helpers.ts";
+import type { RunEvent } from "@appstrate/afps-runtime/types";
 
 const RUN_ID = "run_terminal_test";
+
+const STUB_BUNDLE = makeTestBundle(makeBundlePackage("@test/stub", "0.0.0", "agent", {}));
 
 /** Simulate one settled turn: append the message, then fire message_end. */
 function endTurn(session: ReturnType<typeof createFakeSession>, msg: unknown): void {
@@ -127,5 +139,321 @@ describe("SessionBridgeHandle.getTerminalError", () => {
     const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
     endTurn(session, { role: "assistant", stopReason: "error", content: [] });
     expect(handle.getTerminalError()?.message).toMatch(/ended in an error/);
+  });
+});
+
+/**
+ * The sticky sibling of the terminal verdict. `getTerminalError()` answers
+ * "how did the FINAL turn end" and deliberately forgets a failure the agent
+ * recovered from; `getLastUpstreamError()` answers "did anything upstream ever
+ * fail, and what did it say" and deliberately does not. The second question is
+ * the only one a run cut off by the wall-clock watchdog can still answer.
+ */
+describe("SessionBridgeHandle.getLastUpstreamError", () => {
+  it("returns undefined for a session with no turns", () => {
+    const handle = installSessionBridge(createFakeSession(), createInternalCapture(), RUN_ID);
+    expect(handle.getLastUpstreamError()).toBeUndefined();
+  });
+
+  it("returns undefined when every turn stopped cleanly", () => {
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: "done" }],
+    });
+    expect(handle.getLastUpstreamError()).toBeUndefined();
+  });
+
+  it("records the stop reason and message of an errored turn", () => {
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "503 Service Unavailable",
+      content: [],
+    });
+    expect(handle.getLastUpstreamError()).toEqual({
+      stopReason: "error",
+      message: "503 Service Unavailable",
+    });
+  });
+
+  it("SURVIVES a later clean turn (the case getTerminalError cannot serve)", () => {
+    // The whole reason the state exists: `lastAssistantStopReason` is
+    // overwritten every turn, so the clean turn below erases the cause there.
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "upstream 503",
+      content: [],
+    });
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "stop",
+      content: [{ type: "text", text: "recovered" }],
+    });
+    expect(handle.getTerminalError()).toBeUndefined();
+    expect(handle.getLastUpstreamError()?.message).toBe("upstream 503");
+  });
+
+  it("keeps the MOST RECENT failure when several turns errored", () => {
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "first",
+      content: [],
+    });
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "aborted",
+      errorMessage: "second",
+      content: [],
+    });
+    expect(handle.getLastUpstreamError()).toEqual({ stopReason: "aborted", message: "second" });
+  });
+
+  it("falls back to the generic message when the errored turn carried none", () => {
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    endTurn(session, { role: "assistant", stopReason: "error", content: [] });
+    expect(handle.getLastUpstreamError()?.message).toMatch(/ended in an error/);
+  });
+});
+
+/**
+ * Drive a scripted run whose session errors on the turns described by
+ * `turns`, then hangs until the runner's wall-clock watchdog aborts it —
+ * i.e. the exact production shape this feature exists for: a run whose budget
+ * is consumed upstream and which is cut off before it can settle a verdict.
+ */
+async function runUntilWatchdog(
+  turns: Array<Record<string, unknown>>,
+): Promise<ReturnType<typeof createCaptureSink>> {
+  const sink = createCaptureSink();
+  // `0.05`s → a 50ms watchdog (the field is seconds; the runner × 1000).
+  const runner = new ScriptedPiRunner(async (session: FakeSession, _ctx, signal) => {
+    for (const turn of turns) endTurn(session, turn);
+    await new Promise<void>((resolve) => {
+      if (signal?.aborted) return resolve();
+      signal?.addEventListener("abort", () => resolve(), { once: true });
+    });
+    throw signal?.reason ?? new Error("aborted");
+  });
+  await runner.run({
+    bundle: STUB_BUNDLE,
+    context: makeContext({ timeoutSeconds: 0.05 }),
+    eventSink: sink,
+  });
+  return sink;
+}
+
+/** The LAST `appstrate.error` — the bridge emits its own for each failed turn. */
+function lastErrorEvent(events: RunEvent[]): (RunEvent & { data?: unknown }) | undefined {
+  return events.filter((e) => e.type === "appstrate.error").at(-1);
+}
+
+describe("PiRunner.run — timeout watchdog carries the upstream cause", () => {
+  it("attaches the provider failure as error.context.upstream", async () => {
+    const sink = await runUntilWatchdog([
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "503 Service Unavailable from provider",
+        content: [],
+      },
+    ]);
+
+    expect(sink.finalized?.status).toBe("timeout");
+    // The stable branch key sinks/webhooks match on must NOT have moved.
+    expect(sink.finalized?.error?.code).toBe("timeout");
+    expect(sink.finalized?.error?.message).toMatch(/timed out after/i);
+    expect(sink.finalized?.error?.context).toEqual({
+      upstream: { stop_reason: "error", message: "503 Service Unavailable from provider" },
+    });
+    // …and it reaches the platform: the finalize body's RunError is persisted
+    // by `message` alone, so the live `appstrate.error` event is the path that
+    // lands the structured cause in `run_logs.data`.
+    expect(lastErrorEvent(sink.events)?.data).toEqual({
+      upstream: { stop_reason: "error", message: "503 Service Unavailable from provider" },
+    });
+  });
+
+  it("NEGATIVE CONTROL: no upstream error ever → no `context` key at all", async () => {
+    const sink = await runUntilWatchdog([
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "working" }] },
+    ]);
+
+    expect(sink.finalized?.error?.code).toBe("timeout");
+    // An empty `{}` would read as "we looked upstream and it was fine", which
+    // is not what "we never saw a failed turn" means — the key must be absent.
+    expect(Object.keys(sink.finalized!.error!)).not.toContain("context");
+    expect(lastErrorEvent(sink.events)?.data).toBeUndefined();
+  });
+
+  it("still reports the cause when a CLEAN turn followed the errored one", async () => {
+    // `lastAssistantStopReason` is blanked by the clean turn; the sticky
+    // upstream state is what keeps the 503 attached to the timeout.
+    const sink = await runUntilWatchdog([
+      { role: "assistant", stopReason: "error", errorMessage: "upstream 503", content: [] },
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "retrying" }] },
+    ]);
+
+    expect(sink.finalized?.error?.code).toBe("timeout");
+    expect(sink.finalized?.error?.context).toEqual({
+      upstream: { stop_reason: "error", message: "upstream 503" },
+    });
+  });
+
+  it("bounds the provider message — a huge blob never reaches a log row whole", async () => {
+    const sink = await runUntilWatchdog([
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "x".repeat(5000),
+        content: [],
+      },
+    ]);
+
+    const upstream = (sink.finalized?.error?.context as { upstream: { message: string } }).upstream;
+    expect(upstream.message).toHaveLength(2000);
+  });
+});
+
+describe("PiRunner.run — timeout watchdog names the cause for a HUMAN", () => {
+  // `context` is durable but nothing on screen projects an unknown `data` key,
+  // so the cause has to reach `RunError.message` too — the only field that
+  // lands in both the `runs.error` column and the log-viewer row.
+  it("appends the provider cause after the untouched timeout sentence", async () => {
+    const sink = await runUntilWatchdog([
+      {
+        role: "assistant",
+        stopReason: "error",
+        errorMessage: "503 Service Unavailable",
+        content: [],
+      },
+    ]);
+
+    expect(sink.finalized?.error?.message).toBe(
+      "Run timed out after 0.05s — the model provider returned an error during the run: 503 Service Unavailable",
+    );
+    // The structured channel is untouched by the human-channel work.
+    expect(sink.finalized?.error?.context).toEqual({
+      upstream: { stop_reason: "error", message: "503 Service Unavailable" },
+    });
+  });
+
+  it("REGRESSION GUARD: no cause ⇒ the message is byte-identical to before", async () => {
+    const sink = await runUntilWatchdog([
+      { role: "assistant", stopReason: "stop", content: [{ type: "text", text: "working" }] },
+    ]);
+
+    expect(sink.finalized?.error?.message).toBe("Run timed out after 0.05s");
+  });
+
+  it("collapses a multi-line provider body to ONE bounded line", async () => {
+    // The log viewer renders a row's message with `whitespace-pre-wrap`, so an
+    // embedded newline would turn one row into many. Indentation is collapsed
+    // too, which is what makes the tight cap enough to carry the meaning.
+    const body =
+      '{\n  "error": {\n    "type": "overloaded_error",\n    "message": "Overloaded"\n  }\n}';
+    const sink = await runUntilWatchdog([
+      { role: "assistant", stopReason: "error", errorMessage: body, content: [] },
+    ]);
+
+    const message = sink.finalized!.error!.message;
+    expect(message).not.toContain("\n");
+    expect(message).toBe(
+      'Run timed out after 0.05s — the model provider returned an error during the run: { "error": { "type": "overloaded_error", "message": "Overloaded" } }',
+    );
+    // The archival copy keeps the body verbatim, newlines and all.
+    const upstream = (sink.finalized?.error?.context as { upstream: { message: string } }).upstream;
+    expect(upstream.message).toBe(body);
+  });
+
+  it("bounds the human copy far tighter than the archival copy", async () => {
+    const sink = await runUntilWatchdog([
+      { role: "assistant", stopReason: "error", errorMessage: "y".repeat(5000), content: [] },
+    ]);
+
+    // Human channel: 200 chars — a tenth of the archival budget. Asserted on
+    // the provider run itself rather than the whole string, so the prose of
+    // the lead-in can be reworded without a magic number to re-derive.
+    const message = sink.finalized!.error!.message;
+    expect(message.startsWith("Run timed out after 0.05s — ")).toBe(true);
+    expect(message.match(/y+/)?.[0]).toHaveLength(200);
+    expect(message.endsWith("y".repeat(200))).toBe(true);
+    // Archival channel: still the full 2000.
+    const upstream = (sink.finalized?.error?.context as { upstream: { message: string } }).upstream;
+    expect(upstream.message).toHaveLength(2000);
+  });
+});
+
+describe("SessionBridgeHandle.getLastUpstreamError — benign aborts", () => {
+  /** Complete a terminal tool, which flips the bridge's early-stop flag. */
+  function completeTerminalTool(session: FakeSession): void {
+    session.emit({ type: "tool_execution_end", toolName: "output", toolCallId: "c1" });
+  }
+
+  it("does NOT latch the runner's own early-stop abort", () => {
+    // After a successful `output` the runner aborts the SDK loop itself. That
+    // trailing `aborted` turn is a success artefact — reporting it as an
+    // upstream failure would blame a provider that never failed.
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID, {
+      terminalTools: ["output"],
+    });
+    completeTerminalTool(session);
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "aborted",
+      errorMessage: "The operation was aborted",
+      content: [],
+    });
+    expect(handle.getTerminalError()).toBeUndefined();
+    expect(handle.getLastUpstreamError()).toBeUndefined();
+  });
+
+  it("a benign abort does not ERASE a real failure latched earlier", () => {
+    // Why the suppression is applied at latch time, not read time: the 503 is
+    // the cause a watchdog firing later must still be able to report.
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID, {
+      terminalTools: ["output"],
+    });
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "upstream 503",
+      content: [],
+    });
+    completeTerminalTool(session);
+    endTurn(session, { role: "assistant", stopReason: "aborted", content: [] });
+    expect(handle.getLastUpstreamError()?.message).toBe("upstream 503");
+  });
+
+  it("STILL latches a provider-side abort when no terminal tool ran", () => {
+    // The guard is gated on `terminalToolCompleted` — an abort with no
+    // terminal tool behind it is a genuine upstream failure, not our own stop.
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID, {
+      terminalTools: ["output"],
+    });
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "aborted",
+      errorMessage: "Request was aborted",
+      content: [],
+    });
+    expect(handle.getLastUpstreamError()).toEqual({
+      stopReason: "aborted",
+      message: "Request was aborted",
+    });
   });
 });

--- a/packages/runner-pi/test/terminal-error.test.ts
+++ b/packages/runner-pi/test/terminal-error.test.ts
@@ -65,6 +65,30 @@ describe("SessionBridgeHandle.getTerminalError", () => {
     const err = handle.getTerminalError();
     expect(err?.code).toBe("adapter_error");
     expect(err?.message).toBe("Codex error: server_error");
+    // The classification rides alongside the raw text, never instead of it:
+    // the run surface keeps the debug sentence AND now says what class of
+    // failure it was, using the same rules the chat surface classifies with.
+    // "Codex error: server_error" names no status and no actionable cause, so
+    // the class is `unknown` — which stays retryable: a fresh attempt is the
+    // only way to learn anything more about it.
+    expect(err?.context).toEqual({ error_category: "unknown", error_retryable: true });
+  });
+
+  it("classifies a dead credential as terminal, not as a transient outage", () => {
+    const session = createFakeSession();
+    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    endTurn(session, {
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "401 Incorrect API key provided: sk-***",
+      content: [],
+    });
+    const err = handle.getTerminalError();
+    expect(err?.message).toBe("401 Incorrect API key provided: sk-***");
+    expect(err?.context).toEqual({
+      error_category: "credential_unavailable",
+      error_retryable: false,
+    });
   });
 
   it("returns a RunError on stopReason 'aborted' (provider abort, not user cancel)", () => {

--- a/packages/runner-pi/test/terminal-error.test.ts
+++ b/packages/runner-pi/test/terminal-error.test.ts
@@ -36,6 +36,11 @@ function endTurn(session: ReturnType<typeof createFakeSession>, msg: unknown): v
   session.emit({ type: "message_end" });
 }
 
+/** `data` of the emitted `appstrate.error` event — where the classification lands. */
+function errorEventData(sink: { events: RunEvent[] }): unknown {
+  return sink.events.find((e) => e.type === "appstrate.error")?.data;
+}
+
 describe("SessionBridgeHandle.getTerminalError", () => {
   it("returns undefined for a session with no turns", () => {
     const handle = installSessionBridge(createFakeSession(), createInternalCapture(), RUN_ID);
@@ -55,7 +60,8 @@ describe("SessionBridgeHandle.getTerminalError", () => {
 
   it("returns a RunError when the final assistant turn ended in error", () => {
     const session = createFakeSession();
-    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    const sink = createInternalCapture();
+    const handle = installSessionBridge(session, sink, RUN_ID);
     endTurn(session, {
       role: "assistant",
       stopReason: "error",
@@ -65,18 +71,19 @@ describe("SessionBridgeHandle.getTerminalError", () => {
     const err = handle.getTerminalError();
     expect(err?.code).toBe("adapter_error");
     expect(err?.message).toBe("Codex error: server_error");
-    // The classification rides alongside the raw text, never instead of it:
-    // the run surface keeps the debug sentence AND now says what class of
-    // failure it was, using the same rules the chat surface classifies with.
+    // The classification rides alongside the raw text, never instead of it —
+    // but on the `appstrate.error` event, the only path that reaches a reader
+    // (`run_logs.data`); the finalize body keeps the debug sentence alone.
     // "Codex error: server_error" names no status and no actionable cause, so
     // the class is `unknown` — which stays retryable: a fresh attempt is the
     // only way to learn anything more about it.
-    expect(err?.context).toEqual({ error_category: "unknown", error_retryable: true });
+    expect(errorEventData(sink)).toEqual({ error_category: "unknown", error_retryable: true });
   });
 
   it("classifies a dead credential as terminal, not as a transient outage", () => {
     const session = createFakeSession();
-    const handle = installSessionBridge(session, createInternalCapture(), RUN_ID);
+    const sink = createInternalCapture();
+    const handle = installSessionBridge(session, sink, RUN_ID);
     endTurn(session, {
       role: "assistant",
       stopReason: "error",
@@ -85,7 +92,7 @@ describe("SessionBridgeHandle.getTerminalError", () => {
     });
     const err = handle.getTerminalError();
     expect(err?.message).toBe("401 Incorrect API key provided: sk-***");
-    expect(err?.context).toEqual({
+    expect(errorEventData(sink)).toEqual({
       error_category: "credential_unavailable",
       error_retryable: false,
     });

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -16,6 +16,8 @@ import {
   llmUpstreamAbort,
   readPositiveIntEnv,
   readRequestBodyBounded,
+  withIdleBound,
+  STREAM_IDLE,
   type SidecarConfig,
   type LlmProxyOauthConfig,
 } from "./helpers.ts";
@@ -56,10 +58,12 @@ export interface AppDeps {
   fetchFn?: typeof fetch; // default: global fetch — injectable for tests
   isReady?: () => boolean; // default: () => true — controls /health
   /**
-   * Inter-chunk idle bound applied to proxied `/llm/*` streams. Defaults to
-   * {@link LLM_STREAM_IDLE_TIMEOUT_MS}; the only reason it is injectable is
-   * that the timeout path is otherwise untestable without a real two-minute
-   * wait. Not an operator knob — no env var reads it.
+   * Inter-chunk idle bound applied to proxied `/llm/*` streams (both the raw
+   * forward and the aliased `pi-messages` re-origination). Defaults to
+   * {@link LLM_STREAM_IDLE_TIMEOUT_MS}, which is where the operator override
+   * (`SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS`) is read; this injection point exists
+   * only because the timeout path is otherwise untestable without a real
+   * two-minute wait.
    */
   llmStreamIdleTimeoutMs?: number;
   /**
@@ -150,41 +154,6 @@ interface LlmStreamObservation {
   authMode?: "oauth" | "api_key";
 }
 
-/** Resolution marker for {@link withIdleBound} — a value, not a rejection,
- *  so the genuine upstream-error path keeps its own `catch`. */
-const IDLE = Symbol("llm-stream-idle");
-
-/**
- * Bound a PENDING `reader.read()` by an inter-chunk idle deadline.
- *
- * Takes the promise rather than the reader on purpose: the timer must be
- * created at the moment the read starts and cleared the moment it settles, so
- * it measures only the window in which the consumer has asked for a chunk and
- * the upstream has not produced one. That is the whole reason this is called
- * from inside `pull` rather than installed as a stream-level watchdog — see
- * the long comment at the `observed` stream below.
- *
- * Returns {@link IDLE} on expiry (never rejects for it); a genuine upstream
- * read rejection still propagates untouched.
- */
-async function withIdleBound<T>(read: Promise<T>, idleTimeoutMs: number): Promise<T | typeof IDLE> {
-  // If the timer wins the race, `read` is still pending; a later rejection
-  // would land as a process-level unhandled rejection with nobody left to
-  // catch it. Attach a no-op handler now — the value is already discarded.
-  read.catch(() => {});
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      read,
-      new Promise<typeof IDLE>((resolve) => {
-        timer = setTimeout(() => resolve(IDLE), idleTimeoutMs);
-      }),
-    ]);
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 async function passUpstream(
   upstream: Response,
   observe?: LlmStreamObservation,
@@ -253,20 +222,30 @@ async function passUpstream(
     async pull(controller) {
       try {
         const outcome = await withIdleBound(reader.read(), idleTimeoutMs);
-        if (outcome === IDLE) {
+        if (outcome === STREAM_IDLE) {
           // Four of the ten api shapes this platform maps ignore pi-ai's own
           // `timeoutMs` (google-generative-ai, google-vertex,
           // bedrock-converse-stream, pi-messages), so this proxy is the only
           // provider-agnostic place a stalled stream can be caught. Without it
           // the run just burns its wall-clock budget and dies with no error.
           //
-          // THE WORDING IS LOAD-BEARING: pi-ai classifies a failure as
-          // transient by regex over the error text
-          // (`RETRYABLE_PROVIDER_ERROR_PATTERN` in `dist/utils/retry.js`,
-          // which matches `timed? out` and `timeout`). "timed out" therefore
-          // makes the agent retry the turn; a message like "upstream went
-          // quiet" would be classified as a hard, unretryable provider error
-          // and surface to the user as a mystery. Do not reword.
+          // THIS MESSAGE IS FOR OUR LOG, not for the agent: `controller.error`
+          // on a response body does not cross the HTTP hop. Over a real socket
+          // the in-container client observes a TRUNCATED stream — `{done:true}`
+          // — and the Error is discarded here. (In-process, as the tests drive
+          // it through Hono's `app.request`, it does surface; that is the test
+          // harness, not production.)
+          //
+          // The agent still gets a RETRYABLE failure, from the truncation
+          // rather than from this text: pi-ai's adapters throw on a premature
+          // end — `openai-completions.js` "Stream ended without finish_reason"
+          // (whenever `compat.supportsFinishReason`, its default),
+          // `google-generative-ai.js` "Google stream ended without a finish
+          // reason", `anthropic-messages.js` "Anthropic stream ended before
+          // message_stop" — and those strings match
+          // `RETRYABLE_PROVIDER_ERROR_PATTERN` (`dist/utils/retry.js`:
+          // `ended without`, `stream ended before message_stop`). So the
+          // wording below is free to change; keep it operator-legible.
           const err = new Error(
             `LLM upstream stream timed out: no data received for ${idleTimeoutMs}ms`,
           );
@@ -661,6 +640,9 @@ export function createApp(deps: AppDeps): Hono {
               ? { modelMaxTokens: config.modelMaxTokens }
               : {}),
           },
+          ...(deps.llmStreamIdleTimeoutMs !== undefined
+            ? { llmStreamIdleTimeoutMs: deps.llmStreamIdleTimeoutMs }
+            : {}),
         },
         c.req.raw,
         buffered,

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -10,9 +10,10 @@ import { BlobStore } from "./blob-store.ts";
 import type { IntegrationBootReport } from "@appstrate/core/sidecar-types";
 import {
   DEFAULT_API_CALL_CONCURRENCY,
-  LLM_PROXY_TIMEOUT_MS,
+  LLM_STREAM_IDLE_TIMEOUT_MS,
   MAX_REQUEST_BODY_SIZE,
   filterHeaders,
+  llmUpstreamAbort,
   readPositiveIntEnv,
   readRequestBodyBounded,
   type SidecarConfig,
@@ -54,6 +55,13 @@ export interface AppDeps {
   cookieJar: Map<string, string[]>;
   fetchFn?: typeof fetch; // default: global fetch — injectable for tests
   isReady?: () => boolean; // default: () => true — controls /health
+  /**
+   * Inter-chunk idle bound applied to proxied `/llm/*` streams. Defaults to
+   * {@link LLM_STREAM_IDLE_TIMEOUT_MS}; the only reason it is injectable is
+   * that the timeout path is otherwise untestable without a real two-minute
+   * wait. Not an operator knob — no env var reads it.
+   */
+  llmStreamIdleTimeoutMs?: number;
   /**
    * OAuth token cache. Required when the sidecar serves OAuth-mode LLM
    * configs (`config.llm.authMode === "oauth"`). Production server.ts
@@ -142,7 +150,46 @@ interface LlmStreamObservation {
   authMode?: "oauth" | "api_key";
 }
 
-async function passUpstream(upstream: Response, observe?: LlmStreamObservation): Promise<Response> {
+/** Resolution marker for {@link withIdleBound} — a value, not a rejection,
+ *  so the genuine upstream-error path keeps its own `catch`. */
+const IDLE = Symbol("llm-stream-idle");
+
+/**
+ * Bound a PENDING `reader.read()` by an inter-chunk idle deadline.
+ *
+ * Takes the promise rather than the reader on purpose: the timer must be
+ * created at the moment the read starts and cleared the moment it settles, so
+ * it measures only the window in which the consumer has asked for a chunk and
+ * the upstream has not produced one. That is the whole reason this is called
+ * from inside `pull` rather than installed as a stream-level watchdog — see
+ * the long comment at the `observed` stream below.
+ *
+ * Returns {@link IDLE} on expiry (never rejects for it); a genuine upstream
+ * read rejection still propagates untouched.
+ */
+async function withIdleBound<T>(read: Promise<T>, idleTimeoutMs: number): Promise<T | typeof IDLE> {
+  // If the timer wins the race, `read` is still pending; a later rejection
+  // would land as a process-level unhandled rejection with nobody left to
+  // catch it. Attach a no-op handler now — the value is already discarded.
+  read.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      read,
+      new Promise<typeof IDLE>((resolve) => {
+        timer = setTimeout(() => resolve(IDLE), idleTimeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function passUpstream(
+  upstream: Response,
+  observe?: LlmStreamObservation,
+  idleTimeoutMs: number = LLM_STREAM_IDLE_TIMEOUT_MS,
+): Promise<Response> {
   const responseHeaders: Record<string, string> = {};
   // Shared upstream-response header allowlist (content-type, retry/backoff,
   // x-request-id) — same posture as the platform LLM gateway; everything else
@@ -190,10 +237,48 @@ async function passUpstream(upstream: Response, observe?: LlmStreamObservation):
   // upstream byte timing, but we intentionally match what the serve
   // layer sees so the metric stays comparable to the idle-timeout
   // threshold.
+  //
+  // READ THE PARAGRAPH ABOVE BEFORE TOUCHING THE IDLE TIMEOUT BELOW. Because
+  // this stream is `pull`-based, `maxIdleMs` is NOT upstream silence — it is
+  // consumer latency. Arming a timeout on that counter, or on any timer that
+  // keeps running while nobody is pulling, would kill a merely SLOW CONSUMER
+  // on a perfectly healthy upstream. The correct instrument is the one used
+  // in `withIdleBound`: race a timer against the PENDING `reader.read()`
+  // promise, inside `pull`. That promise is pending exactly while the upstream
+  // is silent AND the consumer is actually waiting for a chunk — the timer is
+  // created when the read starts and cleared the moment it settles, so no
+  // clock runs across a consumer-side pause. Do not "simplify" this into a
+  // single long-lived timer; that is the bug, not the cleanup.
   const observed = new ReadableStream<Uint8Array>({
     async pull(controller) {
       try {
-        const { value, done } = await reader.read();
+        const outcome = await withIdleBound(reader.read(), idleTimeoutMs);
+        if (outcome === IDLE) {
+          // Four of the ten api shapes this platform maps ignore pi-ai's own
+          // `timeoutMs` (google-generative-ai, google-vertex,
+          // bedrock-converse-stream, pi-messages), so this proxy is the only
+          // provider-agnostic place a stalled stream can be caught. Without it
+          // the run just burns its wall-clock budget and dies with no error.
+          //
+          // THE WORDING IS LOAD-BEARING: pi-ai classifies a failure as
+          // transient by regex over the error text
+          // (`RETRYABLE_PROVIDER_ERROR_PATTERN` in `dist/utils/retry.js`,
+          // which matches `timed? out` and `timeout`). "timed out" therefore
+          // makes the agent retry the turn; a message like "upstream went
+          // quiet" would be classified as a hard, unretryable provider error
+          // and surface to the user as a mystery. Do not reword.
+          const err = new Error(
+            `LLM upstream stream timed out: no data received for ${idleTimeoutMs}ms`,
+          );
+          logger.warn("llm.stream.idle_timeout", { ...summary(), idleTimeoutMs });
+          // Release the upstream socket before erroring the consumer branch;
+          // swallow the cancel rejection so teardown can't escape as an
+          // unhandled rejection on the sidecar process.
+          void reader.cancel(err).catch(() => {});
+          controller.error(err);
+          return;
+        }
+        const { value, done } = outcome;
         const now = Date.now();
         const gap = now - lastByteAt;
         if (gap > maxIdleMs) maxIdleMs = gap;
@@ -597,30 +682,45 @@ export function createApp(deps: AppDeps): Hono {
     }
 
     let upstream: Response;
+    // THREE deadlines now bound an LLM stream, and the split matters:
+    //   - `LLM_PROXY_TIMEOUT_MS` (30 min) — absolute cap on the whole
+    //     exchange, the right ceiling for a long agentic completion.
+    //   - `LLM_FIRST_RESPONSE_TIMEOUT_MS` (60 s) — TTFB. Disarmed the instant
+    //     the headers land (`abort.firstResponse()` in the `finally`), because
+    //     an abort signal handed to `fetch` tears down the BODY too.
+    //   - `LLM_STREAM_IDLE_TIMEOUT_MS` (120 s) — inter-chunk silence, enforced
+    //     in `passUpstream`, NOT here (a fetch-level signal cannot express
+    //     "silent for 2 min" without also capping the total).
+    // HISTORY, do not re-litigate: this block used to say there was
+    // "deliberately no inter-chunk timeout", because undici's hardcoded 300 s
+    // `bodyTimeout` once motivated a global `globalThis.fetch` → undici swap
+    // that was reverted in #366 (see issue #369). That reasoning stands —
+    // undici is still not the answer, the sidecar runs Bun's native `fetch`
+    // and we are not swapping it back. What changed is that "no body timeout"
+    // stopped being acceptable: pi-ai's per-adapter `timeoutMs` is ignored by
+    // four of the api shapes we map (google-generative-ai, google-vertex,
+    // bedrock-converse-stream, pi-messages), so a stalled stream had NO bound
+    // below 30 min and runs died on their wall-clock watchdog with no error.
+    // The idle bound lives in our own stream wrapper instead — provider
+    // agnostic, and no transport swap.
+    const abort = llmUpstreamAbort();
     try {
-      // `AbortSignal.timeout(LLM_PROXY_TIMEOUT_MS)` is the ONLY deadline on
-      // an LLM stream — an absolute 30 min cap, not an inactivity timer.
-      // There is deliberately no inter-chunk (body) timeout: undici's
-      // hardcoded 300 s `bodyTimeout` (which once motivated a global
-      // `globalThis.fetch` → undici swap, reverted in #366, see issue #369)
-      // does not exist here — the sidecar runs under Bun and `fetch` is
-      // Bun's native implementation, not undici. A long inter-chunk gap on a
-      // streamed completion therefore cannot trip a body timeout; it is only
-      // bounded by the 30 min absolute deadline. Inter-chunk silence is still
-      // observed (`maxIdleMs` in `llm.stream.observed`, #426) so any real
-      // stall surfaces in logs without re-introducing undici.
       upstream = await fetchFn(targetUrl, {
         method,
         headers: forwardedHeaders,
         body,
-        signal: AbortSignal.timeout(LLM_PROXY_TIMEOUT_MS),
+        signal: abort.signal,
         ...(body instanceof ReadableStream ? { duplex: "half" } : {}),
       });
     } catch (err) {
       return llmFetchErrorResponse(c, targetUrl, err);
+    } finally {
+      // Headers are in (or the call already failed) — the upstream has proven
+      // it is alive, so the TTFB timer must stop before it can abort the body.
+      abort.firstResponse();
     }
 
-    return passUpstream(upstream, { targetUrl, authMode: "api_key" });
+    return passUpstream(upstream, { targetUrl, authMode: "api_key" }, deps.llmStreamIdleTimeoutMs);
   });
 
   // OAuth: resolve the real subscription bearer and swap it onto the request,
@@ -687,13 +787,24 @@ export function createApp(deps: AppDeps): Hono {
       body = buffered.byteLength > 0 ? buffered : undefined;
     }
 
-    const doFetch = (headers: Headers): Promise<Response> =>
-      fetchFn(targetUrl, {
-        method,
-        headers,
-        body,
-        signal: AbortSignal.timeout(LLM_PROXY_TIMEOUT_MS),
-      } as RequestInit);
+    // Same deadline split as the api_key path above (absolute cap + TTFB
+    // bound disarmed on headers; inter-chunk silence handled by
+    // `passUpstream`). Armed PER ATTEMPT: the 401 replay below re-enters this
+    // closure and must get its own fresh TTFB window rather than inherit an
+    // already-half-spent one.
+    const doFetch = async (headers: Headers): Promise<Response> => {
+      const abort = llmUpstreamAbort();
+      try {
+        return await fetchFn(targetUrl, {
+          method,
+          headers,
+          body,
+          signal: abort.signal,
+        } as RequestInit);
+      } finally {
+        abort.firstResponse();
+      }
+    };
 
     let upstream: Response;
     try {
@@ -736,11 +847,15 @@ export function createApp(deps: AppDeps): Hono {
 
     // No model-alias swap on the oauth path — the response streams back
     // verbatim (zero-copy telemetry passthrough only).
-    return passUpstream(upstream, {
-      targetUrl,
-      credentialId: llmConfig.credentialId,
-      authMode: "oauth",
-    });
+    return passUpstream(
+      upstream,
+      {
+        targetUrl,
+        credentialId: llmConfig.credentialId,
+        authMode: "oauth",
+      },
+      deps.llmStreamIdleTimeoutMs,
+    );
   }
 
   // MCP exposure — the agent-facing surface for the first-party tools

--- a/runtime-pi/sidecar/helpers.ts
+++ b/runtime-pi/sidecar/helpers.ts
@@ -19,6 +19,10 @@ export type { HostResolver } from "@appstrate/core/ssrf";
 // Imported (not just re-exported) because `readPositiveByteEnv` below defaults
 // its `ceiling` parameter to it. See the re-export note further down.
 import { ABSOLUTE_BODY_CEILING } from "@appstrate/afps-runtime/resolvers";
+// Compiled default for the inter-chunk idle bound, shared with the platform LLM
+// gateway. Imported (not just re-exported) because the env override below falls
+// back to it.
+import { DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS } from "@appstrate/connect/proxy-primitives";
 
 // Accepts both simple IDs (gmail) and scoped IDs (@appstrate/gmail)
 export const INTEGRATION_ID_RE = /^(@[a-z0-9][a-z0-9-]*\/)?[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
@@ -69,32 +73,40 @@ const LLM_PROXY_TIMEOUT_MS = 1_800_000; // 30 minutes (patched from 300_000 — 
  * aborts the BODY too, so leaving this armed would kill every stream at 60 s.
  * {@link llmUpstreamAbort} owns that lifecycle — do not inline
  * `AbortSignal.timeout(LLM_FIRST_RESPONSE_TIMEOUT_MS)` at a call site.
+ *
+ * Operator-overridable via `SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS`. The 60 s
+ * reasoning above holds for hosted vendors; it does not hold for a self-hosted
+ * `baseUrl` provider (Ollama / llama.cpp / vLLM), where a cold model load
+ * routinely blocks the response HEADERS for minutes. Self-hosting is a
+ * first-class deployment of this platform, so the bound is a default and not a
+ * law.
  */
-const LLM_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
+const LLM_FIRST_RESPONSE_TIMEOUT_MS = readPositiveIntEnv(
+  "SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS",
+  60_000,
+  { unit: "ms" },
+);
 
 /**
  * Bound on INTER-CHUNK silence once an LLM stream is flowing: how long the
  * upstream may say nothing between two body chunks before the sidecar declares
- * the stream dead.
+ * the stream dead. Enforced in `passUpstream` (`./app.ts`) and, on the aliased
+ * `pi-messages` path, in `handlePiMessagesRequest` — never as a fetch-level
+ * signal, which cannot express "silent for 2 min" without also capping the
+ * total.
  *
- * This is the bound that actually fixes the reported bug. Pi's SDK passes a
- * `timeoutMs` down to its provider adapters, but four of the api shapes this
- * platform maps ignore it entirely (`google-generative-ai`, `google-vertex`,
- * `bedrock-converse-stream`, `pi-messages` — grep `timeoutMs` in
- * `@earendil-works/pi-ai/dist/api/*.js`, they honour only `options.signal`).
- * A stalled Gemini/Vertex/Bedrock stream was therefore bounded by nothing
- * tighter than the 30 min absolute cap, so a run with a 300 s budget died on
- * its wall-clock watchdog with no error to show the user. Our proxy is the
- * only provider-agnostic place that covers all four shapes.
- *
- * 120 s, i.e. deliberately looser than the first-response bound: once a
- * provider has started streaming, a long pause is a real (if rare) event —
- * extended-thinking blocks and large parallel tool-call payloads routinely
- * buy 15-45 s of silence, and a provider-side retry can stretch that. 120 s
- * is ~3× the worst honest gap while still leaving the shortest run budget
- * (300 s) room to report the failure and for the agent to retry once.
+ * The value and the reasoning behind it live with the shared default
+ * ({@link DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS} in
+ * `@appstrate/connect/proxy-primitives`), which the platform LLM gateway reads
+ * too. What is local here is the operator override:
+ * `SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS`, for the self-hosted `baseUrl` providers
+ * whose inter-chunk gaps a hosted-vendor default does not describe.
  */
-export const LLM_STREAM_IDLE_TIMEOUT_MS = 120_000;
+export const LLM_STREAM_IDLE_TIMEOUT_MS = readPositiveIntEnv(
+  "SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS",
+  DEFAULT_LLM_STREAM_IDLE_TIMEOUT_MS,
+  { unit: "ms" },
+);
 
 /**
  * Abort plumbing for one LLM upstream call: the absolute
@@ -112,10 +124,17 @@ export const LLM_STREAM_IDLE_TIMEOUT_MS = 120_000;
  * detached once the response is returned"); this is the hand-rolled twin for
  * the sidecar's raw `fetch` call sites.
  *
- * The abort reason is worded to match pi-ai's `RETRYABLE_PROVIDER_ERROR_PATTERN`
- * (`dist/utils/retry.js`, which matches `timed? out` / `timeout`) so the agent
- * classifies a dead upstream as a transient failure and retries, instead of
- * surfacing it as an unclassifiable hard error.
+ * The abort reason NEVER reaches the agent: `fetch` rejects with this
+ * DOMException, the `app.all("/llm/*")` handler's `catch` hands it to
+ * `llmFetchErrorResponse` (`./app.ts`), which reads only `err.code` and answers
+ * a generic `502 {"error":"LLM request failed…"}` — the message is dropped. On
+ * the aliased `pi-messages` path it is replaced by `syntheticAliasErrorMessage`
+ * for the same reason. It is worded for OUR logs.
+ *
+ * The retry still happens, by the status code: `502` is itself one of
+ * `RETRYABLE_PROVIDER_ERROR_PATTERN`'s literals
+ * (`@earendil-works/pi-ai/dist/utils/retry.js`), so pi-ai classifies the
+ * refusal as transient and the agent retries the turn.
  */
 export function llmUpstreamAbort(extra?: AbortSignal): {
   signal: AbortSignal;
@@ -336,6 +355,8 @@ export {
   filterHeaders,
   applyInjectedCredentialHeader,
   normalizeAuthSchemeTemplates,
+  withIdleBound,
+  STREAM_IDLE,
 } from "@appstrate/connect/proxy-primitives";
 
 // `matchesAuthorizedUri` (`(url, patterns[])` allowlist check, AFPS spec

--- a/runtime-pi/sidecar/helpers.ts
+++ b/runtime-pi/sidecar/helpers.ts
@@ -43,7 +43,7 @@ export const MAX_RESPONSE_SIZE = 256 * 1024; // 256 KB
 // lives in packages/afps-runtime.
 export const ABSOLUTE_MAX_RESPONSE_SIZE = 32 * 1024 * 1024; // 32 MB — covers PDFs/images/archives, aligned with MAX_MCP_ENVELOPE_SIZE × 2
 export const OUTBOUND_TIMEOUT_MS = 30_000;
-export const LLM_PROXY_TIMEOUT_MS = 1_800_000; // 30 minutes (patched from 300_000 — was killing legitimate long-running agentic runs at exactly 5 min)
+const LLM_PROXY_TIMEOUT_MS = 1_800_000; // 30 minutes (patched from 300_000 — was killing legitimate long-running agentic runs at exactly 5 min)
 
 /**
  * Bound on how long an LLM upstream may take to produce its RESPONSE HEADERS
@@ -70,7 +70,7 @@ export const LLM_PROXY_TIMEOUT_MS = 1_800_000; // 30 minutes (patched from 300_0
  * {@link llmUpstreamAbort} owns that lifecycle — do not inline
  * `AbortSignal.timeout(LLM_FIRST_RESPONSE_TIMEOUT_MS)` at a call site.
  */
-export const LLM_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
+const LLM_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
 
 /**
  * Bound on INTER-CHUNK silence once an LLM stream is flowing: how long the

--- a/runtime-pi/sidecar/helpers.ts
+++ b/runtime-pi/sidecar/helpers.ts
@@ -46,6 +46,98 @@ export const OUTBOUND_TIMEOUT_MS = 30_000;
 export const LLM_PROXY_TIMEOUT_MS = 1_800_000; // 30 minutes (patched from 300_000 — was killing legitimate long-running agentic runs at exactly 5 min)
 
 /**
+ * Bound on how long an LLM upstream may take to produce its RESPONSE HEADERS
+ * (TTFB). Distinct from {@link LLM_PROXY_TIMEOUT_MS}, which is the ABSOLUTE
+ * cap on the whole exchange: 30 min is the right ceiling for a legitimately
+ * long agentic completion, and exactly the wrong instrument for "the upstream
+ * never answered at all".
+ *
+ * Why this bound is safe at 60 s here even though a non-streaming completion
+ * can legitimately hold its headers for minutes: the ONLY clients of the
+ * sidecar's `/llm/*` surface are pi-ai's provider adapters running inside the
+ * container, and every one of them issues `stream: true` (grep `stream: true`
+ * in `@earendil-works/pi-ai/dist/api/*.js`). A streaming provider emits its
+ * first SSE frame within seconds; 60 s is roughly 10× the worst honest TTFB
+ * we have observed and still an order of magnitude under the shortest run
+ * budget (300 s), so a dead upstream surfaces as an ERROR the agent can retry
+ * instead of a silent wall-clock kill. The platform-side gateway
+ * (`apps/api/src/services/llm-proxy`) serves non-streaming callers too and
+ * therefore keeps a separate, far more generous bound for those — see
+ * `LLM_NON_STREAMING_TIMEOUT_MS` there.
+ *
+ * MUST be disarmed once the headers land: an `AbortSignal` handed to `fetch`
+ * aborts the BODY too, so leaving this armed would kill every stream at 60 s.
+ * {@link llmUpstreamAbort} owns that lifecycle — do not inline
+ * `AbortSignal.timeout(LLM_FIRST_RESPONSE_TIMEOUT_MS)` at a call site.
+ */
+export const LLM_FIRST_RESPONSE_TIMEOUT_MS = 60_000;
+
+/**
+ * Bound on INTER-CHUNK silence once an LLM stream is flowing: how long the
+ * upstream may say nothing between two body chunks before the sidecar declares
+ * the stream dead.
+ *
+ * This is the bound that actually fixes the reported bug. Pi's SDK passes a
+ * `timeoutMs` down to its provider adapters, but four of the api shapes this
+ * platform maps ignore it entirely (`google-generative-ai`, `google-vertex`,
+ * `bedrock-converse-stream`, `pi-messages` — grep `timeoutMs` in
+ * `@earendil-works/pi-ai/dist/api/*.js`, they honour only `options.signal`).
+ * A stalled Gemini/Vertex/Bedrock stream was therefore bounded by nothing
+ * tighter than the 30 min absolute cap, so a run with a 300 s budget died on
+ * its wall-clock watchdog with no error to show the user. Our proxy is the
+ * only provider-agnostic place that covers all four shapes.
+ *
+ * 120 s, i.e. deliberately looser than the first-response bound: once a
+ * provider has started streaming, a long pause is a real (if rare) event —
+ * extended-thinking blocks and large parallel tool-call payloads routinely
+ * buy 15-45 s of silence, and a provider-side retry can stretch that. 120 s
+ * is ~3× the worst honest gap while still leaving the shortest run budget
+ * (300 s) room to report the failure and for the agent to retry once.
+ */
+export const LLM_STREAM_IDLE_TIMEOUT_MS = 120_000;
+
+/**
+ * Abort plumbing for one LLM upstream call: the absolute
+ * {@link LLM_PROXY_TIMEOUT_MS} cap, the {@link LLM_FIRST_RESPONSE_TIMEOUT_MS}
+ * TTFB bound, and optionally the caller's own signal, combined with
+ * `AbortSignal.any` (the idiom already used in `pi-messages-backend.ts`).
+ *
+ * The returned `firstResponse()` MUST be called — from a `finally` — as soon
+ * as the upstream has proven it is alive (headers received, or the first
+ * stream event on the pi-messages path). An abort signal handed to `fetch`
+ * tears down the response BODY as well, so a TTFB timer left armed would kill
+ * every healthy stream at the 60 s mark. `@appstrate/afps-shared`'s
+ * `guardedFetch` solves the same problem the same way (its `timeoutMs`
+ * "covers the redirect chain up to the final response's HEADERS … the timer is
+ * detached once the response is returned"); this is the hand-rolled twin for
+ * the sidecar's raw `fetch` call sites.
+ *
+ * The abort reason is worded to match pi-ai's `RETRYABLE_PROVIDER_ERROR_PATTERN`
+ * (`dist/utils/retry.js`, which matches `timed? out` / `timeout`) so the agent
+ * classifies a dead upstream as a transient failure and retries, instead of
+ * surfacing it as an unclassifiable hard error.
+ */
+export function llmUpstreamAbort(extra?: AbortSignal): {
+  signal: AbortSignal;
+  firstResponse: () => void;
+} {
+  const firstResponse = new AbortController();
+  const timer = setTimeout(
+    () =>
+      firstResponse.abort(
+        new DOMException(
+          `LLM upstream timed out after ${LLM_FIRST_RESPONSE_TIMEOUT_MS}ms waiting for a response`,
+          "TimeoutError",
+        ),
+      ),
+    LLM_FIRST_RESPONSE_TIMEOUT_MS,
+  );
+  const signals: AbortSignal[] = [AbortSignal.timeout(LLM_PROXY_TIMEOUT_MS), firstResponse.signal];
+  if (extra) signals.push(extra);
+  return { signal: AbortSignal.any(signals), firstResponse: () => clearTimeout(timer) };
+}
+
+/**
  * Default cap on simultaneous `api_call` MCP invocations per run.
  * Three matches the typical browsing concurrency a single LLM turn can
  * usefully exploit while leaving headroom under most providers' per-IP

--- a/runtime-pi/sidecar/pi-messages-backend.ts
+++ b/runtime-pi/sidecar/pi-messages-backend.ts
@@ -25,7 +25,12 @@
  */
 
 import type { LlmProxyApiKeyConfig, ModelSwap, SidecarConfig } from "./helpers.ts";
-import { llmUpstreamAbort } from "./helpers.ts";
+import {
+  LLM_STREAM_IDLE_TIMEOUT_MS,
+  llmUpstreamAbort,
+  withIdleBound,
+  STREAM_IDLE,
+} from "./helpers.ts";
 import { anthropicThinkingBudgets } from "@appstrate/core/model-generation";
 import { PI_SDK_VERSION, PI_SDK_VERSION_HEADER } from "@appstrate/runner-pi/provider-map";
 import { PLATFORM_MODEL_COMPAT, ZERO_MODEL_COST } from "@appstrate/runner-pi/model-compat";
@@ -136,6 +141,13 @@ export interface PiMessagesBackendDeps {
   limits: Pick<SidecarConfig, "modelContextWindow" | "modelMaxTokens">;
   /** Defaults to {@link streamBacking}. */
   streamBackingFn?: BackingStreamFn;
+  /**
+   * Inter-chunk idle bound on the re-originated stream. Defaults to
+   * {@link LLM_STREAM_IDLE_TIMEOUT_MS} (where the operator override is read);
+   * injected by `app.ts` from `AppDeps.llmStreamIdleTimeoutMs` so tests need
+   * not wait two real minutes.
+   */
+  llmStreamIdleTimeoutMs?: number;
 }
 
 /**
@@ -438,19 +450,30 @@ export function handlePiMessagesRequest(
   const stream = deps.streamBackingFn ?? streamBacking;
 
   // The same deadlines the non-aliased `/llm/*` forward applies — the 30 min
-  // absolute cap plus the 60 s first-response bound — combined with the
-  // client's disconnect; whichever fires first unwinds pi-ai's fetch.
+  // absolute cap, the 60 s first-response bound and the inter-chunk idle bound
+  // — combined with the client's disconnect; whichever fires first unwinds
+  // pi-ai's fetch.
   //
   // `pi-messages` is one of the four api shapes that IGNORE pi-ai's own
-  // `timeoutMs` (grep `timeoutMs` in `@earendil-works/pi-ai/dist/api/`), so on
-  // this path `options.signal` is the only deadline that exists at all.
+  // `timeoutMs` (grep `timeoutMs` in `@earendil-works/pi-ai/dist/api/`), and
+  // the BACKING re-originated here can be another one of them, so on this path
+  // `options.signal` is the only deadline that exists at all.
   //
   // We never see HTTP headers here (pi-ai owns the fetch), so the first event
   // yielded by the generator is the equivalent liveness proof, and that is
   // where `firstResponse()` disarms the TTFB timer — before it can abort a
   // healthy long stream. The `finally` is the belt: a throw before the first
   // event must not leave a 60 s timer armed either.
-  const abort = llmUpstreamAbort(request.signal);
+  //
+  // `unwind` is how this path RELEASES the upstream. The loop below detects a
+  // stall (a pending `next()` is the same shape of pending promise as a pending
+  // `read()`), but detection alone leaves pi-ai's fetch in flight until the
+  // 30 min cap; aborting is what frees the socket. Fired on every exit, not
+  // just the idle one — on a normal `done` the fetch has already finished, so
+  // it is a no-op there.
+  const unwind = new AbortController();
+  const idleTimeoutMs = deps.llmStreamIdleTimeoutMs ?? LLM_STREAM_IDLE_TIMEOUT_MS;
+  const abort = llmUpstreamAbort(AbortSignal.any([request.signal, unwind.signal]));
   const upstream = stream(
     model,
     body.context,
@@ -461,13 +484,36 @@ export function handlePiMessagesRequest(
   const sse = new ReadableStream<Uint8Array>({
     async start(controller) {
       let terminal: PiMessagesEvent | undefined;
+      // Manual iteration, not `for await`: the idle bound has to be armed
+      // against the PENDING `next()` and cleared the moment it settles, which
+      // `for await` gives no seam for. Same instrument as `passUpstream`'s
+      // `reader.read()` — and same reason it cannot be a long-lived timer: it
+      // must measure only the window where we are waiting and the upstream is
+      // silent.
+      const iterator = upstream[Symbol.asyncIterator]();
       try {
-        for await (const event of upstream) {
+        for (;;) {
+          const outcome = await withIdleBound(iterator.next(), idleTimeoutMs);
+          if (outcome === STREAM_IDLE) {
+            // Server-side only, so it may name the backing.
+            logger.warn("pi-messages backend: upstream went silent mid-stream", {
+              idleTimeoutMs,
+              real: swap.real,
+            });
+            terminal = {
+              type: "error",
+              reason: "error",
+              usage: EMPTY_USAGE,
+              errorMessage: syntheticAliasErrorMessage(swap),
+            };
+            break;
+          }
+          if (outcome.done) break;
           // Liveness proof — see `llmUpstreamAbort` above. `clearTimeout` is
           // idempotent, so calling it per event is cheaper than tracking a
           // "first" flag.
           abort.firstResponse();
-          const projected = projectAssistantEvent(event);
+          const projected = projectAssistantEvent(outcome.value);
           if (!projected) continue;
           if (projected.type === "error") {
             // Attached here so the projection never reads the alias descriptor.
@@ -489,6 +535,11 @@ export function handlePiMessagesRequest(
         });
       } finally {
         abort.firstResponse();
+        // Release the upstream: the abort unwinds pi-ai's in-flight fetch,
+        // `return()` finishes the generator that `for await` would have closed
+        // for us. Both are no-ops once the stream has ended on its own.
+        unwind.abort(new Error("pi-messages backend: releasing the upstream stream"));
+        void Promise.resolve(iterator.return?.()).catch(() => {});
       }
       if (!terminal) {
         // The client MUST see a terminal: `pi-messages` reconstructs the

--- a/runtime-pi/sidecar/pi-messages-backend.ts
+++ b/runtime-pi/sidecar/pi-messages-backend.ts
@@ -25,7 +25,7 @@
  */
 
 import type { LlmProxyApiKeyConfig, ModelSwap, SidecarConfig } from "./helpers.ts";
-import { LLM_PROXY_TIMEOUT_MS } from "./helpers.ts";
+import { llmUpstreamAbort } from "./helpers.ts";
 import { anthropicThinkingBudgets } from "@appstrate/core/model-generation";
 import { PI_SDK_VERSION, PI_SDK_VERSION_HEADER } from "@appstrate/runner-pi/provider-map";
 import { PLATFORM_MODEL_COMPAT, ZERO_MODEL_COST } from "@appstrate/runner-pi/model-compat";
@@ -437,13 +437,24 @@ export function handlePiMessagesRequest(
   const model = buildBackingModel(deps);
   const stream = deps.streamBackingFn ?? streamBacking;
 
-  // The same absolute deadline the non-aliased `/llm/*` forward applies, plus
-  // the client's disconnect — whichever fires first unwinds pi-ai's fetch.
-  const signal = AbortSignal.any([AbortSignal.timeout(LLM_PROXY_TIMEOUT_MS), request.signal]);
+  // The same deadlines the non-aliased `/llm/*` forward applies — the 30 min
+  // absolute cap plus the 60 s first-response bound — combined with the
+  // client's disconnect; whichever fires first unwinds pi-ai's fetch.
+  //
+  // `pi-messages` is one of the four api shapes that IGNORE pi-ai's own
+  // `timeoutMs` (grep `timeoutMs` in `@earendil-works/pi-ai/dist/api/`), so on
+  // this path `options.signal` is the only deadline that exists at all.
+  //
+  // We never see HTTP headers here (pi-ai owns the fetch), so the first event
+  // yielded by the generator is the equivalent liveness proof, and that is
+  // where `firstResponse()` disarms the TTFB timer — before it can abort a
+  // healthy long stream. The `finally` is the belt: a throw before the first
+  // event must not leave a 60 s timer armed either.
+  const abort = llmUpstreamAbort(request.signal);
   const upstream = stream(
     model,
     body.context,
-    projectRequestOptions(body, swap, deps.llm.apiKey, signal),
+    projectRequestOptions(body, swap, deps.llm.apiKey, abort.signal),
   );
 
   const encoder = new TextEncoder();
@@ -452,6 +463,10 @@ export function handlePiMessagesRequest(
       let terminal: PiMessagesEvent | undefined;
       try {
         for await (const event of upstream) {
+          // Liveness proof — see `llmUpstreamAbort` above. `clearTimeout` is
+          // idempotent, so calling it per event is cheaper than tracking a
+          // "first" flag.
+          abort.firstResponse();
           const projected = projectAssistantEvent(event);
           if (!projected) continue;
           if (projected.type === "error") {
@@ -472,6 +487,8 @@ export function handlePiMessagesRequest(
         logger.warn("pi-messages backend: upstream stream threw", {
           error: err instanceof Error ? err.message : String(err),
         });
+      } finally {
+        abort.firstResponse();
       }
       if (!terminal) {
         // The client MUST see a terminal: `pi-messages` reconstructs the

--- a/runtime-pi/sidecar/test/app.test.ts
+++ b/runtime-pi/sidecar/test/app.test.ts
@@ -486,6 +486,11 @@ describe("ALL /llm/* — telemetry", () => {
       const app = createApp(deps);
       const res = await app.request("/llm/v1/messages", { method: "POST" });
 
+      // IN-PROCESS ONLY. Hono's `app.request` hands the same stream object
+      // back, so `controller.error` surfaces here. Over a real socket it does
+      // not: the agent observes a TRUNCATED stream and never sees this text —
+      // which is what pi-ai classifies as retryable. See the branch in
+      // `app.ts`. What this pins is that the stall ENDS the stream.
       await expect(res.text()).rejects.toThrow(/timed out/i);
 
       const idle = warnSpy.mock.calls.find(([msg]) => msg === "llm.stream.idle_timeout");

--- a/runtime-pi/sidecar/test/app.test.ts
+++ b/runtime-pi/sidecar/test/app.test.ts
@@ -444,4 +444,126 @@ describe("ALL /llm/* — telemetry", () => {
       warnSpy.mockRestore();
     }
   });
+
+  // --- inter-chunk idle bound ---
+  //
+  // `passUpstream` bounds how long the UPSTREAM may stay silent between two
+  // chunks (`LLM_STREAM_IDLE_TIMEOUT_MS`, 120 s in production; injected here as
+  // a few ms via `deps.llmStreamIdleTimeoutMs`). Four of the ten api shapes
+  // this platform maps ignore pi-ai's own `timeoutMs`, so a stalled
+  // Gemini/Vertex/Bedrock stream had no bound below the 30 min absolute cap and
+  // runs died on their wall-clock watchdog with nothing to show the user.
+  //
+  // The subtlety these tests pin: the wrapper is `pull`-based, so a timeout
+  // must be armed against the PENDING `reader.read()` and cleared when it
+  // settles — never on `maxIdleMs` (which measures CONSUMER pull gaps) and
+  // never on a timer that keeps running between pulls. The slow-consumer case
+  // below is the regression control for exactly that mistake.
+
+  it("errors the stream and logs llm.stream.idle_timeout when the upstream goes silent mid-pull", async () => {
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      // Upstream that hands over one chunk and then never speaks again — the
+      // consumer IS pulling, so the read stays pending and the idle bound is
+      // the only thing that can end it.
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("first-chunk"));
+        },
+      });
+      const fetchFn = mock(
+        async () =>
+          new Response(stream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+      );
+      const deps = makeDeps({
+        fetchFn: fetchFn as unknown as typeof fetch,
+        llmStreamIdleTimeoutMs: 25,
+      });
+      deps.config.llm = LLM_CONFIG;
+      const app = createApp(deps);
+      const res = await app.request("/llm/v1/messages", { method: "POST" });
+
+      await expect(res.text()).rejects.toThrow(/timed out/i);
+
+      const idle = warnSpy.mock.calls.find(([msg]) => msg === "llm.stream.idle_timeout");
+      expect(idle).toBeDefined();
+      const payload = idle?.[1] as Record<string, unknown> | undefined;
+      expect(payload).toMatchObject({ status: 200, authMode: "api_key", idleTimeoutMs: 25 });
+      // Telemetry still describes what DID arrive before the stall.
+      expect(payload?.chunks).toBe(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("does NOT trip on a slow consumer reading a healthy upstream", async () => {
+    // REGRESSION CONTROL. This is the failure an idle timeout naively hung off
+    // `maxIdleMs` — or off a timer that survives between pulls — would ship:
+    // the upstream answers every pull immediately, but the CONSUMER dawdles far
+    // longer than the idle bound between reads. That must never be a timeout.
+    const infoSpy = spyOn(logger, "info").mockImplementation(() => {});
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      const enc = new TextEncoder();
+      const payloads = ["a", "b", "c", "d"];
+      let next = 0;
+      // Demand-driven upstream: produces only when pulled, and instantly.
+      const stream = new ReadableStream({
+        pull(controller) {
+          if (next >= payloads.length) {
+            controller.close();
+            return;
+          }
+          controller.enqueue(enc.encode(payloads[next]!));
+          next += 1;
+        },
+      });
+      const fetchFn = mock(
+        async () =>
+          new Response(stream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+      );
+      const idleTimeoutMs = 15;
+      const deps = makeDeps({
+        fetchFn: fetchFn as unknown as typeof fetch,
+        llmStreamIdleTimeoutMs: idleTimeoutMs,
+      });
+      deps.config.llm = LLM_CONFIG;
+      const app = createApp(deps);
+      const res = await app.request("/llm/v1/messages", { method: "POST" });
+
+      // Consumer gaps an order of magnitude past the idle bound.
+      const consumerGapMs = idleTimeoutMs * 5;
+      const reader = res.body!.getReader();
+      const seen: string[] = [];
+      const dec = new TextDecoder();
+      for (;;) {
+        await new Promise((r) => setTimeout(r, consumerGapMs));
+        const { value, done } = await reader.read();
+        if (done) break;
+        seen.push(dec.decode(value));
+      }
+
+      expect(seen.join("")).toBe(payloads.join(""));
+      expect(warnSpy.mock.calls.find(([msg]) => msg === "llm.stream.idle_timeout")).toBeUndefined();
+      expect(warnSpy.mock.calls.find(([msg]) => msg === "llm.stream.error")).toBeUndefined();
+
+      // Proof the control tests the right thing: `maxIdleMs` is the
+      // CONSUMER-pull-gap metric, and it really did exceed the idle bound. Any
+      // implementation that timed out on that counter would have failed above.
+      const observed = infoSpy.mock.calls.find(([msg]) => msg === "llm.stream.observed");
+      expect(observed).toBeDefined();
+      const payload = observed?.[1] as Record<string, unknown> | undefined;
+      expect(payload?.chunks).toBe(payloads.length);
+      expect(payload?.maxIdleMs as number).toBeGreaterThan(idleTimeoutMs);
+    } finally {
+      warnSpy.mockRestore();
+      infoSpy.mockRestore();
+    }
+  });
 });

--- a/runtime-pi/sidecar/test/helpers.test.ts
+++ b/runtime-pi/sidecar/test/helpers.test.ts
@@ -639,3 +639,61 @@ describe("concatAndRelease", () => {
     expect(concatAndRelease([], 0).byteLength).toBe(0);
   });
 });
+
+/**
+ * The two LLM upstream deadlines are operator knobs, not laws: an `org_models`
+ * row may point at a self-hosted `baseUrl` (Ollama / llama.cpp / vLLM) whose
+ * cold model load blows past both the 60 s headers bound and the 120 s
+ * inter-chunk bound. Both are resolved at MODULE INIT from `process.env`, so —
+ * as in `request-body-cap.test.ts` — a fresh process per scenario is the only
+ * honest way to exercise them: mutating `process.env` here would come too late
+ * and `import()` caches the evaluated module.
+ */
+describe("LLM deadline overrides", () => {
+  const HELPERS = new URL("../helpers.ts", import.meta.url).pathname;
+  const SCRIPT = `
+const helpers = await import(${JSON.stringify(HELPERS)});
+console.log(JSON.stringify({ idle: helpers.LLM_STREAM_IDLE_TIMEOUT_MS }));
+`;
+
+  async function probe(overrides: Record<string, string>) {
+    const env: Record<string, string> = { ...(process.env as Record<string, string>) };
+    delete env.SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS;
+    delete env.SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS;
+    Object.assign(env, overrides);
+    const proc = Bun.spawn(["bun", "-e", SCRIPT], { env, stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout: stdout.trim(), stderr };
+  }
+
+  it("falls back to the shared compiled default when unset", async () => {
+    const { exitCode, stdout } = await probe({});
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).idle).toBe(120_000);
+  });
+
+  it("honours SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS", async () => {
+    const { exitCode, stdout } = await probe({ SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS: "600000" });
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout).idle).toBe(600_000);
+  });
+
+  it("fails loud at import on a malformed idle override", async () => {
+    const { exitCode, stderr } = await probe({ SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS: "2 minutes" });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/SIDECAR_LLM_STREAM_IDLE_TIMEOUT_MS must be a positive integer/);
+  });
+
+  it("fails loud at import on a malformed first-response override", async () => {
+    // The TTFB constant is module-private, so the refusal is what proves the
+    // variable is actually read — a silently ignored knob is the failure mode
+    // this case exists to catch.
+    const { exitCode, stderr } = await probe({ SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS: "0" });
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toMatch(/SIDECAR_LLM_FIRST_RESPONSE_TIMEOUT_MS must be a positive integer/);
+  });
+});

--- a/runtime-pi/sidecar/test/pi-messages-backend.test.ts
+++ b/runtime-pi/sidecar/test/pi-messages-backend.test.ts
@@ -788,6 +788,107 @@ describe("handlePiMessagesRequest", () => {
     expect(body.error.message).toContain("appstrate-medium");
     expect(JSON.stringify(body)).not.toContain("deepseek");
   });
+
+  // --- inter-chunk idle bound ---
+  //
+  // The alias path re-originates through pi-ai and consumes a GENERATOR, so it
+  // does not go through `passUpstream` and inherited none of its bounds. It is
+  // also exactly the population that needs one: `pi-messages` is one of the four
+  // api shapes that ignore pi-ai's own `timeoutMs`, and the backing rebuilt here
+  // can be another (`google-vertex`, `bedrock-converse-stream`). Without the
+  // bound a stalled backing burned the whole run budget and died on the
+  // wall-clock watchdog with nothing to show.
+  //
+  // Same instrument as `passUpstream`'s (see `app.test.ts`): armed against the
+  // PENDING `next()` and cleared the moment it settles — never a long-lived
+  // timer, which the healthy-but-slow control below would catch.
+
+  it("terminates the turn when the backing stream goes silent mid-turn", async () => {
+    const stalling: BackingStreamFn = () =>
+      ({
+        async *[Symbol.asyncIterator]() {
+          yield { type: "start", partial: partialMessage([]) } as AssistantMessageEvent;
+          // Silent from here on, and never ends — the shape the 30 min absolute
+          // cap used to be the only answer to.
+          await new Promise(() => {});
+        },
+      }) as unknown as ReturnType<BackingStreamFn>;
+
+    let frames: PiMessagesEvent[] = [];
+    const warnings = await captureWarnings(async () => {
+      const res = handlePiMessagesRequest(
+        { ...depsFor(BACKINGS[0]!, stalling), llmStreamIdleTimeoutMs: 25 },
+        new Request("http://sidecar:8080/llm/messages", { method: "POST" }),
+        CLIENT_BODY,
+      );
+      frames = await readFrames(res);
+    });
+
+    // The client MUST see a terminal: without one `pi-messages` cannot
+    // reconstruct the assistant message and the turn hangs anyway.
+    const terminal = frames.at(-1) as Extract<PiMessagesEvent, { type: "error" }>;
+    expect(terminal.type).toBe("error");
+    // Neutral prose, as on every other alias failure — the stall must not
+    // become the one path that names the backing.
+    expect(terminal.errorMessage).toBe('Upstream model error (model "appstrate-medium")');
+    expect(JSON.stringify(frames)).not.toContain("deepseek");
+
+    const stall = warnings.find(
+      (w) => w.msg === "pi-messages backend: upstream went silent mid-stream",
+    );
+    expect(stall).toMatchObject({ idleTimeoutMs: 25, real: "deepseek-chat" });
+  });
+
+  it("does NOT trip on a slow but healthy backing stream", async () => {
+    // REGRESSION CONTROL. The upstream answers every `next()` well inside the
+    // bound, but the TURN lasts far longer than it. A timer that keeps running
+    // across events — or one hung off total elapsed time — would kill this.
+    const idleTimeoutMs = 120;
+    const gapMs = 40;
+    const events: AssistantMessageEvent[] = [
+      { type: "start", partial: partialMessage([]) },
+      {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "hi",
+        partial: partialMessage([{ type: "text", text: "hi" }]),
+      },
+      {
+        type: "text_delta",
+        contentIndex: 0,
+        delta: " there",
+        partial: partialMessage([{ type: "text", text: "hi there" }]),
+      },
+      {
+        type: "done",
+        reason: "stop",
+        message: { ...partialMessage([]), stopReason: "stop", usage: USAGE },
+      },
+    ];
+    const slow: BackingStreamFn = () =>
+      ({
+        async *[Symbol.asyncIterator]() {
+          for (const event of events) {
+            await new Promise((r) => setTimeout(r, gapMs));
+            yield event;
+          }
+        },
+      }) as unknown as ReturnType<BackingStreamFn>;
+
+    const started = Date.now();
+    const res = handlePiMessagesRequest(
+      { ...depsFor(BACKINGS[0]!, slow), llmStreamIdleTimeoutMs: idleTimeoutMs },
+      new Request("http://sidecar:8080/llm/messages", { method: "POST" }),
+      CLIENT_BODY,
+    );
+    const frames = await readFrames(res);
+
+    expect(frames.map((f) => f.type)).toEqual(["start", "text_delta", "text_delta", "done"]);
+    // Proof the control tests the right thing: the turn really did outlast the
+    // idle bound, so any implementation timing the wrong interval would have
+    // terminated it with an `error` frame above.
+    expect(Date.now() - started).toBeGreaterThan(idleTimeoutMs);
+  });
 });
 
 /**


### PR DESCRIPTION
## The report

A run on a Gemini account with no credits ends like this:

```
{"error":{"message":"...503 ... This model is currently experiencing high demand...","code":503}}
got status: UNAVAILABLE.
Deadline nudge at 75% of the run budget — ~75s left
Deadline nudge at 90% of the run budget — ~30s left
→ run finalizes: timeout, no error
```

The same account on OpenAI produces an explicit error in the run — but an opaque one in the chat. Three surfaces, three different stories about one class of failure.

## What was actually wrong

Four separate defects, each verified against the code rather than assumed:

**1. Nothing bounded upstream silence.** Both Appstrate-owned inference proxies let a provider hang. The sidecar's own comment said it outright — *"the ONLY deadline … an absolute 30 min cap, not an inactivity timer. There is deliberately no inter-chunk (body) timeout"* (undici's body timeout does not apply under Bun) — and the platform gateway passed `timeoutMs: 0`, leaving the caller's disconnect as the only bound.

This is invisible on most providers because pi-ai hands its adapters a `timeoutMs`. But **four of the ten api shapes this platform maps ignore it** and honour only `options.signal`: `google-generative-ai`, `google-vertex`, `bedrock-converse-stream`, and `pi-messages` — the aliased path. (`grep timeoutMs node_modules/@earendil-works/pi-ai/dist/api/*.js`.) A stalled stream on any of them burned the whole run budget. Our proxies are the only provider-agnostic place that covers all four.

**2. The timeout threw its own evidence away.** The watchdog branch held the session bridge in hand and never asked it what had failed, finalizing as a bare `Run timed out after Ns`.

**3. `RunError.context` never reached the database.** The ingestion route's `error` sub-object is a closed `z.object` (it strips `context`) and `runs.error` is a `text` column — documented as deliberate, with the jsonb widening tracked as a follow-up.

**4. The chat dropped a cause it had already classified.** `closePiTurn` persists `errorCategory` whatever the finish reason, but the client read it only under `finishReason: "error"` — so a turn cut by the 10-minute ceiling showed "time limit reached" and nothing about the 503s behind it.

## What this changes

**Bound the silence** — three deadlines, each with its own instrument: the absolute cap stays (a long agentic completion is legal); a first-response/TTFB bound (60 s streaming; the platform gateway picks 10 min for `stream: false`, preserving the reason `timeoutMs: 0` existed); and an inter-chunk idle bound (120 s), the one that fixes the report.

The idle bound races a timer against the **pending `reader.read()` inside `pull`**, never a stream-level watchdog: `pull` is demand-driven, so a long-lived timer would kill a merely slow *consumer* on a healthy upstream. Both negative controls assert exactly that, and were verified to fail against the naive implementation.

A TTFB signal handed to `fetch` tears down the body too, so `llmUpstreamAbort()` detaches the timer once headers land — same contract as `guardedFetch` in `@appstrate/afps-shared`. Without it every healthy stream would die at 60 s.

**Make the timeout name its cause** — the bridge keeps a sticky record of the last *failed* turn, separate from the terminal-verdict fields (which are overwritten every turn, so one clean turn erases the cause — right for a run that recovered, wrong for one the watchdog cuts short). The cause reaches the user on the only field that gets there without a migration (`message`, bounded and whitespace-collapsed), and rides to durable storage as the `appstrate.error` event's `data` → `run_logs.data` jsonb. `code` stays `"timeout"`.

**Let the chat say what it was failing on** — the persisted category now surfaces on a deadline turn too, composed with the notice, **no new i18n key**. A deadline with no category still shows the notice alone.

**One classifier** — the chat module's rules move to `@appstrate/core/model-error` and serve both surfaces; ~37 lines of hand-rolled matching drop to zero. The vendor's `isRetryableAssistantError` is deliberately *not* an input (it answers "will the SDK's in-turn loop retry?", already settled by the time anyone reads the error) but is **pinned by a test** over real provider strings, so a pi-ai bump that moves a pattern fails loudly instead of silently.

## Deliberately not done

- **No circuit breaker.** The SDK already has a bounded retry policy and a retryable/non-retryable classifier; a second counter would be a competing policy drifting from the first.
- **No new error category.** `credential_unavailable` already covers a provider account that is dead for access or billing reasons, and `@appstrate/core` carries zero billing vocabulary by standing rule.
- **No `retry.provider.timeoutMs` in the Pi settings.** Once the proxies bound the stream, the SDK's own 300 s default bounds nothing tighter — two lines that would do nothing.
- **No jsonb widening of `runs.error`.** That is the tracked follow-up; the event path carries the structure today without a migration.

## Verification

- `bun run check` — 35/35 tasks, 0 cached (nothing skipped by cache).
- Targeted suites: **4013 pass / 0 fail** across 308 files (`core`, `runner-pi`, `module-chat`, `afps-runtime`, sidecar, `apps/api` unit).
- `verify:dead-code` exits 0.

**Not reproduced end to end.** I could not replay a credit-less Gemini run against a live provider, so the stalled-stream diagnosis rests on code evidence (the four adapters that ignore `timeoutMs`, the two unbounded proxies, a 300 s budget matching the observed nudge timings) rather than on a capture of `maxIdleMs`. The idle bound is correct regardless of what stalled the stream, and the slow-consumer controls are what keep it from being a regression if the real cause turns out to be elsewhere.

**How a stalled stream actually surfaces** (verified, because the first version of this PR got the mechanism wrong): our timeout message never crosses the wire. `controller.error()` on a Bun response body does not propagate — the client observes `{done: true}` — and the platform twin closes cleanly by design, to keep `guardSseTeardown`'s no-throw invariant. What the agent sees is a truncated stream, which the pi-ai adapters turn into a thrown "stream ended without …", and *those* strings are what match the retryable pattern. Our text is for our logs. The three comments that claimed otherwise are corrected.

## Review pass

A blind adversarial review (no description given, intent derived from the code) found nine issues. The machinery survived — no leaked timer, double-settle, unhandled rejection, or body killed by the TTFB signal — but three load-bearing claims were false and one safety net was a no-op. All nine are addressed in the final commit:

- three false "wording is load-bearing" comments → rewritten on the verified mechanism;
- the divergence test's headline assertion could not fail → **deleted** (not replaced by asserting vendor/Appstrate agreement, which the branch deliberately rejects; the corpus now carries a string where they legitimately disagree);
- `getTerminalError()`'s classification was dead data → routed onto the event that reaches storage;
- `withIdleBound` was duplicated across both proxies → moved to `@appstrate/connect/proxy-primitives`, the module whose header exists for exactly this;
- the alias (`pi-messages`) path had **no** idle bound, though it is one of the four uncovered shapes → bounded, with the upstream fetch unwound;
- the platform idle bound cancelled only one `tee()` branch, so the socket stayed pinned → both branches released, which also repairs the one-ledger-row-per-2xx invariant;
- hard-coded bounds on a surface that serves self-hosted models → operator overrides, wired through `SIDECAR_OPERATOR_ENV_KEYS` (without which they are inert under docker/firecracker) and through the numeric gate (the sidecar's parser throws at module scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
