### PR TITLE
test: assert catalog-derived cost against the catalog, not last week's prices

### DIFF
--- a/apps/api/test/integration/routes/model-provider-credentials.test.ts
+++ b/apps/api/test/integration/routes/model-provider-credentials.test.ts
@@ -10,7 +10,7 @@ import { createTestContext, authHeaders, type TestContext } from "../../helpers/
 import { seedOrgModelProviderOAuth } from "../../helpers/seed.ts";
 import { seedTestModelProviders } from "../../helpers/model-providers.ts";
 import { registerModelProvider } from "../../../src/services/model-providers/registry.ts";
-import { registerCatalog } from "../../../src/services/pricing-catalog.ts";
+import { registerCatalog, lookupCatalogModel } from "../../../src/services/pricing-catalog.ts";
 import xaiFeatured from "../../../src/data/featured-models.json" with { type: "json" };
 import type { CatalogModelEntry } from "@appstrate/shared-types";
 
@@ -88,12 +88,22 @@ describe("Model Provider Keys API", () => {
       expect(anthropic).toBeDefined();
       const haiku = anthropic!.models.find((m) => m.id === "claude-haiku-4-5-20251001");
       expect(haiku).toBeDefined();
-      expect(haiku!.cost).toEqual({
-        input: expect.closeTo(1, 4),
-        output: expect.closeTo(5, 4),
-        cacheRead: expect.closeTo(0.1, 4),
-        cacheWrite: expect.closeTo(1.25, 4),
-      });
+      // Assert the route SERVES WHAT THE CATALOG HOLDS, not a transcription of
+      // what it held the day this was written. `apps/api/src/data/pricing/*` is
+      // refreshed weekly by a bot (`chore(pricing): refresh LiteLLM pricing
+      // catalog`), so a literal price turns every vendor repricing into a red
+      // `main` — which is exactly what the xai assertion below did on
+      // 2026-09-02 when xAI moved grok from $3/$15 to $1.25/$2.50.
+      //
+      // Not vacuous: the serializer can still drop the field, read the wrong
+      // provider or model, or reshape the object, and each of those fails here.
+      // What it can no longer do is fail because a vendor changed a price. The
+      // `toBeDefined` guard is the other half — without it a catalog that
+      // stopped pricing this model would compare undefined to undefined and go
+      // green while the route served nothing.
+      const haikuCatalogCost = lookupCatalogModel("anthropic", "claude-haiku-4-5-20251001")?.cost;
+      expect(haikuCatalogCost).toBeDefined();
+      expect(haiku!.cost).toEqual(haikuCatalogCost);
     });
 
     it("marks featured catalog models with featured: true (xai)", async () => {
@@ -119,12 +129,26 @@ describe("Model Provider Keys API", () => {
       for (const id of generated) {
         expect(xai!.models.find((m) => m.id === id)?.featured).toBe(true);
       }
-      // Catalog-derived cost still flows for non-featured models.
+      // Catalog-derived cost still flows for non-featured models. Compared
+      // against the catalog rather than a literal, for the reason spelled out
+      // on the anthropic test above.
       const grok4 = xai!.models.find((m) => m.id === "grok-4");
-      expect(grok4?.cost).toEqual({ input: 3, output: 15 });
-      // A non-featured xai model surfaces too.
-      const grok2 = xai!.models.find((m) => m.id === "grok-2");
-      expect(grok2?.featured).toBe(false);
+      const grok4CatalogCost = lookupCatalogModel("xai", "grok-4")?.cost;
+      expect(grok4CatalogCost).toBeDefined();
+      expect(grok4?.cost).toEqual(grok4CatalogCost);
+      // A non-featured xai model surfaces too, flagged `featured: false`.
+      //
+      // Picked from the response rather than named: `grok-2` used to be the
+      // literal here and the 2026-09-02 catalog refresh DELETED it upstream, so
+      // the assertion started reading `undefined?.featured` and failed on a
+      // model that no longer exists. The property is "everything outside the
+      // generated list is flagged false", which needs no particular model to
+      // survive a vendor's catalog.
+      const nonFeatured = xai!.models.filter((m) => !generated.includes(m.id));
+      expect(nonFeatured.length).toBeGreaterThan(0);
+      for (const m of nonFeatured) {
+        expect(m.featured).toBe(false);
+      }
     });
 
     it("projects only requested fields and drops the heavy models catalog", async () => {


### PR DESCRIPTION
Fixes the red `Integration tests` job on `main`.

## What broke

The weekly pricing bot — `chore(pricing): refresh LiteLLM pricing catalog` (#1239) — broke `model-provider-credentials.test.ts` in two ways. Both are the same defect: **the test named values the vendor owns.**

| | Pinned | What the refresh did |
|---|---|---|
| cost | `grok-4` → literal `{ input: 3, output: 15 }` | xAI repriced to `{ input: 1.25, output: 2.5, cacheRead: 0.2 }` |
| model id | `grok-2`, looked up by id | deleted upstream — the assertion started reading `undefined?.featured` |

Neither the number nor the model id is the property under test.

The `haiku` assertion just above had the same shape (four `expect.closeTo` literals against the anthropic catalog) and was one repricing away from an identical failure, so it moves too rather than being left as the next landmine.

## What it asserts now

The cost checks read `lookupCatalogModel(providerId, modelId)?.cost` — the exact call the test's own docstring already says the serializer must make:

> *"the registry serializer must derive it via `lookupCatalogModel(providerId, modelId)?.cost`. If this regresses, the form UI and the run cost would diverge again."*

The non-featured check derives its subject from the response instead of naming a model, asserting the real invariant — *everything outside the generated featured list is flagged `false`* — which no vendor can retire.

**This is not a vacuous test.** The serializer can still drop the field, read the wrong provider or model, or reshape the object, and each of those fails here. A `toBeDefined` guard on the catalog side is the other half: without it, a model the catalog stops pricing would compare `undefined` to `undefined` and go green while the route served nothing. What the test can no longer do is fail because a vendor changed a price.

## Swept for the rest

The two remaining `{ input: 3, output: 15 }` literals, in `routes/models.test.ts`, are a **user-supplied cost override** round-tripped through the API — the literal is the request body, not a catalog value. Unaffected by a refresh; left alone.

## Verification

`bun run check` 38/38. The file is 25/25 (was 24/25 on `main`), pricing-adjacent suites 77/77.

Note this could not have been caught on the originating PR: `Integration tests` only runs on `main`, and #1239 is a bot commit that lands there directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)