### PR TITLE
fix(cli): reap the skills-sync lock as soon as its owner is dead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -345,6 +345,15 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
 
 ### Fixed
 
+- **A killed `appstrate skills sync` no longer locks the next ten minutes of
+  sessions out.** Closing a Claude Code session seconds after opening it kills
+  the background sync it spawned, and the `mkdir` lock only expired by age —
+  every session in the following ten minutes reported `Another appstrate
+skills sync is running` and kept the stale plugin. The lock now records its
+  owner's pid and is reaped the moment that pid is gone; SIGTERM/SIGHUP release
+  it through the shutdown coordinator. Age remains the fallback for a lock
+  whose owner cannot be read.
+
 - **`appstrate self-update`, `bootstrap.sh` and `bootstrap-runner.sh` no longer
   break for the days between an npm release and the next platform tag.** The
   `cli@`, `core@` and `afps-shared@` publish workflows each create a GitHub

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -449,7 +449,7 @@ A skill whose refresh fails keeps the version already on disk and its state entr
 Skipped @acme/pdf-tools on codex: /home/you/.agents/skills/pdf-tools exists and is not managed by appstrate — remove or rename it
 ```
 
-There is no automatic rename: remove or rename the directory yourself and re-run. While a sync is in flight, staging happens under a dot-prefixed `.appstrate-staging/`, so neither Claude Code nor Codex can pick up a half-written skill.
+There is no automatic rename: remove or rename the directory yourself and re-run. While a sync is in flight, staging happens under a dot-prefixed `.appstrate-staging/`, so neither Claude Code nor Codex can pick up a half-written skill. Concurrent syncs (two Claude Code sessions opening together) are serialized by a lock under `skills-sync/`; it records its owner's pid and is reaped as soon as that process is gone, so a sync killed mid-run never blocks the next one.
 
 Ownership is recorded per target **together with the root it was written under**. `HOME` is not a constant — the same profile run from cron, `launchd`, `sudo -E` or a devcontainer can resolve a different `~/.agents/skills` — so a state file whose recorded root does not match the current one is read as claiming nothing. Every directory it finds is then treated as unmanaged: refused, never overwritten.
 

--- a/apps/cli/src/lib/skills-sync/lock.ts
+++ b/apps/cli/src/lib/skills-sync/lock.ts
@@ -4,12 +4,16 @@
  * Two Claude Code sessions opened together each fire the background command,
  * and nothing survives that: the swaps race and the ledger's last writer wins.
  * A directory is the lock because `mkdir` is atomically create-or-fail
- * everywhere; `mtime` dates it, so a killed process's lock expires.
+ * everywhere. It records its owner's pid: a session closed seconds after it
+ * opened kills the sync it spawned, and a lock that only expired by age left
+ * every session of the next ten minutes failing "busy". `mtime` stays as the
+ * fallback for a lock whose owner cannot be read.
  */
 
-import { mkdir, rm, stat } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getDataDir } from "../config.ts";
+import { onShutdown } from "../shutdown.ts";
 
 export interface SyncLockOptions {
   timeoutMs?: number;
@@ -22,9 +26,12 @@ const DEFAULTS: Required<SyncLockOptions> = {
   // Fits a large org's first sync, inside a marketplace command's timeout.
   timeoutMs: 60_000,
   pollMs: 500,
-  // Far above any plausible sync: only ever fires for a dead process.
+  // Only consulted when the owner pid cannot be read; a dead owner is reaped
+  // at once regardless of age.
   staleMs: 10 * 60_000,
 };
+
+const OWNER_FILE = "owner";
 
 export class SyncLockBusyError extends Error {
   constructor() {
@@ -49,15 +56,20 @@ export async function withSyncLock<T>(
   const deadline = Date.now() + timeoutMs;
   for (;;) {
     if (await tryAcquire(path)) break;
-    if (await reapIfStale(path, staleMs)) continue;
+    if (await reapIfAbandoned(path, staleMs)) continue;
     if (Date.now() >= deadline) throw new SyncLockBusyError();
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
 
+  const release = (): Promise<void> => rm(path, { recursive: true, force: true }).catch(() => {});
+  // SIGTERM/SIGHUP from a closing session: release before the exit the
+  // coordinator performs. SIGKILL cannot be caught — the owner pid covers it.
+  const unregister = onShutdown(release);
   try {
     return await body();
   } finally {
-    await rm(path, { recursive: true, force: true }).catch(() => {});
+    unregister();
+    await release();
   }
 }
 
@@ -65,21 +77,43 @@ async function tryAcquire(path: string): Promise<boolean> {
   try {
     // No `recursive`: it would succeed on an existing directory.
     await mkdir(path, { mode: 0o700 });
-    return true;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "EEXIST") return false;
     throw err;
   }
+  await writeFile(join(path, OWNER_FILE), String(process.pid));
+  return true;
 }
 
-/** Remove a lock whose age proves its owner is gone. Returns whether it did. */
-async function reapIfStale(path: string, staleMs: number): Promise<boolean> {
+/**
+ * Remove a lock whose owner is gone — its pid no longer exists, or it has no
+ * readable owner and is older than `staleMs`. Returns whether it did.
+ */
+async function reapIfAbandoned(path: string, staleMs: number): Promise<boolean> {
+  let abandoned: boolean;
   try {
-    const stats = await stat(path);
-    if (Date.now() - stats.mtimeMs < staleMs) return false;
+    const pid = Number((await readFile(join(path, OWNER_FILE), "utf-8")).trim());
+    abandoned = Number.isInteger(pid) && pid > 0 && !isAlive(pid);
   } catch {
-    return true; // vanished since the failed `mkdir` — the next attempt takes it
+    // Between the holder's `mkdir` and its owner write, or an unreadable file:
+    // age decides.
+    try {
+      abandoned = Date.now() - (await stat(path)).mtimeMs >= staleMs;
+    } catch {
+      return true; // vanished since the failed `mkdir` — the next attempt takes it
+    }
   }
+  if (!abandoned) return false;
   await rm(path, { recursive: true, force: true }).catch(() => {});
   return true;
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // EPERM: exists, owned by someone else — alive. Only ESRCH proves death.
+    return (err as NodeJS.ErrnoException).code !== "ESRCH";
+  }
 }

--- a/apps/cli/test/skills-lock.test.ts
+++ b/apps/cli/test/skills-lock.test.ts
@@ -5,13 +5,13 @@
  *
  * Tested through the helper rather than the command: the production timings
  * are a 60-second wait and a 10-minute staleness window, and a suite that
- * exercised them for real would take eleven minutes to say what four
+ * exercised them for real would take eleven minutes to say what a handful of
  * millisecond-scale cases say here. The command wires the defaults; these
  * cases pin the behaviour those defaults select.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { lstat, mkdir, mkdtemp, rm, utimes } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getLockPath, SyncLockBusyError, withSyncLock } from "../src/lib/skills-sync/lock.ts";
@@ -77,9 +77,17 @@ describe("withSyncLock", () => {
     expect(order).toEqual(["first:start", "first:end", "second:start"]);
   });
 
-  it("gives up with a busy error when the holder never lets go", async () => {
+  it("records its own pid as the lock's owner", async () => {
+    await withSyncLock(async () => {
+      expect(await readFile(join(getLockPath(), "owner"), "utf-8")).toBe(String(process.pid));
+    });
+  });
+
+  it("gives up with a busy error when the holder is alive and never lets go", async () => {
     await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
     await mkdir(getLockPath());
+    // This process IS the holder, so the owner is provably alive.
+    await writeFile(join(getLockPath(), "owner"), String(process.pid));
 
     await expect(
       withSyncLock(async () => "never", { timeoutMs: 30, pollMs: 5 }),
@@ -88,7 +96,20 @@ describe("withSyncLock", () => {
     expect(await exists(getLockPath())).toBe(true);
   });
 
-  it("reaps a lock old enough to prove its owner is gone", async () => {
+  it("reaps a fresh lock whose owner pid is dead", async () => {
+    await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
+    await mkdir(getLockPath());
+    // A process that has already exited: the pid it had is provably dead.
+    const gone = Bun.spawnSync(["true"]).pid;
+    await writeFile(join(getLockPath(), "owner"), String(gone));
+
+    // Fresh mtime, so the age rule alone would report busy: the owner rule
+    // is what makes this pass.
+    expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
+    expect(await exists(getLockPath())).toBe(false);
+  });
+
+  it("reaps an ownerless lock old enough to prove its owner is gone", async () => {
     await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
     await mkdir(getLockPath());
     const longAgo = new Date(Date.now() - 60 * 60_000);


### PR DESCRIPTION
## Summary

Reproduced twice while testing the beta.56 plugin: a Claude Code session closed seconds after opening kills the background `appstrate skills sync` it spawned (SIGKILL — no `finally`), the `mkdir` lock stays, and its only expiry was a 10-minute age rule. Every session in that window reported `Another appstrate skills sync is running` and kept the stale plugin, which read as "my new skill does not sync".

- The lock directory now carries an `owner` file with the holder's pid. A contender reaps the lock the moment `process.kill(pid, 0)` reports `ESRCH`; `EPERM` counts as alive.
- SIGTERM/SIGHUP release the lock through the existing shutdown coordinator (`onShutdown`), unregistered in the `finally`.
- Age (`staleMs`) remains the fallback for a lock whose owner file cannot be read (the window between the holder's `mkdir` and its write).
- Tests: owner pid recorded; alive owner + fresh lock → busy; dead owner + fresh lock → taken; ownerless old lock → taken. Verified end to end with a planted orphan lock on a real machine: the next run took it at once.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `bun run check` passes (pre-push gate)
- [x] `bun test apps/cli/test/skills-lock.test.ts apps/cli/test/skills-command.test.ts` — 65 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)