### PR TITLE
docs: forbid transitional code, add /audit-legacy, and its first run

### DIFF
--- a/.claude/commands/audit-legacy.md
+++ b/.claude/commands/audit-legacy.md
@@ -101,11 +101,20 @@ find config keys read under two names; find module-contract branches keyed on a
 version or capability that every module now has.
 
 **Agent F — Cross-repo & tests.** `cloud/`, `connect-helper/`, `github-action/`,
-plus `test/` fixtures across the workspace. Out-of-tree consumers are the ONE
-legitimate reason a shape survives its in-tree caller — so a finding here must
-state whether the consumer still needs it (check the consumer's source, do not
-assume). Also flag test fixtures that pin a retired shape, which is how a
-compatibility branch acquires a test that justifies keeping it.
+plus `test/` fixtures across the workspace.
+
+> **Read `git show origin/main:<path>` in sibling repos, never the working tree.**
+> A sibling checkout sits on whatever branch someone left it on, which can
+> predate main by weeks. The first run of this audit reported `cloud` pinned to
+> `@appstrate/core >=8.0.0` — true of its working tree, which was parked on a
+> feature branch, and false of `origin/main`, which had been bumped to `>=9.0.0`
+> hours earlier. Run `git -C <repo> fetch -q origin` first, then read from
+> `origin/main`. Also confirm each repo's path before sweeping it: the workspace
+> layout in `CLAUDE.md` is not always where a clone actually lives. Out-of-tree consumers are the ONE
+> legitimate reason a shape survives its in-tree caller — so a finding here must
+> state whether the consumer still needs it (check the consumer's source, do not
+> assume). Also flag test fixtures that pin a retired shape, which is how a
+> compatibility branch acquires a test that justifies keeping it.
 
 ## Sub-agent prompt template
 

--- a/.claude/commands/audit-legacy.md
+++ b/.claude/commands/audit-legacy.md
@@ -1,0 +1,139 @@
+---
+description: Exhaustive transitional-code audit — dispatches parallel opus sub-agents to find every compatibility branch, data-repair-in-a-drizzle-migration, and dead transition shim that docs/NO_TRANSITIONAL_CODE.md forbids
+---
+
+# /audit-legacy — Transitional & legacy code audit
+
+100%-coverage audit of the rule in `docs/NO_TRANSITIONAL_CODE.md`: the codebase
+describes how the system works **now**, never how it used to, and never carries a
+bridge between the two. Dispatches opus sub-agents in parallel, each sweeping one
+dimension, and consolidates into one report written to
+`claudedocs/audit-legacy-<YYYY-MM-DD>.md`.
+
+## When to use
+
+- Before a release
+- After any rename or refactor that spans a schema and its data
+- After completing a migration or retiring a feature flag — the transition is
+  over, so its scaffolding must be gone
+- Periodically, as a debt health-check
+
+## What it checks
+
+`docs/NO_TRANSITIONAL_CODE.md` is authoritative. Three prohibitions:
+
+1. **No backward-compatibility branches** — a validator/parser/resolver accepts
+   exactly one form. No legacy aliases, `X ?? legacyX` fallbacks, dual-read
+   paths, "accept both shapes" parsing, regex alternations admitting a retired
+   spelling. A retired name must fail LOUDLY (the `RETIRED_ENV_RENAMES` shape),
+   never fall back.
+2. **Data repair belongs in `scripts/migration/`, never in a drizzle migration**
+   — `packages/db/drizzle/*.sql` describes schema and is replayed forever. DML
+   that rewrites row contents is an operational task. The one legitimate overlap
+   is a backfill that is the precondition of a `NOT NULL` promotion in the same
+   file.
+3. **No dead transition scaffolding** — decided feature flags, shims, adapters
+   wrapping a shape nothing emits, `@deprecated` exports with no caller,
+   re-export barrels that exist only to keep an old import path resolving.
+
+## Severity
+
+- 🔴 **VIOLATION** — live transitional code: a compatibility branch, data DML in
+  a drizzle migration, or scaffolding whose transition is complete. Has an owner
+  and a deletion path.
+- 🟡 **SUSPECT** — looks transitional but the transition may be unfinished, or
+  the shape is load-bearing for an out-of-tree consumer. Needs a judgement call;
+  report the evidence, do not guess.
+- ✅ **VERIFIED CLEAN** — surface swept, nothing found. Report what was swept, so
+  the coverage claim is checkable.
+
+**No finding without evidence.** Every 🔴 must name the retired form, the code
+that still accepts it, and what replaces it. A finding that cannot name its
+replacement is 🟡 at best. (Same discipline as `/audit-overengineering`.)
+
+## Behavior
+
+1. Read `docs/NO_TRANSITIONAL_CODE.md` for the current authoritative rules
+2. Record starting state: `git status --short`, `git log --oneline -3`
+3. Dispatch **6 opus sub-agents IN PARALLEL** (one message, 6 tool_uses)
+4. Wait for all 6
+5. Consolidate into `claudedocs/audit-legacy-<date>.md` + an in-chat summary
+6. Ask the user which findings to act on — never fix unprompted
+
+## The six agents
+
+**Agent A — Validators & parsers.** Sweep `packages/core/src`, `packages/env`,
+`packages/afps-runtime`, `apps/api/src/lib`, `apps/api/src/services` for any
+accept-path admitting more than one form: regex alternations over a prefix or
+scheme (`(?:file|doc)_`, `(document|appfile)://`), `??` / `||` fallbacks between
+a current and a former field name, `in` checks branching on shape, Zod
+`.or()` / `.union()` where one arm is a retired shape, and every "legacy",
+"deprecated", "compat", "fallback", "v1", "old" identifier. For each: is the
+retired form still WRITTEN anywhere? If not, it is a 🔴.
+
+**Agent B — Drizzle migrations.** Read every `packages/db/drizzle/*.sql`.
+Classify each statement as schema (DDL) or data (DML). Report every `UPDATE` /
+`INSERT` / `DELETE` that rewrites row contents, EXCEPT a backfill that is the
+precondition of a `NOT NULL` / `CHECK` in the same file. Also flag migrations
+whose header argues its own necessity from a read-time alias that no longer
+exists — that pairing is what produced `0046`. Note: existing files are
+permanent and cannot be deleted; the finding is about the PATTERN and what to do
+for the next one. Report counts, not a demand to rewrite history.
+
+**Agent C — Dead scaffolding.** Sweep the whole workspace for feature flags
+whose branch is decided (grep the flag, then check whether both arms are
+reachable), `@deprecated` exports and their caller count, shims/adapters/wrappers
+named for a transition, re-export barrels with a single consumer, and
+`scripts/` entries that were one-off operational tasks already run. Cross-check
+`knip.config.ts` output for unused exports that are transition residue.
+
+**Agent D — Wire & storage contracts.** `apps/api/src/openapi`,
+`packages/shared-types`, `apps/web/src`. Find fields, enum members, or response
+shapes documented or emitted only for an older client; frontend code reading two
+spellings of the same field; SSE/webhook payloads carrying a duplicated legacy
+key. Also: storage keys, ids, and URI schemes where the code tolerates an old
+prefix.
+
+**Agent E — Env, config & modules.** `packages/env/src/index.ts`,
+`docker-compose*.yml`, `.env.example`, `apps/api/src/modules/**`. Verify every
+retired env name is in `RETIRED_ENV_RENAMES` and FAILS rather than falls back;
+find config keys read under two names; find module-contract branches keyed on a
+version or capability that every module now has.
+
+**Agent F — Cross-repo & tests.** `cloud/`, `connect-helper/`, `github-action/`,
+plus `test/` fixtures across the workspace. Out-of-tree consumers are the ONE
+legitimate reason a shape survives its in-tree caller — so a finding here must
+state whether the consumer still needs it (check the consumer's source, do not
+assume). Also flag test fixtures that pin a retired shape, which is how a
+compatibility branch acquires a test that justifies keeping it.
+
+## Sub-agent prompt template
+
+Each agent must:
+
+- `Read` `docs/NO_TRANSITIONAL_CODE.md` first — it is the authority
+- Grep exhaustively; read any ambiguous file in full
+- For every candidate, establish **whether the retired form is still written**.
+  A form that is still produced somewhere is not legacy — it is live, and
+  removing its reader is a bug. This check is the whole audit.
+- Return:
+
+```
+# Dimension <X> — <name>
+## Violations: N
+- file:line — retired form — what still accepts it — what replaces it
+## Suspect: N
+- file:line — why it looks transitional — what evidence is missing
+## Verified clean: N surfaces
+- list of what was swept
+```
+
+- Never fix anything. This audit reports.
+
+## Consolidation
+
+Write `claudedocs/audit-legacy-<YYYY-MM-DD>.md` containing: total violations by
+dimension, the full 🔴 list sorted by blast radius, the 🟡 list with the missing
+evidence named, the coverage claim (what was swept), and a short "next
+retirement" checklist derived from the findings. Then summarise in chat and ask
+which to act on.

--- a/docs/NO_TRANSITIONAL_CODE.md
+++ b/docs/NO_TRANSITIONAL_CODE.md
@@ -1,0 +1,111 @@
+# No transitional code
+
+**The rule.** The codebase describes how the system works _now_. It never
+describes how it used to work, and it never carries a bridge between the two.
+Code that exists only to survive a transition is deleted the moment the
+transition is over — and the transition is over when the data has moved, not
+when the release ships.
+
+This is a _minimality_ rule, not a purity one. Every compatibility branch is a
+second code path that no test exercises on purpose, that no reader can date, and
+that quietly changes what the primary path means.
+
+## The three prohibitions
+
+### 1. No backward-compatibility branches
+
+A validator, parser, or resolver accepts exactly one form: the current one.
+
+```ts
+// ❌ makes a retired spelling legal forever
+export const FILE_ID_RE = /^(?:file|doc)_[A-Za-z0-9_-]{8,}$/;
+
+// ✅ one form written, the same one read
+export const FILE_ID_RE = /^file_[A-Za-z0-9_-]{8,}$/;
+```
+
+If production data does not match the current form, **the data is wrong, not the
+validator**. Move the data (§2). An alias added "just until the data catches up"
+outlives the reason it was added, because nothing records when that reason
+expires.
+
+The same applies to: legacy field aliases, `X ?? legacyX` fallbacks, dual-read
+paths, "accept both shapes" JSON parsing, and env-var aliases. When a name
+changes, the old name must **fail loudly** — see `RETIRED_ENV_RENAMES`
+(`packages/env/src/index.ts`), which refuses to boot rather than silently
+falling back to a default. That is the correct shape for a retirement.
+
+### 2. Data repair lives in `scripts/migration/`, never in a drizzle migration
+
+`packages/db/drizzle/*.sql` describes the **schema**: tables, columns, indexes,
+constraints, types. It is replayed on every database that has ever existed,
+forever, and every file in it is permanent.
+
+A one-off rewrite of row _contents_ is not schema. It is an operational task
+that runs once, against one deployment, and is then finished. It belongs in
+`scripts/migration/<NNNN>-<slug>.{sql,ts}`, run deliberately by an operator, with its
+own verification queries.
+
+|             | drizzle migration          | `scripts/migration/`                   |
+| ----------- | -------------------------- | -------------------------------------- |
+| Describes   | schema shape               | a one-time data fix                    |
+| Runs        | on every DB, forever       | once, on the deployments that need it  |
+| Reviewed as | permanent contract         | an operational task                    |
+| Example     | `ALTER TABLE … ADD COLUMN` | rewrite 521 ids from `doc_` to `file_` |
+
+A `NOT NULL` promotion that requires a backfill is the one legitimate overlap:
+the backfill is the precondition of the constraint and cannot be separated from
+it. Keep it minimal, and keep it in the same file as the constraint it enables.
+
+### 3. No dead transition scaffolding
+
+Feature flags whose branch is decided, shims, adapters wrapping a shape nothing
+emits, `@deprecated` exports with no remaining caller, and re-export barrels
+that exist only so an old import path keeps resolving: delete them with the
+transition, in the same PR that completes it.
+
+## Why this is written down
+
+Both halves of this rule were broken by the same rename (#1177,
+`documents` → `files`), and each break cost a production incident:
+
+- **The data half went into drizzle migrations and was then deleted.**
+  `0044_documents_scope_strings` and `0045_documents_scope_delimited_strings`
+  rewrote persisted permission scope strings. Both were deleted when the
+  physical rename took their numbers, on the reasoning that a read-time
+  canonicalization already covered them. The commit that removed that
+  canonicalization cited these migrations as the reason it was redundant. Each
+  argument was sound alone; together they left every database upgraded from
+  `v1.0.0-beta.51` with **neither half**, silently under-granting API-key
+  permissions. `0046_legacy_permission_scope_strings` exists only to restore
+  what was deleted.
+
+- **The id half was never written at all.** `0043` renamed the table and `0044`
+  rewrote `storage_key`; neither touched `files.id`. Production carried 521 rows
+  with a `doc_` id and 0 with `file_`, while `FILE_ID_RE` accepted only `file_`
+  — and `loadFileForPreview` tests it _before_ any SELECT. On
+  `v1.0.0-beta.53` every stored file returned 404 on preview and download at
+  once. The data was moved by a one-off script; the validator was left strict.
+
+Note what the second incident says about §1: widening the regex would have
+restored service in one line. It was rejected because the line would still be
+there in a year, legalising a spelling nothing should write, with no record of
+why.
+
+## How to retire something correctly
+
+1. Change the code to the new form only. No alias, no fallback.
+2. Write the data fix as `scripts/migration/<NNNN>-<slug>.{sql,ts}`, idempotent, with
+   a `WHERE` clause that is exactly the condition it removes.
+3. Rehearse it against a restored copy of production (`pg_dump` → throwaway
+   container → apply → verify). Record the row counts.
+4. Run it, verify, and delete nothing else — the script stays as the record of
+   what was done, outside the replay path.
+5. If the old form can still arrive from outside (an env var, a stored token, a
+   third-party payload), make it **fail loudly**. Never make it work.
+
+## Audit
+
+`/audit-legacy` dispatches parallel sub-agents across the whole workspace and
+reports every violation of this document. Run it before a release, and after any
+rename or refactor that spans a schema and its data.

--- a/scripts/migration/0001-file-ids-doc-to-file.sql
+++ b/scripts/migration/0001-file-ids-doc-to-file.sql
@@ -1,0 +1,89 @@
+-- 0001 — rename every `doc_` file id to `file_`, and every reference to one.
+--
+-- APPLIED TO PRODUCTION 2026-08-26. Not replayed; kept as the record.
+--
+-- Why this is here and not in packages/db/drizzle/: it rewrites row CONTENTS,
+-- not schema. See docs/NO_TRANSITIONAL_CODE.md §2 — and 0046's header, which
+-- exists only because the data half of this same rename (#1177) was put into
+-- drizzle migrations and then deleted.
+--
+-- The bug it fixed: `FILE_ID_RE` (@appstrate/core/file-uri) accepts only
+-- `file_`, and loadFileForPreview / resolveFileForActor
+-- (apps/api/src/services/files.ts:1220,1285) test it BEFORE any SELECT — so a
+-- `doc_` id was a 404 that never reached the database. 0043 renamed the table
+-- and 0044 rewrote storage_key; neither touched files.id. On v1.0.0-beta.53
+-- every stored file 404'd on preview and download at once.
+--
+-- The validator was deliberately left strict. The data moved instead.
+--
+-- Rehearsed against a pg_dump of live production restored into a throwaway
+-- postgres:16-alpine, then applied. Both runs, identical:
+--
+--   files.id                UPDATE 521
+--   file_links.file_id      UPDATE 25    (2 FKs dropped + recreated verbatim;
+--                                         neither carries ON UPDATE, so the
+--                                         parent id cannot move under them)
+--   runs.input              UPDATE 64    document://doc_x -> appfile://file_x
+--   chat_messages.content   UPDATE 59    bare doc_x -> file_x
+--
+-- Writes 3 and 4 match `doc_` + a STRICT UUID, so the 11 chat rows that merely
+-- DISCUSS the format in prose (`"docId": "doc_123"`, a quoted
+-- `document://doc_xxx`) are untouched. Verified after: 0 rows keep a full-UUID
+-- reference.
+--
+-- NOT touched, deliberately:
+--   * files.storage_key keeps its `doc_` path segment — nothing derives it from
+--     the id and nothing parses the id back out (parseStorageKey returns the
+--     bucket only). No storage object moved.
+--   * run_logs keeps its `document://doc_…` prose — immutable emitted text.
+--
+-- Verify before:
+--   SELECT (SELECT count(*) FROM files WHERE id LIKE 'doc\_%'),
+--          (SELECT count(*) FROM file_links WHERE file_id LIKE 'doc\_%'),
+--          (SELECT count(*) FROM runs WHERE input::text ~ 'document://doc_'),
+--          (SELECT count(*) FROM chat_messages WHERE content::text ~ 'doc_[0-9a-f]{8}-');
+-- Verify after: all four zero, plus
+--   SELECT count(*) FROM file_links l
+--   WHERE NOT EXISTS (SELECT 1 FROM files f WHERE f.id = l.file_id);  -- 0
+--   SELECT count(*) FROM pg_constraint
+--   WHERE confrelid = 'public.files'::regclass AND contype = 'f';     -- 2
+BEGIN;
+SET LOCAL lock_timeout = '3s';
+SET LOCAL statement_timeout = '300s';
+ALTER TABLE "file_links" DROP CONSTRAINT IF EXISTS "file_links_file_id_files_id_fk";
+ALTER TABLE "file_links" DROP CONSTRAINT IF EXISTS "file_links_file_id_org_id_fk";
+UPDATE "files" SET "id" = 'file_' || substring("id" FROM 5) WHERE "id" LIKE 'doc\_%';
+UPDATE "file_links" SET "file_id" = 'file_' || substring("file_id" FROM 5) WHERE "file_id" LIKE 'doc\_%';
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'file_links_file_id_files_id_fk' AND conrelid = 'public.file_links'::regclass
+  ) THEN
+    ALTER TABLE "file_links" ADD CONSTRAINT "file_links_file_id_files_id_fk"
+      FOREIGN KEY ("file_id") REFERENCES "files"("id") ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'file_links_file_id_org_id_fk' AND conrelid = 'public.file_links'::regclass
+  ) THEN
+    ALTER TABLE "file_links" ADD CONSTRAINT "file_links_file_id_org_id_fk"
+      FOREIGN KEY ("file_id", "org_id") REFERENCES "files"("id", "org_id") ON DELETE CASCADE;
+  END IF;
+END $$;
+UPDATE "runs"
+SET "input" = regexp_replace(
+      "input"::text,
+      'document://doc_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
+      'appfile://file_\1', 'g')::jsonb
+WHERE "input"::text ~ 'document://doc_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+UPDATE "chat_messages"
+SET "content" = regexp_replace(
+      "content"::text,
+      'doc_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})',
+      'file_\1', 'g')::jsonb
+WHERE "content"::text ~ 'doc_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+SET LOCAL lock_timeout = DEFAULT;
+SET LOCAL statement_timeout = DEFAULT;
+
+COMMIT;

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -1,0 +1,52 @@
+# `scripts/migration/` — one-off data tasks
+
+Operational scripts that rewrite row **contents** once, against the deployments
+that need it, and are then finished. They are **not** replayed, **not** part of
+boot, and **never** live in `packages/db/drizzle/`.
+
+See `docs/NO_TRANSITIONAL_CODE.md` for why the split exists — both halves of the
+`documents` → `files` rename were botched by ignoring it, each costing a
+production incident.
+
+## The split
+
+|             | `packages/db/drizzle/*.sql`   | here                 |
+| ----------- | ----------------------------- | -------------------- |
+| Describes   | schema shape                  | a one-time data fix  |
+| Runs        | on every DB, forever, at boot | once, by an operator |
+| Reviewed as | a permanent contract          | an operational task  |
+
+The one legitimate overlap: a backfill that is the **precondition** of a
+`NOT NULL` or `CHECK` in the same migration file. It cannot be separated from
+the constraint it enables, so it stays with it.
+
+## Writing one
+
+`<NNNN>-<slug>.sql` (or `.ts` when it needs logic beyond SQL). Requirements:
+
+1. **Idempotent** — every `WHERE` is exactly the condition it removes, so a
+   second run matches zero rows.
+2. **One transaction** — `BEGIN` / `COMMIT`, so a failure leaves nothing half-done.
+3. **Fenced** — `SET LOCAL lock_timeout` and `statement_timeout`.
+4. **Rehearsed** — `pg_dump` production → throwaway `postgres:16-alpine` →
+   apply → verify. Record the row counts in the header.
+5. **Verifiable** — ship the "before" and "after" queries alongside it.
+
+## Running one
+
+```sh
+# 0. ALWAYS dump first
+docker exec <pg> pg_dump -U appstrate -d appstrate --no-owner --no-privileges \
+  -Fc -f /tmp/pre.dump
+
+# 1. rehearse against a restored copy, never straight at production
+# 2. then, and only then:
+docker exec -i <pg> psql -U appstrate -d appstrate -v ON_ERROR_STOP=1 \
+  -f - < scripts/migration/<NNNN>-<slug>.sql
+```
+
+## Log
+
+| #    | date       | what                                            | rows               |
+| ---- | ---------- | ----------------------------------------------- | ------------------ |
+| 0001 | 2026-08-26 | `files.id` `doc_` → `file_` and every reference | 521 / 25 / 64 / 59 |


### PR DESCRIPTION
Closes the loop on today's two production incidents, both caused by the same rule being broken in opposite directions.

## The rule — `docs/NO_TRANSITIONAL_CODE.md`

1. **No backward-compatibility branches.** A validator accepts one form. If production data does not match, the data is wrong. A retired name must **fail loudly** — `RETIRED_ENV_RENAMES` is the correct shape and already exists.
2. **Data repair lives in `scripts/migration/`**, never in a drizzle migration.
3. **No dead transition scaffolding** — deleted in the PR that completes the transition.

Grounded in the two post-mortems: the data half of #1177 went into drizzle migrations and was then deleted (leaving every beta.51 database with neither half, silently under-granting API-key permissions — `0046` exists only to restore it), and the id half was never written at all (521 `doc_` ids against a `file_`-only validator → every stored file 404'd on beta.53).

Also adds `scripts/migration/` with its README and `0001-file-ids-doc-to-file.sql`, the script actually applied to production today.

## The audit — `/audit-legacy`

Six parallel opus sub-agents. First run included: **9 live violations**.

| finding | blast radius |
|---|---|
| `OAUTH_ALLOWED_INTERNAL_IDP_HOSTS` aliased at 3 sites | 🔴 **security** — SSRF allowlist |
| `github-action` reads `runId`, response has `id` | 🔴 breaks every run |
| `github-action` sends `config`, schema is `.strict()` | 🔴 400 on every run |
| pinned-SDK version branch + upload `s: 0` + `bundle` alias + a 0-reader `@deprecated` export | 🟠 clean deletions |

The security one was found **independently by two agents**, and its two readers disagree on the empty string compose produces sixteen times here.

Full report: `claudedocs/audit-legacy-2026-08-26.md`.

## The audit found a defect in itself

Its one false positive came from agents reading sibling repos' working trees rather than `origin/main` — `cloud` reported one major stale when main had been bumped hours earlier. The command now requires `git show origin/main:<path>`. A stale read presented as current state: the audit's own version of the failure it hunts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)