### PR TITLE
Honour the Appstrate runtime override on a connect login

### DIFF
--- a/apps/api/src/services/connect/connect-run-launcher.ts
+++ b/apps/api/src/services/connect/connect-run-launcher.ts
@@ -48,6 +48,7 @@ import {
   type IntegrationSpawnSpec,
 } from "@appstrate/core/sidecar-types";
 import { resolveMcpServerForSpawn } from "../integration-service.ts";
+import { getMcpServerRuntime } from "@appstrate/core/mcp-server-meta";
 import {
   getIntegrationSourceKind,
   getLocalServerRef,
@@ -189,7 +190,24 @@ const defaultMcpServerResolver: McpServerResolver = async (packageId, orgId, pin
   // resolver contract here is deliberately the loose `{ type?, entry_point? }`
   // so a test fixture needs no schema import.
   const run = (resolution.manifest as { server?: { type?: string; entry_point?: string } }).server;
-  return { ...(run ? { server: run } : {}), version: resolution.version };
+  if (!run) return { version: resolution.version };
+  // The Appstrate runtime override (`_meta["dev.appstrate/mcp-server"].runtime`)
+  // wins over the MCPB `server.type`, exactly as it does on the agent-run path
+  // (`integration-spawn-resolver.ts`). MCPB has no `bun` type, so a bun-native
+  // server keeps an MCPB-vocabulary `server.type: "node"` and declares `bun` in
+  // `_meta`; without this the SAME package spawns under bun for an agent run
+  // and under node for a connect login.
+  //
+  // It is applied HERE, at the resolution boundary, rather than in
+  // `buildConnectLoginSpec`: the builder only ever sees `{ type, entry_point }`,
+  // so resolving it there would mean widening the contract to carry the whole
+  // manifest — and the two paths would still be free to drift. Collapsing it
+  // into the resolver leaves exactly one place where a runtime is decided.
+  const effectiveType = getMcpServerRuntime(resolution.manifest) ?? run.type;
+  return {
+    server: { ...run, ...(effectiveType ? { type: effectiveType } : {}) },
+    version: resolution.version,
+  };
 };
 
 export async function buildConnectLoginSpec(

--- a/apps/api/src/services/connect/connect-run-launcher.ts
+++ b/apps/api/src/services/connect/connect-run-launcher.ts
@@ -48,7 +48,7 @@ import {
   type IntegrationSpawnSpec,
 } from "@appstrate/core/sidecar-types";
 import { resolveMcpServerForSpawn } from "../integration-service.ts";
-import { getMcpServerRuntime } from "@appstrate/core/mcp-server-meta";
+import { effectiveMcpServerType } from "@appstrate/core/mcp-server-meta";
 import {
   getIntegrationSourceKind,
   getLocalServerRef,
@@ -191,21 +191,21 @@ const defaultMcpServerResolver: McpServerResolver = async (packageId, orgId, pin
   // so a test fixture needs no schema import.
   const run = (resolution.manifest as { server?: { type?: string; entry_point?: string } }).server;
   if (!run) return { version: resolution.version };
-  // The Appstrate runtime override (`_meta["dev.appstrate/mcp-server"].runtime`)
-  // wins over the MCPB `server.type`, exactly as it does on the agent-run path
-  // (`integration-spawn-resolver.ts`). MCPB has no `bun` type, so a bun-native
-  // server keeps an MCPB-vocabulary `server.type: "node"` and declares `bun` in
-  // `_meta`; without this the SAME package spawns under bun for an agent run
-  // and under node for a connect login.
+  // `effectiveMcpServerType` — the SAME core reader the agent-run spawn
+  // resolver uses, so both paths spawn a given package under one interpreter.
+  // Forwarding the raw `server.type` here did not: MCPB has no `bun` type, so a
+  // bun-native server keeps an MCPB-vocabulary `server.type: "node"` and
+  // declares `bun` in `_meta`, and the same package ran under bun for an agent
+  // run and under node for a connect login.
   //
-  // It is applied HERE, at the resolution boundary, rather than in
+  // Applied HERE, at the resolution boundary, rather than in
   // `buildConnectLoginSpec`: the builder only ever sees `{ type, entry_point }`,
   // so resolving it there would mean widening the contract to carry the whole
-  // manifest — and the two paths would still be free to drift. Collapsing it
-  // into the resolver leaves exactly one place where a runtime is decided.
-  const effectiveType = getMcpServerRuntime(resolution.manifest) ?? run.type;
+  // manifest. `type` stays optional — `buildConnectLoginSpec` is the one that
+  // fails closed on a server it cannot run.
+  const type = effectiveMcpServerType(resolution.manifest);
   return {
-    server: { ...run, ...(effectiveType ? { type: effectiveType } : {}) },
+    server: { ...run, ...(type ? { type } : {}) },
     version: resolution.version,
   };
 };

--- a/apps/api/src/services/integration-spawn-resolver.ts
+++ b/apps/api/src/services/integration-spawn-resolver.ts
@@ -43,7 +43,7 @@ import type {
 // ResolvedConnectionMap is consumed via input prop (`resolvedConnections`) below.
 import { isToolsWildcard, parseManifestIntegrations } from "@appstrate/core/dependencies";
 import {
-  getMcpServerRuntime,
+  effectiveMcpServerType,
   getMcpServerMcpConfigEnv,
   getMcpServerWorkspaceMount,
   renderMcpConfigEnv,
@@ -474,22 +474,23 @@ async function resolveOne(
     }
     const mcpServer = resolution.manifest;
     referencedMcpServer = mcpServer;
-    const run = (mcpServer as { server?: { type?: string; entry_point?: string } }).server;
+    const run = (mcpServer as { server?: { entry_point?: string } }).server;
+    // The runtime this server actually spawns under: the Appstrate `_meta`
+    // override, else the MCPB `server.type`. Decided by core so the
+    // connect-login path (`connect/connect-run-launcher.ts`) cannot decide it
+    // differently — it once did, and the same bun-native package spawned under
+    // two interpreters depending on which path reached it.
+    const effectiveType = effectiveMcpServerType(mcpServer);
     // Defensive: mcpServerManifestSchema makes `server.{type,entry_point}`
     // required, so a manifest that parsed (non-null above) always has them.
     // Kept as a fail-closed guard against a future schema relaxation.
-    if (!run?.type || !run.entry_point) {
+    if (!effectiveType || !run?.entry_point) {
       logger.warn("referenced mcp-server has no runnable server config; skipping", {
         integrationId,
         mcpServerId: ref.name,
       });
       return drop("mcp_server_not_runnable", `referenced mcp-server '${ref.name}'`);
     }
-    // The Appstrate runtime override (`_meta["dev.appstrate/mcp-server"].runtime`)
-    // wins over the MCPB `server.type`. MCPB has no `bun` type, so a bun-native
-    // server keeps an MCPB-vocabulary `server.type: "node"` and declares
-    // `bun` in _meta; the runner then picks the bun interpreter/image.
-    const effectiveType = getMcpServerRuntime(mcpServer) ?? run.type;
     // AFPS §7.1 — propagate `source.server.vendored` build-provenance signal
     // through the spawn spec → boot report so operators can audit "this run
     // used a vendored foreign package". Only meaningful for local sources.

--- a/apps/api/test/integration/routes/connect-spec-runtime-override.test.ts
+++ b/apps/api/test/integration/routes/connect-spec-runtime-override.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The Appstrate runtime override must reach a CONNECT login's spawn spec, not
+ * just an agent run's.
+ *
+ * MCPB has no `bun` server type, so a bun-native mcp-server keeps an
+ * MCPB-vocabulary `server.type: "node"` and declares the real runtime in
+ * `_meta["dev.appstrate/mcp-server"].runtime`. `integration-spawn-resolver.ts`
+ * has always honoured that on the agent path; the connect path forwarded the
+ * raw `server.type`, so the SAME package spawned under bun for an agent run and
+ * under node for a connect login.
+ *
+ * This exercises the DEFAULT resolver deliberately — the unit suite injects one,
+ * which is exactly why the divergence survived there. The override is applied at
+ * the resolution boundary, so an injected resolver cannot prove anything about
+ * it.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { seedPackage, seedPackageVersion } from "../../helpers/seed.ts";
+import {
+  localIntegrationManifest,
+  mcpServerManifest,
+} from "../../helpers/integration-manifests.ts";
+import { connectToolBlock } from "../../helpers/integration-manifests.ts";
+import { buildConnectLoginSpec } from "../../../src/services/connect/connect-run-launcher.ts";
+import type { IntegrationManifest } from "@appstrate/core/integration";
+import type { ConnectToolExecution } from "../../../src/services/connect/orchestrated-strategy.ts";
+
+const INTEGRATION_ID = "@rt/portal";
+const SERVER_ID = "@rt/portal-server";
+
+function manifestWithConnectTool(): IntegrationManifest {
+  return localIntegrationManifest({
+    name: INTEGRATION_ID,
+    serverName: SERVER_ID,
+    auths: {
+      session: {
+        type: "custom",
+        authorizedUris: ["https://portal.example.test/**"],
+        credentialFields: ["email", "password"],
+        connect: connectToolBlock({ tool: "login", runAt: "link", produces: ["session_token"] }),
+      },
+    },
+  });
+}
+
+async function seedPair(ctx: TestContext, appstrateRuntime?: string): Promise<void> {
+  await seedPackage({
+    id: INTEGRATION_ID,
+    orgId: ctx.orgId,
+    type: "integration",
+    source: "local",
+    draftManifest: manifestWithConnectTool(),
+  });
+  const server = mcpServerManifest({
+    name: SERVER_ID,
+    version: "1.0.0",
+    serverType: "node",
+    ...(appstrateRuntime ? { appstrateRuntime } : {}),
+  });
+  await seedPackage({
+    id: SERVER_ID,
+    orgId: ctx.orgId,
+    type: "mcp-server",
+    source: "local",
+    draftManifest: server,
+  });
+  // Published, not draft: the resolver reads the published-version kernel, and
+  // the byte route serves only out of `package_versions`.
+  await seedPackageVersion({ packageId: SERVER_ID, version: "1.0.0", manifest: server });
+}
+
+function execution(ctx: TestContext): ConnectToolExecution {
+  return {
+    integrationId: INTEGRATION_ID,
+    authKey: "session",
+    manifest: manifestWithConnectTool(),
+    scope: { orgId: ctx.orgId, spaceId: ctx.defaultSpaceId },
+    toolName: "login",
+    inputs: {},
+    inputFields: ["email", "password"],
+  };
+}
+
+describe("connect login spec — Appstrate runtime override", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "rt" });
+  });
+
+  it("carries the `_meta` runtime, not the MCPB `server.type`", async () => {
+    await seedPair(ctx, "bun");
+
+    const spec = await buildConnectLoginSpec(execution(ctx));
+
+    // Without the override the spec says "node" and the login spawns under the
+    // wrong interpreter — silently, since node will happily start a bun-native
+    // entry point and fail later.
+    expect(spec.manifest.server?.type).toBe("bun");
+    expect(spec.manifest.server?.packageId).toBe(SERVER_ID);
+  });
+
+  // Control: without the override the MCPB type must survive untouched. A fix
+  // that hard-coded "bun", or dropped `server.type` entirely, passes the case
+  // above and fails this one.
+  it("leaves `server.type` alone when no runtime override is declared", async () => {
+    await seedPair(ctx);
+
+    const spec = await buildConnectLoginSpec(execution(ctx));
+
+    expect(spec.manifest.server?.type).toBe("node");
+  });
+});

--- a/apps/web/src/lib/package-manifest.ts
+++ b/apps/web/src/lib/package-manifest.ts
@@ -16,7 +16,7 @@
  */
 
 import { normalizeHttpUrl } from "@appstrate/core/url";
-import { getMcpServerRuntime, type McpServerManifest } from "@appstrate/core/mcp-server-meta";
+import { effectiveMcpServerType, type McpServerManifest } from "@appstrate/core/mcp-server-meta";
 
 /** Any jsonb object. The manifest and every nested object share this shape. */
 type ManifestObject = Record<string, unknown>;
@@ -321,25 +321,27 @@ export interface McpServerManifestDetails {
  * Takes the WHOLE manifest, not just `server`, because the runtime is not a
  * property of `server`.
  *
- * The platform resolves it as `getMcpServerRuntime(manifest) ?? server.type`
- * (`services/integration-spawn-resolver.ts`), and `getMcpServerRuntime` reads
- * `_meta["dev.appstrate/mcp-server"].runtime` at the manifest ROOT. The two
- * disagree by design: MCPB's `server.type` enum has no `bun`, so a bun-native
- * server keeps `server.type: "node"` and declares `bun` in `_meta`. Reading
- * `server.type` alone labelled that server "node" — a fact about the manifest's
- * vocabulary presented as a fact about how the package runs.
+ * The platform resolves it with core's `effectiveMcpServerType`, which reads
+ * `_meta["dev.appstrate/mcp-server"].runtime` at the manifest ROOT and falls
+ * back to `server.type`. The two disagree by design: MCPB's `server.type` enum
+ * has no `bun`, so a bun-native server keeps `server.type: "node"` and declares
+ * `bun` in `_meta`. Reading `server.type` alone labelled that server "node" — a
+ * fact about the manifest's vocabulary presented as a fact about how the
+ * package runs.
  *
- * Core's reader is used rather than a second `_meta` walk here: a duplicate is
- * how the view ends up describing a runtime the runner does not pick.
+ * Core's reader is used rather than a local re-derivation: every spawn path
+ * calls the same function, so the view cannot describe a runtime the runner
+ * does not pick.
  */
 function readMcpServer(manifest: ManifestObject): McpServerView | undefined {
   const server = obj(manifest.server);
   if (!server) return undefined;
   const config = obj(server.mcp_config);
-  // `getMcpServerRuntime` narrows `_meta` itself and returns `undefined` for
+  // The override half narrows `_meta` itself and returns `undefined` for
   // anything it does not recognise, so an author-controlled value cannot get
-  // past it — the `server.type` fallback is the MCPB value, verbatim.
-  const runtime = getMcpServerRuntime(manifest as unknown as McpServerManifest) ?? str(server.type);
+  // past it — the `server.type` fallback is the MCPB value, verbatim, which is
+  // what a DRAFT being edited here needs: a typo must show as written.
+  const runtime = effectiveMcpServerType(manifest as unknown as McpServerManifest);
   const view: McpServerView = {
     ...(runtime ? { runtime } : {}),
     ...(str(server.entry_point) ? { entryPoint: str(server.entry_point) } : {}),

--- a/apps/web/src/lib/test/package-manifest.test.ts
+++ b/apps/web/src/lib/test/package-manifest.test.ts
@@ -270,8 +270,8 @@ describe("readMcpServerDetails", () => {
     // The case core's own docstring records: MCPB's `server.type` enum has no
     // `bun`, so a bun-native server keeps `server.type: "node"` and declares
     // `bun` under `_meta`. The runner reads `_meta` first
-    // (`getMcpServerRuntime(manifest) ?? run.type`); reading `server.type` here
-    // labelled this server "node", which is not how it runs.
+    // (`effectiveMcpServerType`, the same core reader called here); reading
+    // `server.type` alone labelled this server "node", which is not how it runs.
     const details = readMcpServerDetails({
       ...MINIMAL,
       type: "mcp-server",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`effectiveMcpServerType`** (`./mcp-server-meta`, re-exported from
+  `./mcp-server`) — the runtime an mcp-server actually spawns under: the
+  Appstrate `_meta["dev.appstrate/mcp-server"].runtime` override when present,
+  the MCPB `server.type` otherwise. `getMcpServerRuntime` is unchanged and still
+  exported; it reads the override alone, and every caller that needed a runtime
+  had to bolt the `?? server.type` fallback on by hand. Three did, and one of
+  them did it late: the connect-login spawn path forwarded the raw
+  `server.type`, so the same bun-native package ran under `bun` for an agent run
+  and under `node` for a connect login. The fallback now has one definition.
+  `server.type` is returned VERBATIM rather than narrowed to
+  `McpServerRuntime`, because the SPA reads unvalidated draft manifests where an
+  author's typo must still display as written; `undefined` means neither source
+  declared one, which for a spawn means "not runnable" and is the caller's to
+  fail closed on.
+  Additive — no existing export changes shape, so this is a minor.
+
 - **`formatErrorChain`** (`./errors`) — renders an error and every `cause`
   beneath it as one `": "`-joined string. It exists because `{ cause }` was
   threaded through this codebase with nothing on the other end to print it, and

--- a/packages/core/src/mcp-server-meta.ts
+++ b/packages/core/src/mcp-server-meta.ts
@@ -92,3 +92,29 @@ export function getMcpServerRuntime(manifest: McpServerManifest): McpServerRunti
   const appstrate = meta?.[MCP_SERVER_APPSTRATE_META_KEY] as { runtime?: unknown } | undefined;
   return isMcpServerRuntime(appstrate?.runtime) ? appstrate.runtime : undefined;
 }
+
+/**
+ * The runtime an mcp-server ACTUALLY spawns under: the Appstrate `_meta`
+ * override when present, the MCPB `server.type` otherwise.
+ *
+ * Every caller that needs a runtime must decide it the same way, and the
+ * fallback is the half that drifts. It already did: the connect-login path
+ * forwarded `server.type` verbatim while the agent-run path applied the
+ * override, so the SAME bun-native package spawned under `bun` for an agent run
+ * and under `node` for a connect login. The rule lives here so a third reader
+ * cannot re-derive it a fourth way.
+ *
+ * `server.type` is returned VERBATIM rather than narrowed to
+ * {@link McpServerRuntime}: the SPA reads unvalidated DRAFT manifests, where an
+ * author's typo must still be displayed as written instead of silently
+ * vanishing. Spawn callers read a schema-validated manifest, where the value is
+ * always an MCPB type. `undefined` means neither source declared one — for a
+ * spawn that is "not runnable", and it is the caller's job to fail closed on it.
+ */
+export function effectiveMcpServerType(manifest: McpServerManifest): string | undefined {
+  const type = (manifest as { server?: { type?: unknown } }).server?.type;
+  return (
+    getMcpServerRuntime(manifest) ??
+    (typeof type === "string" && type.trim() !== "" ? type : undefined)
+  );
+}

--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -45,6 +45,7 @@ export {
   MCP_SERVER_RUNTIMES,
   isMcpServerRuntime,
   getMcpServerRuntime,
+  effectiveMcpServerType,
 } from "./mcp-server-meta.ts";
 export type { McpServerRuntime } from "./mcp-server-meta.ts";
 

--- a/packages/core/test/mcp-server.test.ts
+++ b/packages/core/test/mcp-server.test.ts
@@ -12,6 +12,7 @@
 
 import { describe, it, expect } from "bun:test";
 import {
+  effectiveMcpServerType,
   getMcpServerRuntime,
   getMcpServerWorkspaceMount,
   mcpServerManifestSchema,
@@ -219,6 +220,49 @@ describe("mcpServerManifestSchema — _meta.workspace install-time validation", 
         ),
       ).toBe(true);
     }
+  });
+});
+
+describe("effectiveMcpServerType", () => {
+  it("prefers the _meta override over the MCPB server.type", () => {
+    // The whole reason the helper exists: `server.type` says `node` because
+    // MCPB has no `bun`, and the package still runs under bun.
+    const m = manifest({ "dev.appstrate/mcp-server": { runtime: "bun" } });
+    expect((m as unknown as { server: { type: string } }).server.type).toBe("node");
+    expect(effectiveMcpServerType(m)).toBe("bun");
+  });
+
+  it("falls back to the MCPB server.type when no override is declared", () => {
+    expect(effectiveMcpServerType(manifest())).toBe("node");
+    expect(effectiveMcpServerType(manifest({ "dev.appstrate/mcp-server": {} }))).toBe("node");
+  });
+
+  it("falls back to server.type when the override is not a runtime we know", () => {
+    // `_meta` is author-controlled jsonb. An unrecognised value is not a
+    // runtime, so it must not shadow the MCPB type — a caller that spawned on
+    // it would exec an interpreter that does not exist.
+    expect(
+      effectiveMcpServerType(manifest({ "dev.appstrate/mcp-server": { runtime: "deno" } })),
+    ).toBe("node");
+    expect(effectiveMcpServerType(manifest({ "dev.appstrate/mcp-server": { runtime: 42 } }))).toBe(
+      "node",
+    );
+  });
+
+  it("returns server.type VERBATIM, unnarrowed", () => {
+    // The SPA reads unvalidated DRAFT manifests: an author's typo must reach
+    // the view as written rather than vanish. Narrowing this half to
+    // `McpServerRuntime` would silently blank the field being edited.
+    const draft = { ...manifest(), server: { type: "nodejs", entry_point: "./server.ts" } };
+    expect(effectiveMcpServerType(draft as unknown as McpServerManifest)).toBe("nodejs");
+  });
+
+  it("is undefined when neither source declares a runtime", () => {
+    // Not runnable. Every spawn caller fails closed on this.
+    const headless = { ...manifest(), server: { entry_point: "./server.ts" } };
+    expect(effectiveMcpServerType(headless as unknown as McpServerManifest)).toBeUndefined();
+    const blank = { ...manifest(), server: { type: "  ", entry_point: "./server.ts" } };
+    expect(effectiveMcpServerType(blank as unknown as McpServerManifest)).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
MCPB has no `bun` server type, so a bun-native mcp-server keeps an MCPB-vocabulary `server.type: "node"` and declares the real runtime in `_meta["dev.appstrate/mcp-server"].runtime`.

`integration-spawn-resolver.ts` has always honoured that on the **agent-run** path (`getMcpServerRuntime(mcpServer) ?? run.type`). The **connect** path forwarded the raw `server.type`, so the same package spawned under bun for an agent run and under node for a connect login — silently, since node starts a bun-native entry point happily and fails later.

## Why now

This was latent while it lasted: connect runs could not authenticate against any `/internal/*` surface, so no connect login ever reached a spawn. #1230 closed that gap, which made this reachable.

**A fix that turns a dead path live inherits the bugs parked on it.** This is one of them.

## Where the fix sits

At the resolution boundary, not in `buildConnectLoginSpec`. The builder only ever sees `{ type, entry_point }`, so deciding it there would mean widening the resolver contract to carry the whole manifest — and would leave the two paths free to drift again. In the resolver there is exactly one place where a runtime is decided.

## Tests

Driven through the **default** resolver deliberately. The unit suite injects one, which is precisely why the divergence survived there: an injected resolver cannot observe a decision made inside the real one.

| case | mutation it catches |
|---|---|
| override present → spec says `bun` | reverting to `run.type` — verified failing |
| no override → MCPB `node` survives | a fix that hard-codes `bun` or drops `server.type` |

Full gate green (38/38, `Cached: 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up in this PR: the fallback now has one definition

The claim "exactly one place where a runtime is decided" was not true of the
first commit. Core exported only the override reader (`getMcpServerRuntime`),
so the `?? server.type` fallback was restated at every call site — the agent-run
spawn resolver, the SPA's manifest reader, and (as of that commit) the connect
resolver. Fixing the drift by copying the rule a third time leaves the fourth
caller free to get it wrong.

`effectiveMcpServerType(manifest)` in `@appstrate/core/mcp-server-meta` is now
that one function, and all three sites call it. Behaviour is unchanged:

- `server.type` is returned **verbatim**, not narrowed to `McpServerRuntime` —
  the SPA reads unvalidated draft manifests, where an author's typo must display
  as written instead of silently vanishing. Spawn callers read a
  schema-validated manifest, so the value is always an MCPB type there.
- `undefined` means neither source declared a runtime. For a spawn that is "not
  runnable"; the agent path's fail-closed guard keys on the effective value now
  rather than on `server.type` alone, which is the same drop for every manifest
  the schema admits and a stricter one only under a future schema relaxation.
- `getMcpServerRuntime` is unchanged and still exported — published API on core
  9.0.0, and the primitive the new reader is built on. Named in the core
  CHANGELOG's `[Unreleased]` section, which the export-surface guard requires.

Five unit cases in `packages/core/test/mcp-server.test.ts` cover both halves,
the unrecognised-override fallback, the verbatim pass-through, and the
not-runnable case. The integration test above is unchanged and still discriminates:
mutating the connect site back to `run.type` fails it (`Expected: "bun" / Received: "node"`).

Rebased onto `main` (the branch predated the beta.54 compose bump, which failed
`verify:release-version` locally). Full gate green after the rebase: 38/38, `Cached: 0`.
