### PR TITLE
fix(auth): accept scopes on first CIMD authorization

### DIFF
--- a/apps/api/src/modules/oidc/auth/plugins.ts
+++ b/apps/api/src/modules/oidc/auth/plugins.ts
@@ -367,8 +367,13 @@ export function oidcBetterAuthPlugins(opts: OidcBetterAuthPluginsOptions = {}): 
       // confinement then restricts to the protected resource it was issued
       // for. Without this the entire CIMD onboarding path mints nothing.
       onClientCreated: async ({ client }) => {
-        const clientId = (client as { clientId?: unknown }).clientId;
-        if (typeof clientId === "string") await markClientSelfService(clientId);
+        const stamped = await markClientSelfService(client.clientId);
+        // CIMD returns this same object to the first authorize request after
+        // the hook. Persisting alone leaves its scopes empty until the retry.
+        if (stamped) {
+          client.scopes = stamped.scopes;
+          client.metadata = stamped.metadata;
+        }
       },
     }),
   ];

--- a/apps/api/src/modules/oidc/services/oauth-admin.ts
+++ b/apps/api/src/modules/oidc/services/oauth-admin.ts
@@ -431,7 +431,9 @@ export async function createClient(input: CreateClientInput): Promise<OAuthClien
  * is safely re-stamped. Best-effort cache invalidation so the next mint reads
  * the stamped row.
  */
-export async function markClientSelfService(clientId: string): Promise<void> {
+export async function markClientSelfService(
+  clientId: string,
+): Promise<{ scopes: string[]; metadata: string } | undefined> {
   const [row] = await db
     .select({ metadata: oauthClient.metadata, scopes: oauthClient.scopes })
     .from(oauthClient)
@@ -463,17 +465,17 @@ export async function markClientSelfService(clientId: string): Promise<void> {
   // (identity + module end-user-grantable scopes, e.g. mcp:read/mcp:invoke) so
   // the client may request them. Only fill when empty — never widen a client
   // that deliberately declared a narrower scope set.
-  const update: Record<string, unknown> = {
-    level: "instance",
-    metadata: JSON.stringify(metadata),
-    updatedAt: new Date(),
-  };
-  if (!row.scopes || row.scopes.length === 0) {
-    update.scopes = [...OIDC_IDENTITY_SCOPES, ...getModuleEndUserAllowedScopes()];
-  }
+  const scopes = row.scopes?.length
+    ? row.scopes
+    : [...OIDC_IDENTITY_SCOPES, ...getModuleEndUserAllowedScopes()];
+  const stamped = { scopes, metadata: JSON.stringify(metadata) };
 
-  await db.update(oauthClient).set(update).where(eq(oauthClient.clientId, clientId));
+  await db
+    .update(oauthClient)
+    .set({ ...stamped, level: "instance", updatedAt: new Date() })
+    .where(eq(oauthClient.clientId, clientId));
   cacheInvalidate(clientId);
+  return stamped;
 }
 
 // ─── Update / delete / rotate ─────────────────────────────────────────────────

--- a/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
@@ -12,11 +12,11 @@
  *    scopes to the self-service set (identity + module scopes); a core action
  *    scope is rejected.
  *
- * The CIMD fetch/validation path itself is owned + tested by @better-auth/cimd
- * upstream; here we assert our wiring advertises it.
+ * CIMD first authorization also exercises the real resolver with an in-process
+ * metadata response, ensuring our self-service stamp reaches that request.
  */
 
-import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, spyOn } from "bun:test";
 import { eq } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { oauthClient } from "@appstrate/db/schema";
@@ -78,6 +78,129 @@ describe("authorization-server discovery — DCR + CIMD", () => {
     expect(body.client_id_metadata_document_supported).toBe(true);
     expect(typeof body.registration_endpoint).toBe("string");
     expect(String(body.registration_endpoint)).toContain("/oauth2/register");
+  });
+});
+
+describe("CIMD first authorization", () => {
+  // A public IP keeps the real SSRF check but avoids external DNS. The fetch
+  // below serves the document in-process; no request reaches this address.
+  const clientId = "https://93.184.216.34/client.json";
+  const redirectUri = "https://93.184.216.34/callback";
+  let documentScope: string | undefined;
+  let fetchDocument: ReturnType<typeof spyOn<typeof globalThis, "fetch">>;
+
+  beforeEach(async () => {
+    await truncateAll();
+    await flushRedis();
+    resetOidcGuardsLimiters();
+    documentScope = undefined;
+    const fetchMetadata = async (input: string | URL | Request): Promise<Response> => {
+      expect(String(input)).toBe(clientId);
+      return Response.json({
+        client_id: clientId,
+        client_name: "CIMD first authorization",
+        redirect_uris: [redirectUri],
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        token_endpoint_auth_method: "none",
+        ...(documentScope === undefined ? {} : { scope: documentScope }),
+      });
+    };
+    fetchDocument = spyOn(globalThis, "fetch").mockImplementation(
+      Object.assign(fetchMetadata, { preconnect: globalThis.fetch.preconnect }),
+    );
+  });
+
+  afterEach(() => {
+    fetchDocument.mockRestore();
+  });
+
+  async function authorize(scope: string) {
+    const query = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      scope,
+      code_challenge: "a".repeat(43),
+      code_challenge_method: "S256",
+      state: "first-cimd-authorization",
+    });
+    return app.request(`/api/auth/oauth2/authorize?${query}`);
+  }
+
+  async function storedClient() {
+    const [stored] = await db.select().from(oauthClient).where(eq(oauthClient.clientId, clientId));
+    if (!stored) throw new Error("CIMD client was not persisted");
+    return stored;
+  }
+
+  it("accepts identity scopes on the first request for a document without scope", async () => {
+    expect(await db.select().from(oauthClient).where(eq(oauthClient.clientId, clientId))).toEqual(
+      [],
+    );
+
+    const first = await authorize("openid offline_access");
+    const retry = await authorize("openid offline_access");
+
+    for (const res of [first, retry]) {
+      expect(res.status).toBe(302);
+      expect(new URL(res.headers.get("location")!, "http://localhost").pathname).toBe(
+        "/api/oauth/login",
+      );
+    }
+    expect(fetchDocument).toHaveBeenCalledTimes(1);
+    const stored = await storedClient();
+    expect(stored.scopes).toEqual(["openid", "profile", "email", "offline_access"]);
+    expect(stored.level).toBe("instance");
+    expect(JSON.parse(stored.metadata!)).toMatchObject({
+      level: "instance",
+      clientId,
+      selfService: true,
+    });
+  });
+
+  it("preserves explicitly narrow scopes on first authorization and retry", async () => {
+    documentScope = "openid";
+
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const rejected = await authorize("openid offline_access");
+      expect(new URL(rejected.headers.get("location")!).searchParams.get("error")).toBe(
+        "invalid_scope",
+      );
+    }
+    expect((await storedClient()).scopes).toEqual(["openid"]);
+    const allowed = await authorize("openid");
+    expect(new URL(allowed.headers.get("location")!, "http://localhost").pathname).toBe(
+      "/api/oauth/login",
+    );
+    expect(fetchDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not grant a core action scope to a document without scopes", async () => {
+    const rejected = await authorize("openid agents:run");
+    expect(new URL(rejected.headers.get("location")!).searchParams.get("error")).toBe(
+      "invalid_scope",
+    );
+    expect((await storedClient()).scopes).not.toContain("agents:run");
+  });
+
+  it("keeps a newly discovered client confined to protected-resource audiences", async () => {
+    await authorize("openid offline_access");
+
+    const token = await app.request("/api/auth/oauth2/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        client_id: clientId,
+        redirect_uri: redirectUri,
+        code: "irrelevant-code",
+        code_verifier: "a".repeat(43),
+        resource: getEnv().APP_URL,
+      }).toString(),
+    });
+    expect(token.status).toBe(400);
+    expect(await token.json()).toMatchObject({ error: "invalid_target" });
   });
 });
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -835,7 +835,20 @@ If you see `OS keyring ... failed ... falling back to ~/.config/appstrate/creden
 
 ## Source + contributing
 
-Source at [`apps/cli/`](../../apps/cli/). Tests at `apps/cli/test/` (unit tests, run with `bun test` from the CLI directory). E2E against a real instance: spin up an Appstrate Tier 0 with `bun run dev`, then `bun run src/cli.ts login --instance http://localhost:3000`.
+Source at [`apps/cli/`](../../apps/cli/). Tests at `apps/cli/test/` (unit tests, run with `bun test` from the CLI directory).
+
+**Real device-flow smoke tests:** the OS keyring namespace is `(appstrate, <profile>)`;
+isolating XDG directories does **not** isolate credentials. Allocate a unique
+`smoke-<id>` profile and pass `--profile smoke-<id>` to every command, including
+`login`, validation commands and `logout` cleanup after success or failure.
+Never use `default`, another existing profile, or change the user's `defaultProfile`.
+Before login, check only the named fixture profile's non-secret metadata; never
+read or log credentials. Keep `XDG_CONFIG_HOME` and `XDG_DATA_HOME` in temporary
+fixture directories. Skill targets need separate isolation: these XDG settings
+do not redirect `~/.agents/skills/` or `~/.claude/skills/`. Do not run real `codex`
+or `claude-user` target writes unless their destinations are isolated too; use
+the existing fake-keyring test fixtures for those checks. Do not repurpose
+`HOME` or `CODEX_HOME` for a real CLI smoke run.
 
 ### Building locally
 


### PR DESCRIPTION
## Summary

A previously unseen CIMD client whose metadata omits `scope` fails its first authorization with `invalid_scope`, then succeeds on retry. Appstrate already persists the self-service scope defaults, but Better Auth returns the original client object to the first authorization request. Apply the persisted scopes and serialized metadata to that object before returning it.

Explicitly restricted client scopes and protected-resource audience confinement are preserved. Regression tests cover the first request and retry, narrow scopes, forbidden action scopes and the audience guard. The CLI contributor guide now requires unique smoke profiles and isolated targets because XDG directories alone do not isolate OS keyring entries.

Discovered during validation of #1265; this server correction is based directly on `main` and is independent of the skills plugin feature.

## Type of Change

- [x] Bug fix
- [x] Documentation update

## Validation

- Reproduced the failure before the fix: first authorization rejected scopes already persisted in the database; identical retry succeeded.
- Full OIDC + MCP suites: **641 passed**, 0 failed, 3,254 assertions across 58 files (Tier 0).
- API TypeScript check and `bun run check`: passed, **38/38 tasks**.
- Independent application protocol smoke: first authorization → consent with CSRF → PKCE token exchange → MCP `initialize` and `tools/list` all succeed. Replaying the token against another organization returns 401; a client restricted to `openid` still rejects `offline_access`.
- Smoke uses real Appstrate auth, PGlite, consent, tokens and MCP handlers via in-process HTTP. Only the public CIMD document is a fixture; no browser or external deployment is involved. No user keyring is used by these tests.
- GitHub CI passed on `3053270647120de508c23e3fd318d3d4ef3bce46`: full unit and integration suites, platform container health E2E, quality gate, CodeQL, secret scanning, package consumer checks and Codecov patch coverage.

## Checklist

- [x] `bun run check` passes (the full 18-task gate — see `CLAUDE.md`)
- [x] `bun test` passes: scoped OIDC + MCP suites locally, full unit/integration suites in CI
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)
