### PR TITLE
fix(release): keep npm-package releases out of GitHub's "latest"

### DIFF
--- a/.github/workflows/publish-afps-shared.yml
+++ b/.github/workflows/publish-afps-shared.yml
@@ -80,3 +80,10 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
+          # Never GitHub's "latest": `appstrate self-update`, `bootstrap.sh`
+          # and `bootstrap-runner.sh` resolve `releases/latest` and expect a
+          # platform `v*` tag carrying the CLI binaries. Every non-`v*`
+          # release published before this line was "latest" until the next
+          # `v*` tag and broke all three in the meantime (cli@1.0.0-beta.56:
+          # `vcli@1.0.0-beta.56/checksums.txt.minisig` → 404).
+          make_latest: false

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -185,3 +185,10 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
+          # Never GitHub's "latest": `appstrate self-update`, `bootstrap.sh`
+          # and `bootstrap-runner.sh` resolve `releases/latest` and expect a
+          # platform `v*` tag carrying the CLI binaries. Every non-`v*`
+          # release published before this line was "latest" until the next
+          # `v*` tag and broke all three in the meantime (cli@1.0.0-beta.56:
+          # `vcli@1.0.0-beta.56/checksums.txt.minisig` → 404).
+          make_latest: false

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -160,3 +160,10 @@ jobs:
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           generate_release_notes: true
+          # Never GitHub's "latest": `appstrate self-update`, `bootstrap.sh`
+          # and `bootstrap-runner.sh` resolve `releases/latest` and expect a
+          # platform `v*` tag carrying the CLI binaries. Every non-`v*`
+          # release published before this line was "latest" until the next
+          # `v*` tag and broke all three in the meantime (cli@1.0.0-beta.56:
+          # `vcli@1.0.0-beta.56/checksums.txt.minisig` → 404).
+          make_latest: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -343,6 +343,18 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
   runs predating the stamp, such rows now carry the runtime dot instead of the
   speech-bubble icon. Text, ordering, level colour and grouping are unchanged.
 
+### Fixed
+
+- **`appstrate self-update`, `bootstrap.sh` and `bootstrap-runner.sh` no longer
+  break for the days between an npm release and the next platform tag.** The
+  `cli@`, `core@` and `afps-shared@` publish workflows each create a GitHub
+  Release, and GitHub made the newest one "latest" — so `releases/latest`
+  answered `cli@1.0.0-beta.56`, the CLI prefixed it with `v` and asked for
+  `vcli@1.0.0-beta.56/checksums.txt.minisig` (404). Every one of the 15
+  non-`v*` releases to date opened such a window. Those workflows now pass
+  `make_latest: false`, and the CLI names a non-platform `latest` tag instead
+  of building a URL from it.
+
 ### Removed
 
 - **BREAKING (operators): migration `0055` drops `org_invitations.accepted_by`

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -389,7 +389,18 @@ export async function resolveTargetVersion(
   ) {
     throw new Error(`GitHub Releases API response missing tag_name.`);
   }
-  return normalizeVersion((parsed as { tag_name: string }).tag_name);
+  const tag = (parsed as { tag_name: string }).tag_name;
+  // Only a platform `v<semver>` release carries the CLI binaries. The npm
+  // workflows (`cli@`, `core@`, `afps-shared@`) publish their own GitHub
+  // Releases with `make_latest: false`; should one still come back here, name
+  // it instead of building `releases/download/vcli@…` and reporting a 404.
+  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(tag)) {
+    throw new Error(
+      `GitHub's latest release is "${tag}", not a platform v* release. ` +
+        `Pin one with --release X.Y.Z, or mark the newest v* release as latest.`,
+    );
+  }
+  return normalizeVersion(tag);
 }
 
 interface PerformCurlUpdateOptions {

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -195,6 +195,14 @@ describe("resolveTargetVersion", () => {
     expect(calls).toEqual(["https://api.github.com/repos/appstrate/appstrate/releases/latest"]);
   });
 
+  it("names a non-platform latest release instead of building a v-prefixed URL", async () => {
+    await expect(
+      resolveTargetVersion(undefined, {
+        fetchText: async () => JSON.stringify({ tag_name: "cli@1.0.0-beta.56" }),
+      }),
+    ).rejects.toThrow(/"cli@1\.0\.0-beta\.56", not a platform v\* release/);
+  });
+
   it("throws on malformed GitHub response", async () => {
     await expect(
       resolveTargetVersion(undefined, { fetchText: async () => "not json" }),


### PR DESCRIPTION
## Summary

Reported right after the beta.56 deploy:

```
appstrate self-update
Update failed: GET https://github.com/appstrate/appstrate/releases/download/vcli@1.0.0-beta.56/checksums.txt.minisig → 404 Not Found
```

`publish-cli.yml`, `publish-core.yml` and `publish-afps-shared.yml` each create a GitHub Release (softprops), and GitHub marks the newest non-prerelease release as **latest**. `appstrate self-update` resolves `releases/latest` and prefixes the tag with `v`; `scripts/bootstrap.sh` and `scripts/bootstrap-runner.sh` hit `releases/latest/download/…` directly. All three expect a platform `v*` tag carrying the CLI binaries. Every one of the 15 non-`v*` releases to date (`cli@`, `core@`, `afps-shared@`) opened such a window until the next `v*` tag — `cli@1.0.0-beta.54` → `v1.0.0-beta.55` was four days.

- The three publish workflows pass `make_latest: false`.
- `resolveTargetVersion` rejects a latest tag that is not `v<semver>` with a message naming it (`GitHub's latest release is "cli@1.0.0-beta.56", not a platform v* release…`) instead of building a URL from it. One test.
- Immediate mitigation already applied: `gh release edit v1.0.0-beta.56 --latest` — `releases/latest` answers `v1.0.0-beta.56` again.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `bun run check` passes (pre-push gate)
- [x] `bun test apps/cli/test/self-update.test.ts` — 40 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)