### PR TITLE
fix(cli): lock skills sync with flock(2) so a killed holder never blocks the next run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,10 +349,11 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
   sessions out.** Closing a Claude Code session seconds after opening it kills
   the background sync it spawned, and the `mkdir` lock only expired by age —
   every session in the following ten minutes reported `Another appstrate
-skills sync is running` and kept the stale plugin. The lock now records its
-  owner's pid and is reaped the moment that pid is gone; SIGTERM/SIGHUP release
-  it through the shutdown coordinator. Age remains the fallback for a lock
-  whose owner cannot be read.
+skills sync is running` and kept the stale plugin. The lock is now
+  `flock(2)` on `skills-sync/sync.lock` (through `bun:ffi` — Bun is the
+  runtime on every channel): the kernel releases it when the holder ends,
+  however it ends, so there is no pid to trust, no age to guess and nothing
+  left behind.
 
 - **`appstrate self-update`, `bootstrap.sh` and `bootstrap-runner.sh` no longer
   break for the days between an npm release and the next platform tag.** The

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -777,7 +777,8 @@ $XDG_CONFIG_HOME/appstrate/              (or ~/.config/appstrate/)
 
 $XDG_DATA_HOME/appstrate/                (or ~/.local/share/appstrate/)
 ├── claude-plugin/                       # generated Claude Code plugin (`appstrate skills sync`)
-└── skills-sync/state.json               # which skill directory each target owns, and from which artifact
+├── skills-sync/state.json               # which skill directory each target owns, and from which artifact
+└── skills-sync/sync.lock                # flock(2) target serializing concurrent syncs (never removed)
 ```
 
 `skills-sync/state.json` lives outside every target tree on purpose: the generated plugin's version is the hash of its contents, so a state blob inside it would make each sync look like a new plugin version. It is also the only record of which directories in the shared `~/.agents/skills/` and `~/.claude/skills/` belong to the sync.

--- a/apps/cli/src/lib/skills-sync/lock.ts
+++ b/apps/cli/src/lib/skills-sync/lock.ts
@@ -4,13 +4,15 @@
  * Two Claude Code sessions opened together each fire the background command,
  * and nothing survives that: the swaps race and the ledger's last writer wins.
  * A directory is the lock because `mkdir` is atomically create-or-fail
- * everywhere. It records its owner's pid: a session closed seconds after it
- * opened kills the sync it spawned, and a lock that only expired by age left
- * every session of the next ten minutes failing "busy". `mtime` stays as the
- * fallback for a lock whose owner cannot be read.
+ * everywhere. Two facts decide whether a lock still has an owner: the pid it
+ * recorded (gone = reaped at once, which covers a session closing seconds
+ * after it opened and SIGKILL-ing the sync it spawned) and a heartbeat — the
+ * holder touches the lock's `mtime` while it runs, so a pid that was reused,
+ * a zombie or a frozen holder is reaped once the beat stops. Neither is
+ * consulted alone.
  */
 
-import { mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getDataDir } from "../config.ts";
 import { onShutdown } from "../shutdown.ts";
@@ -18,7 +20,9 @@ import { onShutdown } from "../shutdown.ts";
 export interface SyncLockOptions {
   timeoutMs?: number;
   pollMs?: number;
-  /** A lock older than this belonged to a process that is gone. */
+  /** How often the holder touches the lock's `mtime`. */
+  heartbeatMs?: number;
+  /** A lock whose last beat is older than this belonged to a holder that is gone. */
   staleMs?: number;
 }
 
@@ -26,9 +30,9 @@ const DEFAULTS: Required<SyncLockOptions> = {
   // Fits a large org's first sync, inside a marketplace command's timeout.
   timeoutMs: 60_000,
   pollMs: 500,
-  // Only consulted when the owner pid cannot be read; a dead owner is reaped
-  // at once regardless of age.
-  staleMs: 10 * 60_000,
+  heartbeatMs: 2_000,
+  // Several missed beats: a scheduler hiccup must not look like a death.
+  staleMs: 15_000,
 };
 
 const OWNER_FILE = "owner";
@@ -49,7 +53,7 @@ export async function withSyncLock<T>(
   body: () => Promise<T>,
   options: SyncLockOptions = {},
 ): Promise<T> {
-  const { timeoutMs, pollMs, staleMs } = { ...DEFAULTS, ...options };
+  const { timeoutMs, pollMs, heartbeatMs, staleMs } = { ...DEFAULTS, ...options };
   const path = getLockPath();
   await mkdir(join(getDataDir(), "skills-sync"), { recursive: true, mode: 0o700 });
 
@@ -61,6 +65,10 @@ export async function withSyncLock<T>(
     await new Promise((resolve) => setTimeout(resolve, pollMs));
   }
 
+  const beat = setInterval(() => {
+    const now = new Date();
+    void utimes(path, now, now).catch(() => {});
+  }, heartbeatMs);
   const release = (): Promise<void> => rm(path, { recursive: true, force: true }).catch(() => {});
   // SIGTERM/SIGHUP from a closing session: release before the exit the
   // coordinator performs. SIGKILL cannot be caught — the owner pid covers it.
@@ -68,6 +76,7 @@ export async function withSyncLock<T>(
   try {
     return await body();
   } finally {
+    clearInterval(beat);
     unregister();
     await release();
   }
@@ -86,29 +95,35 @@ async function tryAcquire(path: string): Promise<boolean> {
 }
 
 /**
- * Remove a lock whose owner is gone — its pid no longer exists, or it has no
- * readable owner and is older than `staleMs`. Returns whether it did.
+ * Remove a lock whose holder is gone: its recorded pid no longer exists, or
+ * its heartbeat stopped `staleMs` ago. Returns whether it did.
  */
 async function reapIfAbandoned(path: string, staleMs: number): Promise<boolean> {
-  let abandoned: boolean;
+  let mtimeMs: number;
   try {
-    const pid = Number((await readFile(join(path, OWNER_FILE), "utf-8")).trim());
-    abandoned = Number.isInteger(pid) && pid > 0 && !isAlive(pid);
+    mtimeMs = (await stat(path)).mtimeMs;
   } catch {
-    // Between the holder's `mkdir` and its owner write, or an unreadable file:
-    // age decides.
-    try {
-      abandoned = Date.now() - (await stat(path)).mtimeMs >= staleMs;
-    } catch {
-      return true; // vanished since the failed `mkdir` — the next attempt takes it
-    }
+    return true; // vanished since the failed `mkdir` — the next attempt takes it
   }
+  const abandoned = Date.now() - mtimeMs >= staleMs || !(await ownerAlive(path));
   if (!abandoned) return false;
   await rm(path, { recursive: true, force: true }).catch(() => {});
   return true;
 }
 
-function isAlive(pid: number): boolean {
+/**
+ * `true` when the owner cannot be proven dead: an unreadable or missing owner
+ * file (the holder is between its `mkdir` and its write) leaves the verdict
+ * to the heartbeat.
+ */
+async function ownerAlive(path: string): Promise<boolean> {
+  let pid: number;
+  try {
+    pid = Number((await readFile(join(path, OWNER_FILE), "utf-8")).trim());
+  } catch {
+    return true;
+  }
+  if (!Number.isInteger(pid) || pid <= 0) return true;
   try {
     process.kill(pid, 0);
     return true;

--- a/apps/cli/src/lib/skills-sync/lock.ts
+++ b/apps/cli/src/lib/skills-sync/lock.ts
@@ -3,39 +3,39 @@
 /**
  * Two Claude Code sessions opened together each fire the background command,
  * and nothing survives that: the swaps race and the ledger's last writer wins.
- * A directory is the lock because `mkdir` is atomically create-or-fail
- * everywhere. Two facts decide whether a lock still has an owner: the pid it
- * recorded (gone = reaped at once, which covers a session closing seconds
- * after it opened and SIGKILL-ing the sync it spawned) and a heartbeat — the
- * holder touches the lock's `mtime` while it runs, so a pid that was reused,
- * a zombie or a frozen holder is reaped once the beat stops. Neither is
- * consulted alone.
+ * The lock is `flock(2)` on a file that is never unlinked: the kernel ties it
+ * to the open descriptor and drops it when the process ends, however it ends
+ * — SIGKILL from a session closed seconds after it opened included. No pid to
+ * trust, no age to guess, no heartbeat. Bun is the runtime on every channel
+ * (npm shebang, curl binary), so the libc call comes through `bun:ffi`.
  */
 
-import { mkdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { dlopen, FFIType } from "bun:ffi";
+import { closeSync, openSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { getDataDir } from "../config.ts";
-import { onShutdown } from "../shutdown.ts";
 
 export interface SyncLockOptions {
   timeoutMs?: number;
   pollMs?: number;
-  /** How often the holder touches the lock's `mtime`. */
-  heartbeatMs?: number;
-  /** A lock whose last beat is older than this belonged to a holder that is gone. */
-  staleMs?: number;
 }
 
 const DEFAULTS: Required<SyncLockOptions> = {
   // Fits a large org's first sync, inside a marketplace command's timeout.
   timeoutMs: 60_000,
   pollMs: 500,
-  heartbeatMs: 2_000,
-  // Several missed beats: a scheduler hiccup must not look like a death.
-  staleMs: 15_000,
 };
 
-const OWNER_FILE = "owner";
+// <sys/file.h>, identical on macOS and Linux.
+const LOCK_EX = 2;
+const LOCK_NB = 4;
+
+/** glibc first; the musl spellings cover a Bun built for Alpine. */
+const LIBC_CANDIDATES =
+  process.platform === "darwin"
+    ? ["libSystem.B.dylib"]
+    : ["libc.so.6", "libc.musl-x86_64.so.1", "libc.musl-aarch64.so.1"];
 
 export class SyncLockBusyError extends Error {
   constructor() {
@@ -45,7 +45,7 @@ export class SyncLockBusyError extends Error {
 }
 
 export function getLockPath(): string {
-  return join(getDataDir(), "skills-sync", "lock");
+  return join(getDataDir(), "skills-sync", "sync.lock");
 }
 
 /** Released in a `finally`. Throws {@link SyncLockBusyError} past `timeoutMs`. */
@@ -53,82 +53,45 @@ export async function withSyncLock<T>(
   body: () => Promise<T>,
   options: SyncLockOptions = {},
 ): Promise<T> {
-  const { timeoutMs, pollMs, heartbeatMs, staleMs } = { ...DEFAULTS, ...options };
+  const { timeoutMs, pollMs } = { ...DEFAULTS, ...options };
   const path = getLockPath();
   await mkdir(join(getDataDir(), "skills-sync"), { recursive: true, mode: 0o700 });
 
-  const deadline = Date.now() + timeoutMs;
-  for (;;) {
-    if (await tryAcquire(path)) break;
-    if (await reapIfAbandoned(path, staleMs)) continue;
-    if (Date.now() >= deadline) throw new SyncLockBusyError();
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-
-  const beat = setInterval(() => {
-    const now = new Date();
-    void utimes(path, now, now).catch(() => {});
-  }, heartbeatMs);
-  const release = (): Promise<void> => rm(path, { recursive: true, force: true }).catch(() => {});
-  // SIGTERM/SIGHUP from a closing session: release before the exit the
-  // coordinator performs. SIGKILL cannot be caught — the owner pid covers it.
-  const unregister = onShutdown(release);
+  // Never unlinked: a holder that removed it would let the next opener lock a
+  // file nobody else can see, and two syncs would run at once.
+  const fd = openSync(path, "a", 0o600);
   try {
+    const deadline = Date.now() + timeoutMs;
+    while (flock(fd, LOCK_EX | LOCK_NB) !== 0) {
+      if (Date.now() >= deadline) throw new SyncLockBusyError();
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+    }
     return await body();
   } finally {
-    clearInterval(beat);
-    unregister();
-    await release();
+    // Closing the descriptor releases the lock — the same thing the kernel
+    // does on exit, so there is no signal handling to get right.
+    closeSync(fd);
   }
 }
 
-async function tryAcquire(path: string): Promise<boolean> {
-  try {
-    // No `recursive`: it would succeed on an existing directory.
-    await mkdir(path, { mode: 0o700 });
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "EEXIST") return false;
-    throw err;
-  }
-  await writeFile(join(path, OWNER_FILE), String(process.pid));
-  return true;
-}
+let flockSymbol: ((fd: number, operation: number) => number) | undefined;
 
-/**
- * Remove a lock whose holder is gone: its recorded pid no longer exists, or
- * its heartbeat stopped `staleMs` ago. Returns whether it did.
- */
-async function reapIfAbandoned(path: string, staleMs: number): Promise<boolean> {
-  let mtimeMs: number;
-  try {
-    mtimeMs = (await stat(path)).mtimeMs;
-  } catch {
-    return true; // vanished since the failed `mkdir` — the next attempt takes it
+function flock(fd: number, operation: number): number {
+  if (!flockSymbol) {
+    const failures: string[] = [];
+    for (const name of LIBC_CANDIDATES) {
+      try {
+        flockSymbol = dlopen(name, {
+          flock: { args: [FFIType.i32, FFIType.i32], returns: FFIType.i32 },
+        }).symbols.flock;
+        break;
+      } catch (err) {
+        failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (!flockSymbol) {
+      throw new Error(`Cannot load flock(2) from libc — tried ${failures.join("; ")}`);
+    }
   }
-  const abandoned = Date.now() - mtimeMs >= staleMs || !(await ownerAlive(path));
-  if (!abandoned) return false;
-  await rm(path, { recursive: true, force: true }).catch(() => {});
-  return true;
-}
-
-/**
- * `true` when the owner cannot be proven dead: an unreadable or missing owner
- * file (the holder is between its `mkdir` and its write) leaves the verdict
- * to the heartbeat.
- */
-async function ownerAlive(path: string): Promise<boolean> {
-  let pid: number;
-  try {
-    pid = Number((await readFile(join(path, OWNER_FILE), "utf-8")).trim());
-  } catch {
-    return true;
-  }
-  if (!Number.isInteger(pid) || pid <= 0) return true;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch (err) {
-    // EPERM: exists, owned by someone else — alive. Only ESRCH proves death.
-    return (err as NodeJS.ErrnoException).code !== "ESRCH";
-  }
+  return flockSymbol(fd, operation);
 }

--- a/apps/cli/test/skills-lock.test.ts
+++ b/apps/cli/test/skills-lock.test.ts
@@ -4,14 +4,14 @@
  * The cross-process lock `appstrate skills sync` holds for its whole body.
  *
  * Tested through the helper rather than the command: the production timings
- * are a 60-second wait and a 10-minute staleness window, and a suite that
- * exercised them for real would take eleven minutes to say what a handful of
- * millisecond-scale cases say here. The command wires the defaults; these
+ * are a 60-second wait, a 2-second heartbeat and a 15-second staleness
+ * window, and a suite that exercised them for real would take minutes to say
+ * what a handful of millisecond-scale cases say here. The command wires the defaults; these
  * cases pin the behaviour those defaults select.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { lstat, mkdir, mkdtemp, readFile, rm, utimes, writeFile } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getLockPath, SyncLockBusyError, withSyncLock } from "../src/lib/skills-sync/lock.ts";
@@ -107,6 +107,31 @@ describe("withSyncLock", () => {
     // is what makes this pass.
     expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
     expect(await exists(getLockPath())).toBe(false);
+  });
+
+  it("keeps the lock's mtime beating while the body runs", async () => {
+    await withSyncLock(
+      async () => {
+        const stale = new Date(Date.now() - 60_000);
+        await utimes(getLockPath(), stale, stale);
+        await new Promise((resolve) => setTimeout(resolve, 40));
+        // A holder that stopped beating would still read as `stale` here.
+        expect((await stat(getLockPath())).mtimeMs).toBeGreaterThan(stale.getTime() + 30_000);
+      },
+      { heartbeatMs: 5 },
+    );
+  });
+
+  it("reaps a lock whose owner pid is alive but whose heartbeat stopped", async () => {
+    await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
+    await mkdir(getLockPath());
+    // A reused pid, a zombie or a frozen holder all look like this: the pid
+    // answers, the beat does not.
+    await writeFile(join(getLockPath(), "owner"), String(process.pid));
+    const longAgo = new Date(Date.now() - 60_000);
+    await utimes(getLockPath(), longAgo, longAgo);
+
+    expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
   });
 
   it("reaps an ownerless lock old enough to prove its owner is gone", async () => {

--- a/apps/cli/test/skills-lock.test.ts
+++ b/apps/cli/test/skills-lock.test.ts
@@ -3,15 +3,15 @@
 /**
  * The cross-process lock `appstrate skills sync` holds for its whole body.
  *
- * Tested through the helper rather than the command: the production timings
- * are a 60-second wait, a 2-second heartbeat and a 15-second staleness
- * window, and a suite that exercised them for real would take minutes to say
- * what a handful of millisecond-scale cases say here. The command wires the defaults; these
- * cases pin the behaviour those defaults select.
+ * Tested through the helper rather than the command: the production wait is
+ * 60 seconds, and a suite that exercised it for real would take a minute to
+ * say what these millisecond-scale cases say. The one property that matters
+ * most — the kernel releases the lock when the holder is killed — is proven
+ * with a real child process and a real SIGKILL.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { lstat, mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import { lstat, mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { getLockPath, SyncLockBusyError, withSyncLock } from "../src/lib/skills-sync/lock.ts";
@@ -31,10 +31,11 @@ afterEach(async () => {
 });
 
 describe("withSyncLock", () => {
-  it("runs the body and releases the lock", async () => {
-    const result = await withSyncLock(async () => "done");
-    expect(result).toBe("done");
-    expect(await exists(getLockPath())).toBe(false);
+  it("runs the body and leaves the lock file in place, unlocked", async () => {
+    expect(await withSyncLock(async () => "done")).toBe("done");
+    // The file is never unlinked (see the source); a second run takes it.
+    expect(await exists(getLockPath())).toBe(true);
+    expect(await withSyncLock(async () => "again", { timeoutMs: 30, pollMs: 5 })).toBe("again");
   });
 
   it("releases the lock when the body throws", async () => {
@@ -43,7 +44,7 @@ describe("withSyncLock", () => {
         throw new Error("boom");
       }),
     ).rejects.toThrow("boom");
-    expect(await exists(getLockPath())).toBe(false);
+    expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
   });
 
   it("serializes two overlapping runs rather than interleaving them", async () => {
@@ -77,71 +78,48 @@ describe("withSyncLock", () => {
     expect(order).toEqual(["first:start", "first:end", "second:start"]);
   });
 
-  it("records its own pid as the lock's owner", async () => {
-    await withSyncLock(async () => {
-      expect(await readFile(join(getLockPath(), "owner"), "utf-8")).toBe(String(process.pid));
+  it("gives up with a busy error while a live holder keeps the lock", async () => {
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => (release = resolve));
+    let entered!: () => void;
+    const entry = new Promise<void>((resolve) => (entered = resolve));
+    const holder = withSyncLock(async () => {
+      entered();
+      await held;
     });
-  });
-
-  it("gives up with a busy error when the holder is alive and never lets go", async () => {
-    await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
-    await mkdir(getLockPath());
-    // This process IS the holder, so the owner is provably alive.
-    await writeFile(join(getLockPath(), "owner"), String(process.pid));
+    await entry;
 
     await expect(
       withSyncLock(async () => "never", { timeoutMs: 30, pollMs: 5 }),
     ).rejects.toBeInstanceOf(SyncLockBusyError);
-    // The foreign lock is left exactly where it was.
-    expect(await exists(getLockPath())).toBe(true);
+    release();
+    await holder;
   });
 
-  it("reaps a fresh lock whose owner pid is dead", async () => {
-    await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
-    await mkdir(getLockPath());
-    // A process that has already exited: the pid it had is provably dead.
-    const gone = Bun.spawnSync(["true"]).pid;
-    await writeFile(join(getLockPath(), "owner"), String(gone));
-
-    // Fresh mtime, so the age rule alone would report busy: the owner rule
-    // is what makes this pass.
-    expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
-    expect(await exists(getLockPath())).toBe(false);
-  });
-
-  it("keeps the lock's mtime beating while the body runs", async () => {
-    await withSyncLock(
-      async () => {
-        const stale = new Date(Date.now() - 60_000);
-        await utimes(getLockPath(), stale, stale);
-        await new Promise((resolve) => setTimeout(resolve, 40));
-        // A holder that stopped beating would still read as `stale` here.
-        expect((await stat(getLockPath())).mtimeMs).toBeGreaterThan(stale.getTime() + 30_000);
-      },
-      { heartbeatMs: 5 },
+  it("is released by the kernel when the holder is SIGKILLed", async () => {
+    // A real process holds the lock through this module, then dies the way
+    // a background sync dies when its Claude Code session closes.
+    const holder = Bun.spawn(
+      [
+        "bun",
+        "-e",
+        `const { withSyncLock } = await import(${JSON.stringify(
+          new URL("../src/lib/skills-sync/lock.ts", import.meta.url).pathname,
+        )});
+         await withSyncLock(async () => { console.log("held"); await new Promise(() => {}); });`,
+      ],
+      { env: { ...process.env, XDG_DATA_HOME: dataHome }, stdout: "pipe" },
     );
-  });
+    const reader = holder.stdout.getReader();
+    const { value } = await reader.read();
+    expect(new TextDecoder().decode(value)).toContain("held");
 
-  it("reaps a lock whose owner pid is alive but whose heartbeat stopped", async () => {
-    await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
-    await mkdir(getLockPath());
-    // A reused pid, a zombie or a frozen holder all look like this: the pid
-    // answers, the beat does not.
-    await writeFile(join(getLockPath(), "owner"), String(process.pid));
-    const longAgo = new Date(Date.now() - 60_000);
-    await utimes(getLockPath(), longAgo, longAgo);
+    await expect(
+      withSyncLock(async () => "never", { timeoutMs: 30, pollMs: 5 }),
+    ).rejects.toBeInstanceOf(SyncLockBusyError);
 
-    expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
-  });
-
-  it("reaps an ownerless lock old enough to prove its owner is gone", async () => {
-    await mkdir(join(dataHome, "appstrate", "skills-sync"), { recursive: true });
-    await mkdir(getLockPath());
-    const longAgo = new Date(Date.now() - 60 * 60_000);
-    await utimes(getLockPath(), longAgo, longAgo);
-
-    // Same short timeout as the busy case above: without the staleness rule
-    // this call would fail the same way, so the assertion discriminates.
+    holder.kill("SIGKILL");
+    await holder.exited;
     expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
   });
 });


### PR DESCRIPTION
## Summary

Adversarial re-read of #1256 (pid-only reaping) found four holes: a **reused pid**, a **zombie** holder, a holder **frozen under SIGSTOP**, and a lock **without an `owner` file** still falling back to the ten-minute age rule. A first commit here added a heartbeat (the proper-lockfile pattern); the second replaces the whole userland lock with the kernel's.

**`flock(2)` on `skills-sync/sync.lock`, through `bun:ffi`.** Bun is the runtime on every CLI channel (`#!/usr/bin/env bun` on npm, `bun build --compile` for the curl binaries), so libc's `flock` is one `dlopen` away. The kernel ties the lock to the open descriptor and releases it when the holder ends, however it ends — SIGKILL from a closing Claude Code session, crash, Claude Code's command timeout. No pid to trust, no age to guess, no heartbeat, no signal handling: closing the descriptor is the release. The file is never unlinked (a holder that removed it would let the next opener lock an invisible inode).

- `lock.ts`: 40 lines shorter than the pid + heartbeat version; `SyncLockOptions` keeps `timeoutMs`/`pollMs` only. glibc first, musl spellings as fallback, a clear error if none loads.
- Tests: contention with a live in-process holder → busy; **a real child process holds the lock and is SIGKILLed → the next acquire succeeds at once**; body throw releases; overlapping runs serialize.
- Verified on a real machine: `bun:ffi` + `flock` in a script, in a `bun build --compile` binary, and in the npm bundle (`bun:ffi` stays an external import); two concurrent `skills sync` runs serialize; `kill -9` on a holder frees the lock for the next process.

Not covered, by design: a holder alive but hung (e.g. a keychain prompt) keeps the lock until Claude Code's 120 s timeout kills it — contenders correctly report busy meanwhile. `flock` on NFS-mounted `$XDG_DATA_HOME` is advisory at best; the data dir is local on every supported setup.

## Type of Change

- [x] Bug fix

## Checklist

- [x] `bun run check` passes (pre-push gate)
- [x] `bun test apps/cli/test/skills-lock.test.ts apps/cli/test/skills-command.test.ts` — 63 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)