### PR TITLE
chore: clear the post-beta.54 rename residue an audit turned up

### DIFF
--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -1192,7 +1192,8 @@ export const packagesPaths = {
       operationId: "getAgentPackage",
       tags: ["Packages"],
       summary: "Get agent detail",
-      description: "Returns agent detail including integrations, config, state, and skills.",
+      description:
+        "Returns agent detail including `input`, `output`, and the `dependencies` group (skills, mcp_servers, integrations).",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XSpaceId" },
@@ -1204,7 +1205,7 @@ export const packagesPaths = {
           required: false,
           schema: { type: "string" },
           description:
-            "Which agent definition to project: `draft` (the live editor working copy), `published` (latest published), or a version spec (exact version, dist-tag, or semver range). **Omitting resolves the `draft`** (the editor default). A concrete version returns config / input / integrations / skills from that published manifest — the same definition the run executes (issue #770) — so the run-with-options modal stays consistent with the selected version. Ignored for system agents.",
+            "Which agent definition to project: `draft` (the live editor working copy), `published` (latest published), or a version spec (exact version, dist-tag, or semver range). **Omitting resolves the `draft`** (the editor default). A concrete version returns `input` / `output` / `dependencies` from that published manifest — the same definition the run executes (issue #770) — so the run-with-options modal stays consistent with the selected version. Ignored for system agents.",
         },
       ],
       responses: {

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -2673,7 +2673,7 @@ export interface paths {
         };
         /**
          * Get agent detail
-         * @description Returns agent detail including integrations, config, state, and skills.
+         * @description Returns agent detail including `input`, `output`, and the `dependencies` group (skills, mcp_servers, integrations).
          */
         get: operations["getAgentPackage"];
         /**
@@ -14480,7 +14480,7 @@ export interface operations {
     getAgentPackage: {
         parameters: {
             query?: {
-                /** @description Which agent definition to project: `draft` (the live editor working copy), `published` (latest published), or a version spec (exact version, dist-tag, or semver range). **Omitting resolves the `draft`** (the editor default). A concrete version returns config / input / integrations / skills from that published manifest — the same definition the run executes (issue #770) — so the run-with-options modal stays consistent with the selected version. Ignored for system agents. */
+                /** @description Which agent definition to project: `draft` (the live editor working copy), `published` (latest published), or a version spec (exact version, dist-tag, or semver range). **Omitting resolves the `draft`** (the editor default). A concrete version returns `input` / `output` / `dependencies` from that published manifest — the same definition the run executes (issue #770) — so the run-with-options modal stays consistent with the selected version. Ignored for system agents. */
                 version?: string;
             };
             header?: {

--- a/bun.lock
+++ b/bun.lock
@@ -472,7 +472,6 @@
     "@better-auth/cimd@1.7.0-beta.4": "patches/@better-auth%2Fcimd@1.7.0-beta.4.patch",
   },
   "overrides": {
-    "@ai-sdk/mcp": "^2.0.22",
     "@ai-sdk/provider-utils": "^5.0.18",
     "@ai-sdk/react": "^4.0.51",
     "ai": "^7.0.48",
@@ -2821,6 +2820,8 @@
 
     "ajv-formats/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 
+    "appstrate/@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "babel-plugin-macros/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
@@ -3020,6 +3021,8 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "appstrate/@types/bun/bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "babel-plugin-macros/cosmiconfig/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
   "overrides": {
     "zod": "4.4.3",
     "ai": "^7.0.48",
-    "@ai-sdk/mcp": "^2.0.22",
     "@ai-sdk/react": "^4.0.51",
     "@ai-sdk/provider-utils": "^5.0.18"
   },


### PR DESCRIPTION
A blind multi-agent audit of the 47 commits since `v1.0.0-beta.51` — the four renames (`application`→`space`, `document`→`file`, manifest `config`→`input`, chat unified onto Pi) — came back essentially clean in-tree. Four prior remediation passes (#1225, #1226, #1229, #1230) had already closed the real violations. These are the two leftovers it did find. Neither changes behaviour.

## Stale OpenAPI prose on `getAgentPackage`

Two description strings still advertised a `config` field that #1179 collapsed into `input`. They were wrong on four counts, not one — `AgentDetail` exposes:

```
id, display_name, description, source, scope, version,
manifest, prompt, lock_version, input, output, dependencies
```

There is no `config`, no `state`, no `skills`, and no top-level `integrations`; those last three live under the required `dependencies` group. Both strings now name the real shape, and `apps/web/src/api/schema.d.ts` is regenerated to match (doc comments only — no type change).

## Redundant `@ai-sdk/mcp` root declaration

#1173 dropped the AI SDK inference loop along with `@ai-sdk/anthropic` and `@ai-sdk/openai-compatible`. `@ai-sdk/mcp` was left declared with zero importers.

It is **not** dead weight in the install graph — `@ai-sdk/react` and `@assistant-ui/react-ai-sdk` both pin it transitively, which is why knip does not flag it. Removing the direct declaration changes nothing that resolves; it just stops claiming a dependency this repo does not use.

`bun.lock` also picks up two `appstrate/@types/bun` entries that `bun install` materialised on its own — pre-existing drift, not a consequence of this change.

## Verification

`bun run check` — **38/38 tasks, 4 cached** (34 genuinely ran). `verify:api-types` initially failed here and the pre-push hook caught it: editing an OpenAPI description invalidates the generated typed client, which is easy to miss when running gates individually.

## Not in this PR

The audit's one live defect is out-of-tree and needs an npm credential: `@afps-spec/schema` is pinned `^0.6.1` in three manifests, so `agent.schema.json` still declares the retired `config` section — the dashboard editor validates it **green** while the platform silently ignores it. The fix is publishing `0.7.0` (the rename is already on afps-spec `main`), which currently fails with `E404` on `PUT` — the repo's `NPM_TOKEN` lacks publish rights on the scope. Pins deliberately left at `^0.6.1`: declaring `^0.7.0` before it exists would break `bun install --frozen-lockfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)