### PR TITLE
fix(scripts): resolve the latest release after the bootstrap source-only guard

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -166,19 +166,6 @@ _appstrate_bootstrap() {
     return 1
   }
 
-  if [ "$VERSION" = "latest" ]; then
-    VERSION=$(resolve_latest_platform_release || true)
-    if [ -z "$VERSION" ]; then
-      err "No platform v* release found among the newest GitHub Releases. Pin one with APPSTRATE_VERSION=vX.Y.Z."
-      exit 1
-    fi
-    log "Resolved latest platform release: $VERSION"
-  fi
-  URL_BASE="https://github.com/appstrate/appstrate/releases/download/${VERSION}"
-  URL="${URL_BASE}/${ASSET}"
-  CHECKSUMS_URL="${URL_BASE}/checksums.txt"
-  CHECKSUMS_SIG_URL="${URL_BASE}/checksums.txt.minisig"
-
   # ─── Retired env vars ───────────────────────────────────────────────────────
   #
   # APPSTRATE_AUTO_INSTALL=1 selected unattended mode; `--yes` says the same
@@ -581,6 +568,21 @@ _appstrate_bootstrap() {
   fi
 
   # ─── Download + verify ──────────────────────────────────────────────────────
+
+  # Resolved here, past the SOURCE_ONLY return above: a test harness that
+  # sources this script must define the helpers without a network call.
+  if [ "$VERSION" = "latest" ]; then
+    VERSION=$(resolve_latest_platform_release || true)
+    if [ -z "$VERSION" ]; then
+      err "No platform v* release found among the newest GitHub Releases. Pin one with APPSTRATE_VERSION=vX.Y.Z."
+      exit 1
+    fi
+    log "Resolved latest platform release: $VERSION"
+  fi
+  URL_BASE="https://github.com/appstrate/appstrate/releases/download/${VERSION}"
+  URL="${URL_BASE}/${ASSET}"
+  CHECKSUMS_URL="${URL_BASE}/checksums.txt"
+  CHECKSUMS_SIG_URL="${URL_BASE}/checksums.txt.minisig"
 
   log "Downloading Appstrate CLI ($OS/$ARCH, $VERSION)"
   curl $CURL_OPTS "$URL" -o "$TMPDIR/$ASSET"


### PR DESCRIPTION
## Summary

Follow-up to #1270, which left **Unit tests red on `main`** (4 failures in `apps/api/test/unit/scripts-bootstrap.test.ts`, see [the run](https://github.com/appstrate/appstrate/actions/runs/34054425995/job/101543629763)). I merged #1270 on a `--watch` output that had scrolled that row out of view; the failure is mine.

That harness sources the unrendered `bootstrap.sh` with `APPSTRATE_BOOTSTRAP_SOURCE_ONLY=1` to reach the minisign helpers. #1270 put the GitHub Releases lookup (`VERSION=latest` → `resolve_latest_platform_release`) among the variable setup at the top of `_appstrate_bootstrap`, before that guard's `return`, so every test paid a network call (one 5 s timeout) and its stdout carried the resolver's log line (three `stdout.trim()` assertions off by one line).

The resolution block and the four URL variables now live in the download step, after the guard, next to their first consumer. No behavior change for a real run.

## Validation

- Control on `main`'s script: 3 failures locally (the 4th is the 5 s timeout, which the local network was fast enough to dodge). Fixed script: 15/15.
- `shfmt -d -i 2 -ci`, `shellcheck -S warning`, `bash -n`: clean.
- `bun run check` 38/38 via pre-push.