### PR TITLE
fix(cli): resolve the newest platform v* release by listing, not releases/latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,9 +80,14 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
   keeps it correct only as long as every future workflow and every hand-made
   Release remembers the flag. The consumers now filter by tag themselves
   (drafts and prereleases skipped, as before), so a stray Release can no
-  longer point an update at assets that do not exist. The CLI names the
-  releases it skipped when no `v*` one is found; `releaseUrls` no longer has a
-  `latest/download` branch because nothing reaches it any more.
+  longer point an update at assets that do not exist. Both walk pages of 30
+  (5 at most) until one holds a `v*` Release; the CLI then takes the highest
+  version on that page rather than the most recently created one, so a hotfix
+  for an older line published after a newer release is not "latest" (the shell
+  scripts keep creation order: no `sort -V` on macOS, and the rendered
+  installer pins its version anyway). The CLI names the releases it skipped
+  when no `v*` one is found; `releaseUrls` no longer has a `latest/download`
+  branch because nothing reaches it any more.
 
 - **BREAKING (wire): WRITING a skill whose `SKILL.md` frontmatter has no
   `description`, or a `name` that breaks the Agent Skills naming rule, is now a 400.** The platform only required the `name` KEY to be present, so a skill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,18 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
 
 ### Changed
 
+- **`appstrate self-update`, `scripts/bootstrap.sh` and `scripts/bootstrap-runner.sh`
+  resolve "latest" by listing GitHub Releases and picking the newest platform
+  `v<semver>` one, never through `releases/latest`.** GitHub's "latest" is
+  whichever non-prerelease Release was created last, whatever its tag; the
+  `make_latest: false` on the npm workflows (`cli@`, `core@`, `afps-shared@`)
+  keeps it correct only as long as every future workflow and every hand-made
+  Release remembers the flag. The consumers now filter by tag themselves
+  (drafts and prereleases skipped, as before), so a stray Release can no
+  longer point an update at assets that do not exist. The CLI names the
+  releases it skipped when no `v*` one is found; `releaseUrls` no longer has a
+  `latest/download` branch because nothing reaches it any more.
+
 - **BREAKING (wire): WRITING a skill whose `SKILL.md` frontmatter has no
   `description`, or a `name` that breaks the Agent Skills naming rule, is now a 400.** The platform only required the `name` KEY to be present, so a skill
   created with the editor's default skeleton — `name:` and `description:` both

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -43,8 +43,19 @@ const RELEASE_URL_BASE = "https://github.com/appstrate/appstrate/releases";
  * CLI pick the newest platform `v<semver>` Release itself, so nothing outside
  * `release.yml` can steer an update.
  */
-const RELEASES_API_URL = "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30";
+const RELEASES_API_URL = "https://api.github.com/repos/appstrate/appstrate/releases";
+const RELEASES_PAGE_SIZE = 30;
+/**
+ * Pages scanned before giving up: 150 releases. Every platform cycle creates
+ * one `v*` plus at most three npm Releases, so a `v*` sits inside the first
+ * page in practice; the cap only bounds the API calls when it does not.
+ */
+const RELEASES_MAX_PAGES = 5;
 const PLATFORM_TAG = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+function releasesPageUrl(page: number): string {
+  return `${RELEASES_API_URL}?per_page=${RELEASES_PAGE_SIZE}&page=${page}`;
+}
 
 /**
  * Error thrown by the default fetch deps when an HTTP request returns a
@@ -364,9 +375,47 @@ export async function resolveTargetVersion(
     }
     return v;
   }
+  // Newest first, as the API orders them. Only a platform `v<semver>` release
+  // carries the CLI binaries; the npm workflows (`cli@`, `core@`,
+  // `afps-shared@`) publish their own Releases and are skipped by tag, the
+  // same way `releases/latest` skips drafts and prereleases. Within the newest
+  // page that holds any candidate, the HIGHEST version wins, not the newest by
+  // creation date: a hotfix for an older line published after a newer release
+  // must not become "latest".
+  const skipped: string[] = [];
+  for (let page = 1; page <= RELEASES_MAX_PAGES; page++) {
+    const releases = await fetchReleasesPage(deps, page);
+    if (releases.length === 0) break;
+    const candidates: string[] = [];
+    for (const release of releases) {
+      if (!release || typeof release !== "object") continue;
+      const { tag_name, draft, prerelease } = release as {
+        tag_name?: unknown;
+        draft?: unknown;
+        prerelease?: unknown;
+      };
+      if (typeof tag_name !== "string") continue;
+      if (draft === true || prerelease === true) continue;
+      if (PLATFORM_TAG.test(tag_name)) candidates.push(tag_name);
+      else skipped.push(tag_name);
+    }
+    if (candidates.length > 0) {
+      candidates.sort(compareSemver);
+      return normalizeVersion(candidates[candidates.length - 1]!);
+    }
+  }
+  throw new Error(
+    `No platform v* release among the newest ${skipped.length} GitHub Releases` +
+      (skipped.length > 0 ? ` (${skipped.slice(0, 5).join(", ")})` : "") +
+      `. Pin one with --release X.Y.Z.`,
+  );
+}
+
+/** One page of the Releases list, newest first. Empty past the last page. */
+async function fetchReleasesPage(deps: ResolveTargetVersionDeps, page: number): Promise<unknown[]> {
   let body: string;
   try {
-    body = await deps.fetchText(RELEASES_API_URL);
+    body = await deps.fetchText(releasesPageUrl(page));
   } catch (err) {
     // GitHub's unauthenticated API caps at 60 req/h per IP. On shared CI
     // runners this often surfaces as a 403 with X-RateLimit-Remaining: 0;
@@ -394,28 +443,7 @@ export async function resolveTargetVersion(
   if (!Array.isArray(parsed)) {
     throw new Error(`GitHub Releases API response is not a release list.`);
   }
-  // Newest first, as the API orders them. Only a platform `v<semver>` release
-  // carries the CLI binaries; the npm workflows (`cli@`, `core@`,
-  // `afps-shared@`) publish their own Releases and are skipped by tag, the
-  // same way `releases/latest` skips drafts and prereleases.
-  const seen: string[] = [];
-  for (const release of parsed as unknown[]) {
-    if (!release || typeof release !== "object") continue;
-    const { tag_name, draft, prerelease } = release as {
-      tag_name?: unknown;
-      draft?: unknown;
-      prerelease?: unknown;
-    };
-    if (typeof tag_name !== "string") continue;
-    if (draft === true || prerelease === true) continue;
-    if (PLATFORM_TAG.test(tag_name)) return normalizeVersion(tag_name);
-    seen.push(tag_name);
-  }
-  throw new Error(
-    `No platform v* release among the newest ${seen.length} GitHub Releases` +
-      (seen.length > 0 ? ` (${seen.slice(0, 5).join(", ")})` : "") +
-      `. Pin one with --release X.Y.Z.`,
-  );
+  return parsed as unknown[];
 }
 
 interface PerformCurlUpdateOptions {

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -35,7 +35,16 @@ export { normalizeVersion };
 export const APPSTRATE_MINISIGN_PUBKEY = "RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e";
 
 const RELEASE_URL_BASE = "https://github.com/appstrate/appstrate/releases";
-const LATEST_API_URL = "https://api.github.com/repos/appstrate/appstrate/releases/latest";
+/**
+ * The newest releases, not `releases/latest`. GitHub's `latest` is whichever
+ * non-prerelease Release was created last, whatever its tag — a `cli@`, `core@`
+ * or `afps-shared@` Release created without `make_latest: false`, or by hand in
+ * the UI, would be handed back here and carries no CLI binary. Listing lets the
+ * CLI pick the newest platform `v<semver>` Release itself, so nothing outside
+ * `release.yml` can steer an update.
+ */
+const RELEASES_API_URL = "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30";
+const PLATFORM_TAG = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 /**
  * Error thrown by the default fetch deps when an HTTP request returns a
@@ -114,10 +123,9 @@ interface ReleaseUrls {
  * UX is identical whether the user is bootstrapping or self-updating.
  */
 export function releaseUrls(version: string, info: PlatformInfo): ReleaseUrls {
-  const base =
-    version === "latest"
-      ? `${RELEASE_URL_BASE}/latest/download`
-      : `${RELEASE_URL_BASE}/download/v${stripVersionPrefix(version)}`;
+  // Always a pinned tag: `resolveTargetVersion` turns "latest" into the newest
+  // platform `v*` Release first, so `releases/latest/download` is never built.
+  const base = `${RELEASE_URL_BASE}/download/v${stripVersionPrefix(version)}`;
   const asset = assetName(info);
   return {
     binary: `${base}/${asset}`,
@@ -333,8 +341,9 @@ export interface ResolveTargetVersionDeps {
 }
 
 /**
- * Resolve the tag name to install. Defaults to `latest` (queries the GitHub
- * Releases API), but accepts an explicit version (`1.2.3` or `v1.2.3`).
+ * Resolve the tag name to install. Defaults to the newest platform `v*`
+ * Release (lists the GitHub Releases API), but accepts an explicit version
+ * (`1.2.3` or `v1.2.3`).
  *
  * The API call is cheap (one GET) and avoids the GitHub-issued redirect chain
  * on `releases/latest/download/<asset>` which otherwise costs three round-trips
@@ -357,7 +366,7 @@ export async function resolveTargetVersion(
   }
   let body: string;
   try {
-    body = await deps.fetchText(LATEST_API_URL);
+    body = await deps.fetchText(RELEASES_API_URL);
   } catch (err) {
     // GitHub's unauthenticated API caps at 60 req/h per IP. On shared CI
     // runners this often surfaces as a 403 with X-RateLimit-Remaining: 0;
@@ -382,25 +391,31 @@ export async function resolveTargetVersion(
   } catch {
     throw new Error(`GitHub Releases API returned non-JSON; cannot determine latest version.`);
   }
-  if (
-    !parsed ||
-    typeof parsed !== "object" ||
-    typeof (parsed as { tag_name?: unknown }).tag_name !== "string"
-  ) {
-    throw new Error(`GitHub Releases API response missing tag_name.`);
+  if (!Array.isArray(parsed)) {
+    throw new Error(`GitHub Releases API response is not a release list.`);
   }
-  const tag = (parsed as { tag_name: string }).tag_name;
-  // Only a platform `v<semver>` release carries the CLI binaries. The npm
-  // workflows (`cli@`, `core@`, `afps-shared@`) publish their own GitHub
-  // Releases with `make_latest: false`; should one still come back here, name
-  // it instead of building `releases/download/vcli@…` and reporting a 404.
-  if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(tag)) {
-    throw new Error(
-      `GitHub's latest release is "${tag}", not a platform v* release. ` +
-        `Pin one with --release X.Y.Z, or mark the newest v* release as latest.`,
-    );
+  // Newest first, as the API orders them. Only a platform `v<semver>` release
+  // carries the CLI binaries; the npm workflows (`cli@`, `core@`,
+  // `afps-shared@`) publish their own Releases and are skipped by tag, the
+  // same way `releases/latest` skips drafts and prereleases.
+  const seen: string[] = [];
+  for (const release of parsed as unknown[]) {
+    if (!release || typeof release !== "object") continue;
+    const { tag_name, draft, prerelease } = release as {
+      tag_name?: unknown;
+      draft?: unknown;
+      prerelease?: unknown;
+    };
+    if (typeof tag_name !== "string") continue;
+    if (draft === true || prerelease === true) continue;
+    if (PLATFORM_TAG.test(tag_name)) return normalizeVersion(tag_name);
+    seen.push(tag_name);
   }
-  return normalizeVersion(tag);
+  throw new Error(
+    `No platform v* release among the newest ${seen.length} GitHub Releases` +
+      (seen.length > 0 ? ` (${seen.slice(0, 5).join(", ")})` : "") +
+      `. Pin one with --release X.Y.Z.`,
+  );
 }
 
 interface PerformCurlUpdateOptions {

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -170,59 +170,112 @@ describe("resolveTargetVersion", () => {
     ).rejects.toThrow(/Invalid version/);
   });
 
+  const RELEASES_URL = "https://api.github.com/repos/appstrate/appstrate/releases";
+  const release = (tag_name: string, flags: { draft?: boolean; prerelease?: boolean } = {}) => ({
+    tag_name,
+    draft: flags.draft ?? false,
+    prerelease: flags.prerelease ?? false,
+  });
+  /** Serve `pages[n-1]` for `page=n`, `[]` past the last one, like GitHub. */
+  const paged = (pages: unknown[][], calls?: string[]) => async (url: string) => {
+    calls?.push(url);
+    const page = Number(new URL(url).searchParams.get("page"));
+    return JSON.stringify(pages[page - 1] ?? []);
+  };
+
   it("lists GitHub releases when no version is requested", async () => {
     const calls: string[] = [];
     const out = await resolveTargetVersion(undefined, {
-      fetchText: async (url) => {
-        calls.push(url);
-        return JSON.stringify([{ tag_name: "v2.5.0", draft: false, prerelease: false }]);
-      },
+      fetchText: paged([[release("v2.5.0")]], calls),
     });
     expect(out).toBe("2.5.0");
-    expect(calls).toEqual([
-      "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30",
-    ]);
+    expect(calls).toEqual([`${RELEASES_URL}?per_page=30&page=1`]);
   });
 
   it("skips newer npm-package releases and picks the newest platform v* release", async () => {
     // The exact shape of the "latest" hijack: a `cli@` Release created after
     // the platform one. `releases/latest` would return it; the list does not.
     const out = await resolveTargetVersion(undefined, {
-      fetchText: async () =>
-        JSON.stringify([
-          { tag_name: "cli@1.0.0-beta.56", draft: false, prerelease: false },
-          { tag_name: "core@9.0.0", draft: false, prerelease: false },
-          { tag_name: "v1.0.0-beta.56", draft: false, prerelease: false },
-          { tag_name: "v1.0.0-beta.55", draft: false, prerelease: false },
-        ]),
+      fetchText: paged([
+        [
+          release("cli@1.0.0-beta.56"),
+          release("core@9.0.0"),
+          release("v1.0.0-beta.56"),
+          release("v1.0.0-beta.55"),
+        ],
+      ]),
     });
     expect(out).toBe("1.0.0-beta.56");
   });
 
+  it("picks the highest version on the page, not the most recently created", async () => {
+    // A hotfix for an older line published after a newer release: creation
+    // order (what `releases/latest` uses) would hand back 1.0.1.
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: paged([[release("v1.0.1"), release("v1.1.0"), release("v1.0.0")]]),
+    });
+    expect(out).toBe("1.1.0");
+  });
+
+  it("orders beta builds numerically when picking the highest", async () => {
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: paged([[release("v1.0.0-beta.9"), release("v1.0.0-beta.57")]]),
+    });
+    expect(out).toBe("1.0.0-beta.57");
+  });
+
   it("skips draft and prerelease v* releases like releases/latest does", async () => {
     const out = await resolveTargetVersion(undefined, {
-      fetchText: async () =>
-        JSON.stringify([
-          { tag_name: "v3.0.0", draft: true, prerelease: false },
-          { tag_name: "v2.9.0-rc.1", draft: false, prerelease: true },
-          { tag_name: "v2.8.0", draft: false, prerelease: false },
-        ]),
+      fetchText: paged([
+        [
+          release("v3.0.0", { draft: true }),
+          release("v2.9.0-rc.1", { prerelease: true }),
+          release("v2.8.0"),
+        ],
+      ]),
     });
     expect(out).toBe("2.8.0");
   });
 
+  it("walks to the next page when the newest one holds only npm-package releases", async () => {
+    const calls: string[] = [];
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: paged(
+        [[release("cli@1.0.0-beta.56"), release("core@9.0.0")], [release("v1.0.0-beta.56")]],
+        calls,
+      ),
+    });
+    expect(out).toBe("1.0.0-beta.56");
+    expect(calls).toEqual([
+      `${RELEASES_URL}?per_page=30&page=1`,
+      `${RELEASES_URL}?per_page=30&page=2`,
+    ]);
+  });
+
   it("names the releases it saw when none is a platform v* release", async () => {
+    const calls: string[] = [];
     await expect(
       resolveTargetVersion(undefined, {
-        fetchText: async () =>
-          JSON.stringify([
-            { tag_name: "cli@1.0.0-beta.56", draft: false, prerelease: false },
-            { tag_name: "core@9.0.0", draft: false, prerelease: false },
-          ]),
+        fetchText: paged([[release("cli@1.0.0-beta.56"), release("core@9.0.0")]], calls),
       }),
     ).rejects.toThrow(
       /No platform v\* release among the newest 2 .*cli@1\.0\.0-beta\.56, core@9\.0\.0/,
     );
+    // Stopped at the first empty page, not at the page cap.
+    expect(calls).toHaveLength(2);
+  });
+
+  it("stops at the page cap when every page holds only npm-package releases", async () => {
+    const calls: string[] = [];
+    await expect(
+      resolveTargetVersion(undefined, {
+        fetchText: async (url) => {
+          calls.push(url);
+          return JSON.stringify([release("cli@1.0.0-beta.56")]);
+        },
+      }),
+    ).rejects.toThrow(/No platform v\* release among the newest 5 /);
+    expect(calls).toHaveLength(5);
   });
 
   it("throws on malformed GitHub response", async () => {

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -56,19 +56,6 @@ describe("assetName + releaseUrls", () => {
     expect(assetName({ platform: "darwin", arch: "x64" })).toBe("appstrate-darwin-x64");
   });
 
-  it("builds /latest/download URLs when target is 'latest'", () => {
-    const urls = releaseUrls("latest", { platform: "linux", arch: "x64" });
-    expect(urls.binary).toBe(
-      "https://github.com/appstrate/appstrate/releases/latest/download/appstrate-linux-x64",
-    );
-    expect(urls.checksums).toBe(
-      "https://github.com/appstrate/appstrate/releases/latest/download/checksums.txt",
-    );
-    expect(urls.checksumsSig).toBe(
-      "https://github.com/appstrate/appstrate/releases/latest/download/checksums.txt.minisig",
-    );
-  });
-
   it("builds /download/v<version>/ URLs for a pinned version", () => {
     const urls = releaseUrls("1.2.3", { platform: "darwin", arch: "arm64" });
     expect(urls.binary).toBe(
@@ -183,24 +170,59 @@ describe("resolveTargetVersion", () => {
     ).rejects.toThrow(/Invalid version/);
   });
 
-  it("queries GitHub when no version is requested", async () => {
+  it("lists GitHub releases when no version is requested", async () => {
     const calls: string[] = [];
     const out = await resolveTargetVersion(undefined, {
       fetchText: async (url) => {
         calls.push(url);
-        return JSON.stringify({ tag_name: "v2.5.0" });
+        return JSON.stringify([{ tag_name: "v2.5.0", draft: false, prerelease: false }]);
       },
     });
     expect(out).toBe("2.5.0");
-    expect(calls).toEqual(["https://api.github.com/repos/appstrate/appstrate/releases/latest"]);
+    expect(calls).toEqual([
+      "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30",
+    ]);
   });
 
-  it("names a non-platform latest release instead of building a v-prefixed URL", async () => {
+  it("skips newer npm-package releases and picks the newest platform v* release", async () => {
+    // The exact shape of the "latest" hijack: a `cli@` Release created after
+    // the platform one. `releases/latest` would return it; the list does not.
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: async () =>
+        JSON.stringify([
+          { tag_name: "cli@1.0.0-beta.56", draft: false, prerelease: false },
+          { tag_name: "core@9.0.0", draft: false, prerelease: false },
+          { tag_name: "v1.0.0-beta.56", draft: false, prerelease: false },
+          { tag_name: "v1.0.0-beta.55", draft: false, prerelease: false },
+        ]),
+    });
+    expect(out).toBe("1.0.0-beta.56");
+  });
+
+  it("skips draft and prerelease v* releases like releases/latest does", async () => {
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: async () =>
+        JSON.stringify([
+          { tag_name: "v3.0.0", draft: true, prerelease: false },
+          { tag_name: "v2.9.0-rc.1", draft: false, prerelease: true },
+          { tag_name: "v2.8.0", draft: false, prerelease: false },
+        ]),
+    });
+    expect(out).toBe("2.8.0");
+  });
+
+  it("names the releases it saw when none is a platform v* release", async () => {
     await expect(
       resolveTargetVersion(undefined, {
-        fetchText: async () => JSON.stringify({ tag_name: "cli@1.0.0-beta.56" }),
+        fetchText: async () =>
+          JSON.stringify([
+            { tag_name: "cli@1.0.0-beta.56", draft: false, prerelease: false },
+            { tag_name: "core@9.0.0", draft: false, prerelease: false },
+          ]),
       }),
-    ).rejects.toThrow(/"cli@1\.0\.0-beta\.56", not a platform v\* release/);
+    ).rejects.toThrow(
+      /No platform v\* release among the newest 2 .*cli@1\.0\.0-beta\.56, core@9\.0\.0/,
+    );
   });
 
   it("throws on malformed GitHub response", async () => {
@@ -208,7 +230,10 @@ describe("resolveTargetVersion", () => {
       resolveTargetVersion(undefined, { fetchText: async () => "not json" }),
     ).rejects.toThrow(/non-JSON/);
     await expect(resolveTargetVersion(undefined, { fetchText: async () => "{}" })).rejects.toThrow(
-      /missing tag_name/,
+      /not a release list/,
+    );
+    await expect(resolveTargetVersion(undefined, { fetchText: async () => "[]" })).rejects.toThrow(
+      /No platform v\* release among the newest 0/,
     );
   });
 

--- a/scripts/bootstrap-runner.sh
+++ b/scripts/bootstrap-runner.sh
@@ -85,17 +85,26 @@ _appstrate_runner_bootstrap() {
   # platform `v*` Release carries the CLI binaries; `releases/latest` can name
   # an npm-package Release instead.
   resolve_latest_platform_release() {
-    curl -fsSL -H 'Accept: application/vnd.github+json' \
-      'https://api.github.com/repos/appstrate/appstrate/releases?per_page=30' \
-      | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)' \
-      | awk -F': *' '
+    local page fields tag
+    for page in 1 2 3 4 5; do
+      fields=$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30&page=${page}" \
+        | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)') || true
+      [ -z "$fields" ] && return 1
+      tag=$(printf '%s\n' "$fields" | awk -F': *' '
           $1 ~ /tag_name/   { gsub(/"/, "", $2); tag = $2; draft = ""; pre = "" }
           $1 ~ /"draft"/    { draft = $2 }
           $1 ~ /prerelease/ { pre = $2 }
           tag != "" && draft != "" && pre != "" {
             if (tag ~ /^v[0-9]+\.[0-9]+\.[0-9]+/ && draft == "false" && pre == "false") { print tag; exit }
             tag = ""
-          }'
+          }')
+      if [ -n "$tag" ]; then
+        printf '%s\n' "$tag"
+        return 0
+      fi
+    done
+    return 1
   }
 
   if [ "$VERSION" = "latest" ]; then

--- a/scripts/bootstrap-runner.sh
+++ b/scripts/bootstrap-runner.sh
@@ -76,16 +76,37 @@ _appstrate_runner_bootstrap() {
   # Same key as scripts/bootstrap.sh — signs every release's checksums.txt.
   APPSTRATE_MINISIGN_PUBKEY="RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e"
 
-  if [ "$VERSION" = "latest" ]; then
-    URL_BASE="https://github.com/appstrate/appstrate/releases/latest/download"
-  else
-    URL_BASE="https://github.com/appstrate/appstrate/releases/download/${VERSION}"
-  fi
-
   TMPDIR=$(mktemp -d)
   trap 'rm -rf "$TMPDIR"' EXIT
   log() { printf '\033[0;36m→\033[0m  %s\n' "$*"; }
   err() { printf '\033[0;31m✗\033[0m  %s\n' "$*" >&2; }
+
+  # Same resolver as scripts/bootstrap.sh — see the comment there. Only a
+  # platform `v*` Release carries the CLI binaries; `releases/latest` can name
+  # an npm-package Release instead.
+  resolve_latest_platform_release() {
+    curl -fsSL -H 'Accept: application/vnd.github+json' \
+      'https://api.github.com/repos/appstrate/appstrate/releases?per_page=30' \
+      | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)' \
+      | awk -F': *' '
+          $1 ~ /tag_name/   { gsub(/"/, "", $2); tag = $2; draft = ""; pre = "" }
+          $1 ~ /"draft"/    { draft = $2 }
+          $1 ~ /prerelease/ { pre = $2 }
+          tag != "" && draft != "" && pre != "" {
+            if (tag ~ /^v[0-9]+\.[0-9]+\.[0-9]+/ && draft == "false" && pre == "false") { print tag; exit }
+            tag = ""
+          }'
+  }
+
+  if [ "$VERSION" = "latest" ]; then
+    VERSION=$(resolve_latest_platform_release || true)
+    if [ -z "$VERSION" ]; then
+      err "No platform v* release found among the newest GitHub Releases. Pin one with APPSTRATE_VERSION=vX.Y.Z."
+      exit 1
+    fi
+    log "Resolved latest platform release: $VERSION"
+  fi
+  URL_BASE="https://github.com/appstrate/appstrate/releases/download/${VERSION}"
 
   log "Downloading Appstrate CLI ($OS/$ARCH, $VERSION)"
   curl -fsSL "${URL_BASE}/${ASSET}" -o "$TMPDIR/$ASSET"

--- a/scripts/bootstrap-runner.sh
+++ b/scripts/bootstrap-runner.sh
@@ -88,8 +88,8 @@ _appstrate_runner_bootstrap() {
     local page fields tag
     for page in 1 2 3 4 5; do
       fields=$(curl -fsSL -H 'Accept: application/vnd.github+json' \
-        "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30&page=${page}" \
-        | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)') || true
+        "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30&page=${page}" |
+        grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)') || true
       [ -z "$fields" ] && return 1
       tag=$(printf '%s\n' "$fields" | awk -F': *' '
           $1 ~ /tag_name/   { gsub(/"/, "", $2); tag = $2; draft = ""; pre = "" }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -120,15 +120,6 @@ _appstrate_bootstrap() {
   # Rotation SOP: docs/adr/ADR-006-cli-device-flow-monorepo.md.
   APPSTRATE_MINISIGN_PUBKEY="RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e"
 
-  if [ "$VERSION" = "latest" ]; then
-    URL_BASE="https://github.com/appstrate/appstrate/releases/latest/download"
-  else
-    URL_BASE="https://github.com/appstrate/appstrate/releases/download/${VERSION}"
-  fi
-  URL="${URL_BASE}/${ASSET}"
-  CHECKSUMS_URL="${URL_BASE}/checksums.txt"
-  CHECKSUMS_SIG_URL="${URL_BASE}/checksums.txt.minisig"
-
   # ─── Helpers ────────────────────────────────────────────────────────────────
 
   TMPDIR=$(mktemp -d)
@@ -137,6 +128,42 @@ _appstrate_bootstrap() {
   warn() { printf '\033[0;33m⚠\033[0m  %s\n' "$*" >&2; }
   log() { printf '\033[0;36m→\033[0m  %s\n' "$*"; }
   err() { printf '\033[0;31m✗\033[0m  %s\n' "$*" >&2; }
+
+  # Newest platform `v<semver>` GitHub Release, resolved by listing — not
+  # `releases/latest`. GitHub's "latest" is whichever non-prerelease Release
+  # was created last, whatever its tag: a `cli@` / `core@` / `afps-shared@`
+  # Release published without `make_latest: false`, or created by hand, would
+  # be handed back and carries no CLI binary (`checksums.txt.minisig` 404).
+  # Only `v*` Releases ship the assets this script downloads. Drafts and
+  # prereleases are skipped, same as `releases/latest`. No jq: the three
+  # fields are grepped in document order (tag_name precedes draft/prerelease
+  # in GitHub's payload) and awk decides once it holds all three.
+  resolve_latest_platform_release() {
+    curl -fsSL -H 'Accept: application/vnd.github+json' \
+      'https://api.github.com/repos/appstrate/appstrate/releases?per_page=30' \
+      | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)' \
+      | awk -F': *' '
+          $1 ~ /tag_name/   { gsub(/"/, "", $2); tag = $2; draft = ""; pre = "" }
+          $1 ~ /"draft"/    { draft = $2 }
+          $1 ~ /prerelease/ { pre = $2 }
+          tag != "" && draft != "" && pre != "" {
+            if (tag ~ /^v[0-9]+\.[0-9]+\.[0-9]+/ && draft == "false" && pre == "false") { print tag; exit }
+            tag = ""
+          }'
+  }
+
+  if [ "$VERSION" = "latest" ]; then
+    VERSION=$(resolve_latest_platform_release || true)
+    if [ -z "$VERSION" ]; then
+      err "No platform v* release found among the newest GitHub Releases. Pin one with APPSTRATE_VERSION=vX.Y.Z."
+      exit 1
+    fi
+    log "Resolved latest platform release: $VERSION"
+  fi
+  URL_BASE="https://github.com/appstrate/appstrate/releases/download/${VERSION}"
+  URL="${URL_BASE}/${ASSET}"
+  CHECKSUMS_URL="${URL_BASE}/checksums.txt"
+  CHECKSUMS_SIG_URL="${URL_BASE}/checksums.txt.minisig"
 
   # ─── Retired env vars ───────────────────────────────────────────────────────
   #

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -145,9 +145,10 @@ _appstrate_bootstrap() {
   resolve_latest_platform_release() {
     local page fields tag
     for page in 1 2 3 4 5; do
-      fields=$(curl -fsSL -H 'Accept: application/vnd.github+json' \
-        "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30&page=${page}" \
-        | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)') || true
+      # shellcheck disable=SC2086 # CURL_OPTS is word-split on purpose (see its definition)
+      fields=$(curl $CURL_OPTS -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30&page=${page}" |
+        grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)') || true
       [ -z "$fields" ] && return 1
       tag=$(printf '%s\n' "$fields" | awk -F': *' '
           $1 ~ /tag_name/   { gsub(/"/, "", $2); tag = $2; draft = ""; pre = "" }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -135,21 +135,34 @@ _appstrate_bootstrap() {
   # Release published without `make_latest: false`, or created by hand, would
   # be handed back and carries no CLI binary (`checksums.txt.minisig` 404).
   # Only `v*` Releases ship the assets this script downloads. Drafts and
-  # prereleases are skipped, same as `releases/latest`. No jq: the three
-  # fields are grepped in document order (tag_name precedes draft/prerelease
-  # in GitHub's payload) and awk decides once it holds all three.
+  # prereleases are skipped, same as `releases/latest`. Pages of 30 are walked
+  # (5 at most) until one holds a `v*` Release. No jq: the three fields are
+  # grepped in document order (tag_name precedes draft/prerelease in GitHub's
+  # payload) and awk decides once it holds all three. Creation order within a
+  # page, unlike the CLI's highest-semver pick: BSD sort has no -V and a
+  # semver comparator in awk is not worth it for a path the rendered installer
+  # never takes (it pins `__APPSTRATE_VERSION__`).
   resolve_latest_platform_release() {
-    curl -fsSL -H 'Accept: application/vnd.github+json' \
-      'https://api.github.com/repos/appstrate/appstrate/releases?per_page=30' \
-      | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)' \
-      | awk -F': *' '
+    local page fields tag
+    for page in 1 2 3 4 5; do
+      fields=$(curl -fsSL -H 'Accept: application/vnd.github+json' \
+        "https://api.github.com/repos/appstrate/appstrate/releases?per_page=30&page=${page}" \
+        | grep -oE '"(tag_name|draft|prerelease)": *("[^"]*"|true|false)') || true
+      [ -z "$fields" ] && return 1
+      tag=$(printf '%s\n' "$fields" | awk -F': *' '
           $1 ~ /tag_name/   { gsub(/"/, "", $2); tag = $2; draft = ""; pre = "" }
           $1 ~ /"draft"/    { draft = $2 }
           $1 ~ /prerelease/ { pre = $2 }
           tag != "" && draft != "" && pre != "" {
             if (tag ~ /^v[0-9]+\.[0-9]+\.[0-9]+/ && draft == "false" && pre == "false") { print tag; exit }
             tag = ""
-          }'
+          }')
+      if [ -n "$tag" ]; then
+        printf '%s\n' "$tag"
+        return 0
+      fi
+    done
+    return 1
   }
 
   if [ "$VERSION" = "latest" ]; then


### PR DESCRIPTION
## Summary

`appstrate self-update`, `scripts/bootstrap.sh` and `scripts/bootstrap-runner.sh` resolved "latest" through GitHub's `releases/latest`, which is whichever non-prerelease Release was created last, whatever its tag. #1255 put `make_latest: false` on the three npm workflows (`cli@`, `core@`, `afps-shared@`), which fixed the observed window (validated on beta.57), but the guard lives in each workflow: a future workflow without the flag, or a Release created by hand in the UI, hands the consumers a tag with no CLI binary and they die on a 404 for `checksums.txt.minisig`.

The three consumers now list the Releases API themselves, skipping drafts and prereleases exactly as `releases/latest` does, and walk pages of 30 (5 at most) until one holds a platform `v<semver>` Release. Nothing outside `release.yml` can steer an update any more.

- **CLI** (`apps/cli/src/lib/self-update.ts`): `resolveTargetVersion` pages and filters, then takes the **highest version** on the first page that holds a candidate (`compareSemver`), not the most recently created — a hotfix for an older line published after a newer release must not become latest. When no `v*` release is found it names the ones it skipped. The `latest/download` branch of `releaseUrls` is removed: no caller can reach it now.
- **Bootstrap scripts**: `resolve_latest_platform_release()` (curl + grep + awk, no jq) pages the same way and resolves the tag once; the download URL is always the pinned form. Creation order within a page is kept there: BSD `sort` has no `-V`, and this path only runs for an unrendered copy or `APPSTRATE_VERSION=latest`. Note the rendered installer pins `__APPSTRATE_VERSION__` at publish time, so this path only runs for an unrendered copy or `APPSTRATE_VERSION=latest`.
- CHANGELOG entry under Unreleased / Changed.

## Validation

- `apps/cli` self-update suite: 45 passed (new cases: `cli@` newer than `v*` → picks `v*`; hotfix `v1.0.1` created after `v1.1.0` → `1.1.0`; `beta.9` vs `beta.57` numeric; draft/prerelease `v*` skipped; page 1 npm-only → page 2; stop at first empty page; stop at the 5-page cap; `{}` / `[]` responses).
- The shell resolver run against the live API returns `v1.0.0-beta.57` while `cli@1.0.0-beta.57` sits in the same page; field order (`tag_name` before `draft`/`prerelease`) confirmed on the live payload. With a stubbed `curl`: page 1 npm-only + page 2 `v*` → `v1.0.0-beta.56`; npm-only everywhere → 5 calls then exit 1.
- `shellcheck -S warning` clean on both scripts; `bash -n` clean.
- `bun run check`: 38/38 via the pre-push hook.
- Not exercised: a real `curl … | bash` install through the new resolver (needs a rendered script from `publish-installer.yml`); `test-install.yml` covers that in CI.

Follow-up to #1255. The remaining dependency on the GitHub API (60 req/h unauthenticated) is the subject of #1271 (signed channel manifest on get.appstrate.dev).
