### PR TITLE
Stop tallying mcp-server façade readers, derive them

### DIFF
--- a/packages/core/src/mcp-server.ts
+++ b/packages/core/src/mcp-server.ts
@@ -40,21 +40,21 @@ export type { McpServerManifest };
 // needs the runtime hint cannot tree-shake it away. Measured: +65 kB gzipped
 // on the integration detail page.
 //
-// `MCP_SERVER_APPSTRATE_META_KEY` is the one name in this list with no in-tree
-// reader through EITHER subpath (it is used inside both modules, never
-// imported across one), so a dead-export scan run with `includeEntryExports`
-// on `packages/core` reports THIS LINE. It stays: `./mcp-server` is the
-// complete façade by contract (core 6.2.0 CHANGELOG), `./mcp-server-meta` is
-// only the bundler escape hatch behind it, and dropping one of six names would
-// break that published subpath for an out-of-tree manifest author — the exact
-// consumer the key exists for — to save a re-export line. FIVE of the six are
-// read through the façade in-tree today — `MCP_SERVER_RUNTIME_CAPABILITIES` and
-// `MCP_SERVER_RUNTIMES` (`apps/api/src/modules/mcp/package-file-tools.ts`),
-// `isMcpServerRuntime` and the `McpServerRuntime` type (both sidecar
-// `integration-runtime-adapter-*.ts`), and `getMcpServerRuntime`
-// (`apps/api/src/services/integration-spawn-resolver.ts`) — so it is a live
-// façade, not a shim keeping an old import path alive. Only
-// `MCP_SERVER_APPSTRATE_META_KEY` itself has no in-tree reader.
+// A dead-export scan run with `includeEntryExports` on `packages/core` reports
+// THIS LINE, because at least one name below is used inside both modules and
+// imported across neither — `MCP_SERVER_APPSTRATE_META_KEY` is the standing
+// example. The list stays whole regardless: `./mcp-server` is the complete
+// façade by contract (core 6.2.0 CHANGELOG) and `./mcp-server-meta` is only
+// the bundler escape hatch behind it, so dropping a name to satisfy the scan
+// would break that published subpath for an out-of-tree manifest author — the
+// exact consumer the meta key exists for — to save a re-export line.
+//
+// Deliberately no tally of which names have in-tree façade readers: that set
+// moves whenever a call site swaps one helper for another, and a count written
+// here has already gone stale twice. Derive it instead —
+// `rg 'from "@appstrate/core/mcp-server"' --glob '!node_modules'` — and note
+// that a name reading zero is evidence about THIS repo only, never about the
+// published surface.
 export {
   MCP_SERVER_APPSTRATE_META_KEY,
   MCP_SERVER_RUNTIME_CAPABILITIES,


### PR DESCRIPTION
Follow-up to #1237, fixing a comment that #1236 falsified between review and merge.

#1237 corrected the comment under `mcp-server.ts`'s re-export block from "four of the six" to "five of the six". While it was in review, #1236 added `effectiveMcpServerType` to that block and swapped the one call site that read `getMcpServerRuntime` through the façade. Neither collided textually with the comment, so nothing flagged it — and both halves of the tally (the count and the list of readers) landed on `main` wrong.

That is twice in one day for the same sentence. The count is not the useful part of the comment and it cannot be kept true: it moves whenever a call site swaps one helper for another, and no gate watches it.

So the tally is gone. What remains is the part that does not drift — why a dead-export scan reports that line, and why the list stays whole anyway (`./mcp-server` is the complete façade by contract, `./mcp-server-meta` only the bundler escape hatch behind it, so dropping a name to satisfy the scan would break a published subpath for the out-of-tree manifest author the meta key exists for). In place of the count, a command to derive the current reader set, plus the note that a name reading zero is evidence about this repo only, never about the published surface.

Same treatment #1237 applied to the `EXECUTE format(` count in `docs/NO_TRANSITIONAL_CODE.md`, for the same reason.

Comment-only — no behaviour change, no export added or removed.

`bun run check` — 38/38, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)