### PR TITLE
chore: bump compose version fallbacks to 1.0.0-beta.56

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -140,8 +140,8 @@ CONNECTION_ENCRYPTION_KEY=jChGxOEG1YjCtrkrTYhO7FFdIKaHpe/j1PBY/LqID6s=
 # `sha-<sha>`) — APP_VERSION is a git ref name and can only ever equal a
 # `{{version}}` tag. In all of those the two images are still checked against
 # each other, which is what keeps the zero-config dev defaults working.
-# PI_IMAGE=ghcr.io/appstrate/appstrate-pi:1.0.0-beta.55
-# SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:1.0.0-beta.55
+# PI_IMAGE=ghcr.io/appstrate/appstrate-pi:1.0.0-beta.56
+# SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:1.0.0-beta.56
 # Per-integration MCP runner images. Forwarded to the sidecar, which spawns
 # one runner container per local AFPS integration (server.type). Absent =>
 # bare ":latest" default, resolvable only on a host that ran

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,12 +148,12 @@ services:
   # Without this, the first execution would block on a slow image pull.
   # These containers exit immediately after pulling.
   appstrate-pi:
-    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   appstrate-sidecar:
-    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
@@ -162,27 +162,27 @@ services:
   # Pre-pulled so the first integration boot doesn't block on — or fail at —
   # an on-demand pull.
   appstrate-mcp-runner-node:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   appstrate-mcp-runner-python:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   appstrate-mcp-runner-bun:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   appstrate-mcp-runner-uv:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   appstrate-mcp-runner-binary:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
@@ -249,7 +249,7 @@ services:
   #     - /var/run/docker.sock:/var/run/docker.sock:ro
 
   appstrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
       - appstrate-public
@@ -295,16 +295,16 @@ services:
       # from the effective container hostname. Forwarding `${PLATFORM_API_URL:-}`
       # injects an empty string, which bypasses the auto-detection path.
       # Set it only if you need to point sidecars at a different host.
-      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # Runner images forwarded to the sidecar (SIDECAR_OPERATOR_ENV_KEYS) so
       # it spawns integration runners from GHCR instead of bare `:latest` tags
       # (which the daemon would try — and fail — to pull from Docker Hub).
-      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # ── System config (JSON arrays) ──
       - SYSTEM_PROVIDER_KEYS
       - SYSTEM_PROXIES

--- a/examples/self-hosting/.env.example
+++ b/examples/self-hosting/.env.example
@@ -363,7 +363,7 @@ POSTGRES_PASSWORD=<generate-with-openssl-rand-base64-32>
 # not exist and pulling it fails. The compose files therefore fall back to a
 # hardcoded release tag; set this explicitly to control which one you run.
 # `appstrate install` writes it for you.
-# APPSTRATE_VERSION=1.0.0-beta.55
+# APPSTRATE_VERSION=1.0.0-beta.56
 
 # Override individual runtime images (e.g. private registry mirrors).
 # PI_IMAGE=ghcr.io/appstrate/appstrate-pi:latest

--- a/examples/self-hosting/docker-compose.tier1.yml
+++ b/examples/self-hosting/docker-compose.tier1.yml
@@ -65,7 +65,7 @@ services:
   # happens in the platform's own boot pass, which is another reason not to
   # "optimise" the platform's migration step away.
   migrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
     restart: "no"
@@ -78,12 +78,12 @@ services:
 
   # ── Pre-pull runtime images ─────────────────────────────────
   pi-pull:
-    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   sidecar-pull:
-    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
@@ -91,33 +91,33 @@ services:
   # platform) `docker create`s these, and it never issues an image pull — an
   # absent image is a hard failure at integration boot, not a slow first run.
   mcp-runner-node-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-python-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-bun-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-uv-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-binary-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   # ── Appstrate platform ─────────────────────────────────────
   appstrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
       - appstrate-public
@@ -155,19 +155,19 @@ services:
       # default which points at Docker Hub).
       - PORT=3000
       - DOCKER_SOCKET=/var/run/docker.sock
-      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # Per-integration MCP runner images. The sidecar `docker create`s one of
       # these per LOCAL AFPS integration; the refs are forwarded into the
       # sidecar via SIDECAR_OPERATOR_ENV_KEYS. Without them the sidecar falls
       # back to bare `appstrate-mcp-runner-*:latest` tags, which the daemon
       # tries — and fails — to pull from Docker Hub, so every local
       # integration dies at boot. Same APPSTRATE_VERSION coupling as above.
-      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # ── Intentional overrides (YAML default ≠ code default) ──────
       # RUN_ADAPTER: code default is `process` for OSS dev — a
       # containerized self-host must run agents in Docker.

--- a/examples/self-hosting/docker-compose.tier2.yml
+++ b/examples/self-hosting/docker-compose.tier2.yml
@@ -76,7 +76,7 @@ services:
   # happens in the platform's own boot pass, which is another reason not to
   # "optimise" the platform's migration step away.
   migrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
     restart: "no"
@@ -89,12 +89,12 @@ services:
 
   # ── Pre-pull runtime images ─────────────────────────────────
   pi-pull:
-    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   sidecar-pull:
-    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
@@ -102,33 +102,33 @@ services:
   # platform) `docker create`s these, and it never issues an image pull — an
   # absent image is a hard failure at integration boot, not a slow first run.
   mcp-runner-node-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-python-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-bun-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-uv-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-binary-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   # ── Appstrate platform ─────────────────────────────────────
   appstrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
       - appstrate-public
@@ -166,19 +166,19 @@ services:
       # default which points at Docker Hub).
       - PORT=3000
       - DOCKER_SOCKET=/var/run/docker.sock
-      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # Per-integration MCP runner images. The sidecar `docker create`s one of
       # these per LOCAL AFPS integration; the refs are forwarded into the
       # sidecar via SIDECAR_OPERATOR_ENV_KEYS. Without them the sidecar falls
       # back to bare `appstrate-mcp-runner-*:latest` tags, which the daemon
       # tries — and fails — to pull from Docker Hub, so every local
       # integration dies at boot. Same APPSTRATE_VERSION coupling as above.
-      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # ── Intentional overrides (YAML default ≠ code default) ──────
       # RUN_ADAPTER: code default is `process` for OSS dev — a
       # containerized self-host must run agents in Docker.

--- a/examples/self-hosting/docker-compose.tier3.yml
+++ b/examples/self-hosting/docker-compose.tier3.yml
@@ -131,7 +131,7 @@ services:
   # happens in the platform's own boot pass, which is another reason not to
   # "optimise" the platform's migration step away.
   migrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
     restart: "no"
@@ -144,12 +144,12 @@ services:
 
   # ── Pre-pull runtime images ─────────────────────────────────
   pi-pull:
-    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   sidecar-pull:
-    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
@@ -157,33 +157,33 @@ services:
   # platform) `docker create`s these, and it never issues an image pull — an
   # absent image is a hard failure at integration boot, not a slow first run.
   mcp-runner-node-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-python-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-bun-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-uv-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-binary-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   # ── Appstrate platform ─────────────────────────────────────
   appstrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
       - appstrate-public
@@ -229,19 +229,19 @@ services:
       # default which points at Docker Hub).
       - PORT=3000
       - DOCKER_SOCKET=/var/run/docker.sock
-      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # Per-integration MCP runner images. The sidecar `docker create`s one of
       # these per LOCAL AFPS integration; the refs are forwarded into the
       # sidecar via SIDECAR_OPERATOR_ENV_KEYS. Without them the sidecar falls
       # back to bare `appstrate-mcp-runner-*:latest` tags, which the daemon
       # tries — and fails — to pull from Docker Hub, so every local
       # integration dies at boot. Same APPSTRATE_VERSION coupling as above.
-      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # ── Intentional overrides (YAML default ≠ code default) ──────
       # RUN_ADAPTER: code default is `process` for OSS dev — a
       # containerized self-host must run agents in Docker.

--- a/examples/self-hosting/docker-compose.yml
+++ b/examples/self-hosting/docker-compose.yml
@@ -129,7 +129,7 @@ services:
   # happens in the platform's own boot pass, which is another reason not to
   # "optimise" the platform's migration step away.
   migrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
     restart: "no"
@@ -142,12 +142,12 @@ services:
 
   # ── Pre-pull runtime images ─────────────────────────────────
   pi-pull:
-    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   sidecar-pull:
-    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
@@ -155,33 +155,33 @@ services:
   # platform) `docker create`s these, and it never issues an image pull — an
   # absent image is a hard failure at integration boot, not a slow first run.
   mcp-runner-node-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-python-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-bun-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-uv-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   mcp-runner-binary-pull:
-    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
     entrypoint: ["true"]
     restart: "no"
 
   # ── Appstrate platform ─────────────────────────────────────
   appstrate:
-    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.55}
+    image: ghcr.io/appstrate/appstrate:${APPSTRATE_VERSION:-1.0.0-beta.56}
     networks:
       - appstrate-data
       - appstrate-public
@@ -227,19 +227,19 @@ services:
       # default which points at Docker Hub).
       - PORT=3000
       - DOCKER_SOCKET=/var/run/docker.sock
-      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - PI_IMAGE=ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - SIDECAR_IMAGE=ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # Per-integration MCP runner images. The sidecar `docker create`s one of
       # these per LOCAL AFPS integration; the refs are forwarded into the
       # sidecar via SIDECAR_OPERATOR_ENV_KEYS. Without them the sidecar falls
       # back to bare `appstrate-mcp-runner-*:latest` tags, which the daemon
       # tries — and fails — to pull from Docker Hub, so every local
       # integration dies at boot. Same APPSTRATE_VERSION coupling as above.
-      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.55}
-      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.55}
+      - RUNNER_IMAGE_NODE=ghcr.io/appstrate/appstrate-mcp-runner-node:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_PYTHON=ghcr.io/appstrate/appstrate-mcp-runner-python:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BUN=ghcr.io/appstrate/appstrate-mcp-runner-bun:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_UV=ghcr.io/appstrate/appstrate-mcp-runner-uv:${APPSTRATE_VERSION:-1.0.0-beta.56}
+      - RUNNER_IMAGE_BINARY=ghcr.io/appstrate/appstrate-mcp-runner-binary:${APPSTRATE_VERSION:-1.0.0-beta.56}
       # ── Intentional overrides (YAML default ≠ code default) ──────
       # RUN_ADAPTER: code default is `process` for OSS dev — a
       # containerized self-host must run agents in Docker.


### PR DESCRIPTION
## Summary

Bumps every `${APPSTRATE_VERSION:-…}` compose fallback and `.env.example` pin from `1.0.0-beta.55` to `1.0.0-beta.56` — 82 sites across 11 tracked files, the same shape as #1240.

`verify:release-version` takes the exact arm on a `v*` tag push, so this must land **before** `v1.0.0-beta.56` is tagged. Locally: `✓ 82 hardcoded version site(s) … all name 1.0.0-beta.56 (ahead of newest git tag v1.0.0-beta.55 — a release bump in flight)`.

## Type of Change

- [x] Chore / release plumbing

## Checklist

- [x] `bun run check` passes (pre-push gate)
- [x] `bun run verify:release-version` passes in floor mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)