### PR TITLE
fix(files)!: accept the legacy `doc_` id — the rename never touched files.id

### DIFF
--- a/packages/core/src/file-uri.ts
+++ b/packages/core/src/file-uri.ts
@@ -23,17 +23,19 @@
  * afterwards so historical `runs.input` rows, persisted chat attachments and
  * model-authored prompts stayed resolvable. That compatibility became
  * unreachable when the rename was finished at the physical layer: every URI
- * ever written under the old scheme addresses a `doc_` id, and
- * {@link FILE_ID_RE} accepts only `file_`. So the pair `document://` +
- * `file_xxx` — the only thing the accept-path could still have matched — is a
- * form nothing has ever emitted, and a genuine `document://doc_xxx` fails on
- * the id, not the scheme. One spelling is read and one is written, and they
- * are the same one.
+ * ever written under the old scheme addresses a `doc_` id. Only the SCHEME is
+ * unread: `document://` is never parsed, while the `doc_` ID it addressed is
+ * still perfectly live and {@link FILE_ID_RE} accepts it.
  *
- * The row id prefix is `file_`, minted by `prefixedId("file")`. It was `doc_`
- * until the rename was finished at the physical layer; nothing reads the old
- * spelling any more, which is exactly why the old scheme has nothing left to
- * address.
+ * That distinction was lost once, expensively. An earlier revision of this
+ * header asserted the row id prefix "was `doc_` until the rename was finished
+ * at the physical layer" and concluded the old spelling had nothing left to
+ * address. The physical rename never touched `files.id` — 0043 renamed the
+ * table, 0044 rewrote `storage_key`, and no migration rewrites the id — so on
+ * production every row was still `doc_`, and a validator that accepted only
+ * `file_` 404'd all of them. Write the ids, not the intent.
+ *
+ * New rows mint `file_` via `prefixedId("file")`; `doc_` is read-only history.
  *
  * Dependency-free on purpose (no DB/storage imports) so the MCP tool layer,
  * the chat module, and the runtime can import it without pulling in the files
@@ -119,7 +121,34 @@ export const UPLOAD_URI_PREFIX = "upload://";
  * input before it reaches any database SELECT. Mirrors the service-side
  * validator (`apps/api/src/services/files.ts`).
  */
-export const FILE_ID_RE = /^file_[A-Za-z0-9_-]{8,}$/;
+/**
+ * Accepts `doc_` as well as `file_`, and that is not a courtesy — it is the
+ * only prefix production rows actually carry.
+ *
+ * The prose above this file claimed "the row id prefix is `file_` … it was
+ * `doc_` until the rename was finished at the physical layer". That premise was
+ * false. 0043 renamed the TABLE (`ALTER TABLE documents RENAME TO files`) and
+ * 0044 rewrote `storage_key`; NEITHER touched `files.id`, and no other
+ * migration does. Measured on production the day 0044 shipped: 521 rows with a
+ * `doc_` id, 0 with `file_`, plus 25 `file_links.file_id` pointing at them.
+ *
+ * Because `loadFileForPreview` and `resolveFileForActor`
+ * (`apps/api/src/services/files.ts`) test this regex BEFORE any SELECT, a
+ * `doc_` id returned null without ever reaching the database — so every
+ * pre-rename file 404'd on preview and download at once.
+ *
+ * Widened rather than migrating the ids: the id is opaque, and its prefix is
+ * read by nothing but this validator. Rewriting it would mean rewriting 521
+ * ids, 25 foreign keys, 521 `storage_key` values that embed the id in their
+ * path, and MOVING 521 storage objects a second time — all to change a string
+ * nobody parses. The one thing that could have forced a rewrite is a persisted
+ * `appfile://doc_…` reference, and there are none (measured: 0 rows in
+ * `runs.input`).
+ *
+ * New rows mint `file_` via `prefixedId("file")`. `doc_` is frozen history: it
+ * is never written again, only read.
+ */
+export const FILE_ID_RE = /^(?:file|doc)_[A-Za-z0-9_-]{8,}$/;
 
 /** Strict upload id shape: `upl_` + ≥8 id chars. Mirrors the uploads service validator. */
 export const UPLOAD_ID_RE = /^upl_[A-Za-z0-9_-]{8,}$/;
@@ -154,11 +183,19 @@ export function parseFileUri(uri: string): string | null {
 }
 
 /**
- * Scans a free-form text blob for an embedded stored-file URI. `file_` + ≥1 id
- * char keeps the boundary scan permissive, with the strict `{8,}` length
- * enforced by {@link parseFileUri}.
+ * Scans a free-form text blob for an embedded stored-file URI. The prefix
+ * alternation + ≥1 id char keeps the boundary scan permissive, with the strict
+ * `{8,}` length enforced by {@link parseFileUri}.
+ *
+ * `doc_` is matched here for the same reason {@link FILE_ID_RE} accepts it:
+ * {@link fileUri} is a bare concatenation, so a pre-rename row yields
+ * `appfile://doc_…`. A scan that matched only `file_` would silently drop every
+ * such reference from a prompt or a run's `input` — the callers
+ * (`inline-run.ts`, `files.ts`, `state/runs.ts`) treat "not found" as "not
+ * referenced". No production row carries one today, but attaching any existing
+ * file to a run mints one.
  */
-const EMBEDDED_FILE_URI_SCAN = /appfile:\/\/file_[A-Za-z0-9_-]+/g;
+const EMBEDDED_FILE_URI_SCAN = /appfile:\/\/(?:file|doc)_[A-Za-z0-9_-]+/g;
 
 /** The canonical `appfile://` URI for a file id. */
 export function fileUri(id: string): string {

--- a/packages/core/test/file-uri.test.ts
+++ b/packages/core/test/file-uri.test.ts
@@ -6,9 +6,9 @@
  * {@link extractFileIds} keeps matching only whole-string leaf values inside
  * structured JSON (objects/arrays) and never scans embedded prose, and the
  * single-scheme contract: `appfile://` is the only spelling written AND the
- * only one read. The pre-#1177 `document://` scheme is refused, which the
- * third block below pins from both sides — a `doc_` id fails, and so does the
- * `document://file_…` pairing that no build has ever emitted. The last block
+ * only one read. The pre-#1177 `document://` SCHEME is refused — but the
+ * `doc_` ID it used to address is still live on every production row, and the
+ * third and fourth blocks below pin that split in both directions. The last block
  * covers the sibling `upload://` predicate, which every caller of the URI
  * helpers (the API parser, `packages/ui`'s `FileWidget`) shares.
  */
@@ -16,6 +16,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   FILE_URI_PREFIX,
+  FILE_ID_RE,
   extractFileIds,
   extractFileIdsFromText,
   fileUri,
@@ -84,16 +85,33 @@ describe("single-scheme contract (#1177)", () => {
     expect(fileUri(A)).toBe(`appfile://${A}`);
   });
 
-  it("parseFileUri refuses the retired document:// scheme", () => {
+  it("parseFileUri refuses the retired document:// scheme, on the SCHEME alone", () => {
     expect(parseFileUri(`appfile://${A}`)).toBe(A);
-    // The only form the retired accept-path could still have matched, and no
-    // build ever emitted it: `document://` was replaced by `appfile://` in the
-    // same issue that eventually re-minted the id prefix to `file_`.
     expect(parseFileUri(`document://${A}`)).toBeNull();
-    // The form that WAS written under the old scheme fails on the id, which is
-    // why the prefix had nothing left to address.
+    // The scheme is retired; the `doc_` ID it used to address is NOT. Both of
+    // these pin that split, and the second one is the production bug: an
+    // earlier revision rejected it, which 404'd every pre-rename file at once
+    // because `loadFileForPreview` tests the id regex before any SELECT.
     expect(parseFileUri("document://doc_aaaaaaaa")).toBeNull();
-    expect(parseFileUri("appfile://doc_aaaaaaaa")).toBeNull();
+    expect(parseFileUri("appfile://doc_aaaaaaaa")).toBe("doc_aaaaaaaa");
+  });
+
+  it("a legacy doc_ id survives every reader on the serving path", () => {
+    // 0043 renamed the table and 0044 rewrote storage_key; NEITHER touched
+    // files.id. Measured on production the day 0044 shipped: 521 rows `doc_`,
+    // 0 rows `file_`. So `doc_` is not a hypothetical — it is every row there.
+    const legacy = "doc_31c2435b-a7f8-41da-a82c-3b86ad59f8e6";
+    expect(FILE_ID_RE.test(legacy)).toBe(true);
+    expect(parseFileUri(fileUri(legacy))).toBe(legacy);
+    // The prose scan must see it too: `fileUri` is a bare concatenation, so a
+    // legacy row yields `appfile://doc_…`, and a `file_`-only scan would drop
+    // it from a prompt while the caller read "not found" as "not referenced".
+    expect(extractFileIdsFromText(`see ${fileUri(legacy)} for details`)).toEqual([legacy]);
+    expect(extractFileIds({ input: fileUri(legacy) })).toEqual([legacy]);
+    // Still minted as `file_`; `doc_` is read-only history, never written.
+    expect(FILE_ID_RE.test("file_aaaaaaaa")).toBe(true);
+    expect(FILE_ID_RE.test("doc_short")).toBe(false);
+    expect(FILE_ID_RE.test("upl_aaaaaaaa")).toBe(false);
   });
 
   it("parseFileUri still rejects a malformed id and a foreign scheme", () => {


### PR DESCRIPTION
**Production regression, live since `v1.0.0-beta.53`: every stored file 404s on preview and download.** Reported from the UI, reproduced against the live database.

## The path

`loadFileForPreview` and `resolveFileForActor` (`apps/api/src/services/files.ts:1220,1285`) test `FILE_ID_RE` **before any SELECT**:

```ts
if (!FILE_ID_RE.test(fileId)) return null;   // → 404, without touching the DB
```

`FILE_ID_RE` accepted only `file_`.

## Why that was safe, and why it wasn't

`file-uri.ts` asserted the row id prefix *"was `doc_` until the rename was finished at the physical layer"*.

It never was. `0043` renamed the **table** (`ALTER TABLE documents RENAME TO files`), `0044` rewrote **`storage_key`** — neither touches `files.id`, and no other migration does. Measured on production after `0044` shipped:

| | |
|---|---|
| `files` with id `doc_` | **521** |
| `files` with id `file_` | **0** |
| `file_links` → `doc_` | 25 |

The rename was finished everywhere except the one place this validator reads.

## Why widen instead of migrating the ids

The id is opaque; its prefix is read by nothing but this validator. Rewriting it means 521 ids, 25 foreign keys, 521 `storage_key` values that **embed the id in their path**, and moving 521 storage objects a second time. The one thing that could have forced a rewrite is a persisted `appfile://doc_…` reference — measured: **0 rows** in `runs.input`.

New rows still mint `file_` via `prefixedId("file")`. `doc_` is read-only history.

## The sibling a narrow fix would have left open

`EMBEDDED_FILE_URI_SCAN` matched only `appfile://file_…`. But `fileUri()` is a bare concatenation, so a legacy row yields `appfile://doc_…`, and `inline-run.ts` / `files.ts` / `state/runs.ts` all read "not found" as "not referenced" — a file silently dropped from a prompt, no error. No such row exists today; attaching any existing file to a run mints one. Widened too.

## Tests

Two existing assertions pinned the wrong behaviour and are corrected. The retired **`document://` scheme** is still refused; the **`doc_` id** it addressed is not — the split is now pinned in both directions.

- `bun run check` — 35/35, **`Cached: 0`** (nothing masked by the turbo cache)
- `packages/core` — 1099 pass / 0 fail
- `apps/api/test/unit` — 1628 pass / 0 fail
- **Negative control** — restoring the `file_`-only regex fails 2 of the new assertions, so the guard discriminates rather than merely passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)