### PR TITLE
fix(auth): grant scope-less DCR registrants the self-service scope set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,12 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
 
 ### Fixed
 
+- **A Dynamic Client Registration body without `scope` now yields the full
+  self-service scope set (#1267).** An MCP client registering without `scope`
+  got the identity scopes alone, so authorizing for `mcp:read` / `mcp:invoke`
+  was bounced with `invalid_scope`. Narrow registrations stay narrow — and an
+  already-registered scope-less client reads as one, so it must re-register.
+
 - **A killed `appstrate skills sync` no longer locks the next ten minutes of
   sessions out.** Closing a Claude Code session seconds after opening it kills
   the background sync it spawned, and the `mkdir` lock only expired by age —

--- a/apps/api/src/modules/oidc/auth/plugins.ts
+++ b/apps/api/src/modules/oidc/auth/plugins.ts
@@ -58,8 +58,7 @@ import { socialOverridePlugin } from "../services/ba-social-override-plugin.ts";
 import { oidcGuardsPlugin } from "./guards.ts";
 import { cliTokenPlugin } from "./cli-plugin.ts";
 import { assertUserRealm } from "./realm-check.ts";
-import { getAppstrateScopes, OIDC_IDENTITY_SCOPES } from "./scopes.ts";
-import { getModuleEndUserAllowedScopes } from "@appstrate/core/permissions";
+import { getAppstrateScopes, getSelfServiceScopes } from "./scopes.ts";
 import { isBlockedUrlWithDns } from "../../../lib/ssrf-dns.ts";
 import { markClientSelfService } from "../services/oauth-admin.ts";
 import { mcpValidAudiences, initMcpValidAudiences } from "../../../lib/audiences.ts";
@@ -174,7 +173,7 @@ export function oidcBetterAuthPlugins(opts: OidcBetterAuthPluginsOptions = {}): 
   // Deliberately EXCLUDES core action scopes (agents:run, llm-proxy:call, …) —
   // those remain for admin-managed first-party clients. The user-consent screen
   // and the caller's own permissions still gate the actual grant on top of this.
-  const selfServiceScopes = [...OIDC_IDENTITY_SCOPES, ...getModuleEndUserAllowedScopes()];
+  const selfServiceScopes = getSelfServiceScopes();
   const cachedTrustedClients =
     opts.cachedTrustedClientIds && opts.cachedTrustedClientIds.length > 0
       ? new Set(opts.cachedTrustedClientIds)
@@ -267,9 +266,12 @@ export function oidcBetterAuthPlugins(opts: OidcBetterAuthPluginsOptions = {}): 
       // self-service scope set (identity + module scopes), PKCE is enforced by
       // the plugin, and the /oauth2/register endpoint is rate-limited in
       // routes.ts. The user-consent screen remains the real authorization gate.
+      // Default and ceiling are the same set so a body without `scope` can
+      // still reach `mcp:*` at authorize; it grants nothing the registrant
+      // could not already request explicitly.
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
-      clientRegistrationDefaultScopes: [...OIDC_IDENTITY_SCOPES],
+      clientRegistrationDefaultScopes: getSelfServiceScopes(),
       clientRegistrationAllowedScopes: selfServiceScopes,
       storeClientSecret: {
         hash: hashSecret,

--- a/apps/api/src/modules/oidc/auth/scopes.ts
+++ b/apps/api/src/modules/oidc/auth/scopes.ts
@@ -87,6 +87,14 @@ export const APPSTRATE_BUILTIN_SCOPES: readonly string[] = [
 ];
 
 /**
+ * Scope ceiling for self-service (DCR / CIMD) clients: identity scopes plus
+ * every module end-user-grantable scope. Evaluated per call, fresh array.
+ */
+export function getSelfServiceScopes(): string[] {
+  return [...OIDC_IDENTITY_SCOPES, ...getModuleEndUserAllowedScopes()];
+}
+
+/**
  * Full scope vocabulary served by the OIDC module — core built-ins plus any
  * module scopes opted in via `endUserGrantable: true`.
  *

--- a/apps/api/src/modules/oidc/services/oauth-admin.ts
+++ b/apps/api/src/modules/oidc/services/oauth-admin.ts
@@ -45,8 +45,7 @@ import { spaces } from "@appstrate/db/schema";
 import { oauthClient } from "@appstrate/db/schema";
 import { prefixedId } from "../../../lib/ids.ts";
 import { logger } from "../../../lib/logger.ts";
-import { getAppstrateScopeSet, OIDC_IDENTITY_SCOPES } from "../auth/scopes.ts";
-import { getModuleEndUserAllowedScopes } from "@appstrate/core/permissions";
+import { getAppstrateScopeSet, getSelfServiceScopes } from "../auth/scopes.ts";
 import { isValidRedirectUri } from "./redirect-uri.ts";
 
 // ─── SECURITY: Trust boundary ─────────────────────────────────────────────────
@@ -465,9 +464,7 @@ export async function markClientSelfService(
   // (identity + module end-user-grantable scopes, e.g. mcp:read/mcp:invoke) so
   // the client may request them. Only fill when empty — never widen a client
   // that deliberately declared a narrower scope set.
-  const scopes = row.scopes?.length
-    ? row.scopes
-    : [...OIDC_IDENTITY_SCOPES, ...getModuleEndUserAllowedScopes()];
+  const scopes = row.scopes?.length ? row.scopes : getSelfServiceScopes();
   const stamped = { scopes, metadata: JSON.stringify(metadata) };
 
   await db

--- a/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
@@ -212,11 +212,9 @@ describe("Dynamic Client Registration (RFC 7591)", () => {
   });
 
   it("registers a public client unauthenticated with identity scopes", async () => {
-    // Identity scopes are always in the self-service set. Module scopes
-    // (mcp:read/mcp:invoke) are added in production via the module-permission
-    // provider (`getModuleEndUserAllowedScopes()`), which boot wires before the
-    // auth instance builds — the test harness doesn't aggregate module
-    // permissions, so they aren't asserted here.
+    // An explicit `scope` is honoured verbatim: this registration asks for the
+    // identity scopes only and gets exactly those, whatever else the
+    // self-service ceiling holds.
     const { status, json } = await register({
       client_name: "Claude Code (test)",
       redirect_uris: ["http://localhost:9911/callback"],

--- a/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
@@ -37,6 +37,7 @@ import {
   _resetMcpOrgAudiencesForTesting,
 } from "../../../../../lib/audiences.ts";
 import { getEnv } from "@appstrate/env";
+import { OIDC_IDENTITY_SCOPES } from "../../../auth/scopes.ts";
 import oidcModule from "../../../index.ts";
 
 const app = getTestApp({ modules: [oidcModule] });
@@ -211,10 +212,22 @@ describe("Dynamic Client Registration (RFC 7591)", () => {
     resetOidcGuardsLimiters();
   });
 
-  it("registers a public client unauthenticated with identity scopes", async () => {
-    // An explicit `scope` is honoured verbatim: this registration asks for the
-    // identity scopes only and gets exactly those, whatever else the
-    // self-service ceiling holds.
+  async function authorizeClient(clientId: string, redirectUri: string, scope: string) {
+    const query = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      scope,
+      code_challenge: "a".repeat(43),
+      code_challenge_method: "S256",
+      state: "dcr-authorization",
+    });
+    return app.request(`/api/auth/oauth2/authorize?${query}`);
+  }
+
+  it("honours an explicit identity-only scope", async () => {
+    // Asks for the identity scopes and gets exactly those — the self-service
+    // ceiling never widens an explicit request.
     const { status, json } = await register({
       client_name: "Claude Code (test)",
       redirect_uris: ["http://localhost:9911/callback"],
@@ -225,8 +238,59 @@ describe("Dynamic Client Registration (RFC 7591)", () => {
     });
     expect([200, 201]).toContain(status);
     expect(typeof json.client_id).toBe("string");
+    expect(String(json.scope).split(" ").sort()).toEqual([...OIDC_IDENTITY_SCOPES].sort());
     // Public client (PKCE) — registered with no client authentication method.
     expect(json.token_endpoint_auth_method ?? "none").toBe("none");
+  });
+
+  it("defaults a scope-less registration to the self-service set and authorizes it", async () => {
+    const redirectUri = "http://localhost:9915/callback";
+    const { status, json } = await register({
+      client_name: "MCP client (no scope)",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    });
+    expect([200, 201]).toContain(status);
+    // `mcp` is the only module contributing end-user scopes today, and
+    // `getTestApp({ modules: [oidcModule] })` narrows the live provider — hence
+    // the literals. A superset, so a second module opting in stays green.
+    const scopes = String(json.scope).split(" ");
+    expect(scopes).toEqual(
+      expect.arrayContaining([...OIDC_IDENTITY_SCOPES, "mcp:read", "mcp:invoke"]),
+    );
+    expect(scopes).not.toContain("agents:run");
+
+    const authorized = await authorizeClient(
+      String(json.client_id),
+      redirectUri,
+      "mcp:read mcp:invoke offline_access",
+    );
+    expect(authorized.status).toBe(302);
+    expect(new URL(authorized.headers.get("location")!, "http://localhost").pathname).toBe(
+      "/api/oauth/login",
+    );
+  });
+
+  it("keeps an explicitly narrow registration narrow", async () => {
+    const redirectUri = "http://localhost:9916/callback";
+    const { status, json } = await register({
+      client_name: "Narrow client",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      scope: "openid",
+    });
+    expect([200, 201]).toContain(status);
+    expect(String(json.scope)).toBe("openid");
+
+    const rejected = await authorizeClient(String(json.client_id), redirectUri, "mcp:read");
+    expect(rejected.status).toBe(302);
+    expect(
+      new URL(rejected.headers.get("location")!, "http://localhost").searchParams.get("error"),
+    ).toBe("invalid_scope");
   });
 
   it("rejects a registration requesting a core action scope outside the self-service set", async () => {

--- a/test/setup/preload.ts
+++ b/test/setup/preload.ts
@@ -362,9 +362,23 @@ for (const { dir: moduleDir, entry: indexFile } of moduleEntries) {
 // cast needed at this layer. Subsequent `getTestApp({ modules })` calls
 // reuse this singleton so strategy tests and E2E OAuth flow tests see a
 // coherent auth surface with no double-initialization cost.
-const { collectModuleContributions, emitEvent, loadModulesFromInstances } =
-  await import("../../apps/api/src/lib/modules/module-loader.ts");
+const {
+  collectModuleContributions,
+  collectModulePermissions,
+  emitEvent,
+  loadModulesFromInstances,
+} = await import("../../apps/api/src/lib/modules/module-loader.ts");
+const { setModulePermissionsProvider, setPermissionDenialHandler } =
+  await import("@appstrate/core/permissions");
 const { createAuth, setPostBootstrapOrgHook } = await import("../../packages/db/src/auth.ts");
+
+// Register module RBAC contributions BEFORE the plugins are built — mirrors
+// boot.ts, where `loadModules()` runs ahead of `createAuth()`. Plugin
+// factories read `getModuleEndUserAllowedScopes()` at construction; phase 3
+// re-sets an identical snapshot.
+const preloadRbacSnapshot = collectModulePermissions(importedModules);
+setModulePermissionsProvider(() => preloadRbacSnapshot);
+
 const contributions = collectModuleContributions(importedModules);
 createAuth(contributions.betterAuthPlugins as Parameters<typeof createAuth>[0]);
 
@@ -410,12 +424,10 @@ setPostBootstrapOrgHook(async ({ orgId, slug, userId, userEmail }) => {
 // process (see the "Testing" header in CLAUDE.md). Reset after every
 // test so no test needs to remember an `afterEach` of its own.
 //
-// Registering through a dynamic import avoids coupling this preload to
-// the core types at top-level, and lets us tolerate the (already
-// unlikely) case where the module fails to resolve — we log and move on
-// rather than blocking the whole suite.
+// The handler comes from the single dynamic `@appstrate/core/permissions`
+// import above, which keeps this preload uncoupled from the core types at
+// top level.
 const { afterEach } = await import("bun:test");
-const { setPermissionDenialHandler } = await import("@appstrate/core/permissions");
 afterEach(() => {
   setPermissionDenialHandler(null);
 });


### PR DESCRIPTION
## Summary

A Dynamic Client Registration (RFC 7591) body without `scope` was stored with the identity scopes only, because `clientRegistrationDefaultScopes` was `OIDC_IDENTITY_SCOPES` while the ceiling (`clientRegistrationAllowedScopes`) was the full self-service set. Every following `/oauth2/authorize` asking `mcp:read mcp:invoke` was bounced with `invalid_scope` before login, and nothing repaired the row: `markClientSelfService` only backfills an empty scope set (the CIMD case).

The default is now the same set as the ceiling. This grants nothing new: any anonymous registrant could already request the whole self-service set explicitly (issue step 4), consent is unavoidable on the DCR path (`skip_consent` is rejected at registration), and the RFC 8707 audience confinement at `/oauth2/token` is untouched. The ceiling itself still excludes core action scopes (`agents:run`, `llm-proxy:call`, …).

The self-service ceiling is now defined once (`getSelfServiceScopes()` in `auth/scopes.ts`) and used by both the plugin options and `markClientSelfService`, since the fix makes the two agree by construction.

Closes #1267

## Test harness

The test preload built the Better Auth instance **before** registering module permissions, the reverse of `boot.ts` (`loadModules()` → `createAuth()`). Under test, `selfServiceScopes` and discovery `scopes_supported` therefore never contained a module scope, which is exactly why no existing test could tell the bug from the fix. The preload now registers the module RBAC snapshot before `collectModuleContributions()`, mirroring production order. Blast radius audited: every existing `scopes_supported` assertion uses `toContain`, and the full suite is green.

## Regression tests

- Scope-less registration → response `scope` contains the identity scopes plus `mcp:read`/`mcp:invoke` and no core action scope; `/authorize` for `mcp:read mcp:invoke offline_access` redirects to `/api/oauth/login`. Fails on `main` (reverting the one-line default makes it fail on the `mcp:read`/`mcp:invoke` assertion).
- Explicit `scope: "openid"` registration stays narrow: `/authorize` for `mcp:read` → `invalid_scope`.
- The existing explicit-scope test now asserts the returned `scope` instead of only claiming it in a comment.

## Not covered

- Rows already registered scope-less are not repaired: a stored identity-only set is indistinguishable from a deliberate one. Such a client must re-register (noted in the CHANGELOG).
- The issue title attributes the failure to `claude mcp add`; current Claude Code uses CIMD against this server (`client_id_metadata_document_supported: true`), whose first-authorize failure was #1269 / #1266. The DCR default affects MCP clients that register without `scope` (older SDKs without SEP-835 scope selection, non-SDK clients, DCR fallback).

Diagnosis and proposed fix by @otarbes in #1267.

## Type of Change

- [x] Bug fix
- [x] Test infrastructure

## Validation

- `bun run check`: 38/38 tasks.
- `TEST_TIER=0 bun test` (full suite, sequential after check).
- Scoped OIDC + MCP + module-loader suites: 705 pass / 0 fail.
- Discrimination proven by temporarily reverting the default in the working tree: the new test fails on the `mcp:read`/`mcp:invoke` assertion, green with the fix restored.
- `bunx tsc --noEmit` in `apps/api`, eslint and prettier on every touched file, `bun run verify:dead-code`: clean.

## Checklist

- [x] `bun run check` passes (the full 18-task gate — see `CLAUDE.md`)
- [x] `bun test` passes
- [x] I have read the [Contributing Guide](../CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
