### PR TITLE
test(cli): sort readdir before asserting the plugin skill list

### DIFF
--- a/apps/cli/test/skills-command.test.ts
+++ b/apps/cli/test/skills-command.test.ts
@@ -165,7 +165,10 @@ describe("skills sync — claude-plugin target", () => {
 
     await skillsSyncCommand({}, io);
 
-    expect(await readdir(join(pluginRoot(), "skills"))).toEqual(["other-reports", "pdf-tools"]);
+    expect((await readdir(join(pluginRoot(), "skills"))).sort()).toEqual([
+      "other-reports",
+      "pdf-tools",
+    ]);
     expect(stderr()).toContain('Renamed @other/reports to "other-reports"');
   });
 


### PR DESCRIPTION
## Summary

`Unit tests` failed on #1253 (a compose-only PR) in `skills sync — claude-plugin target > renames a colliding skill and says so on stderr`: both directories were present, in the other order. `readdir` order is filesystem-defined — APFS returns entries sorted, ext4 does not — so the assertion at `apps/cli/test/skills-command.test.ts:168` passed locally and on #1251's runner by luck. It now sorts like every other multi-entry `readdir` assertion in the file; the source already sorts (`targets.ts` `entriesMatch`).

## Type of Change

- [x] Test fix

## Checklist

- [x] `bun run check` passes (pre-push gate)
- [x] `bun test apps/cli/test/skills-command.test.ts` — 58 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)