### PR TITLE
fix(models): review gpt-6-astra for Codex, re-pin the temperature test after the catalog refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,17 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
 
 ### Fixed
 
+- **Unit tests green again after the 2026-09-07 LiteLLM catalog refresh
+  (#1277).** The refresh brought `gpt-6-astra` into `openai.json`, which
+  `curated-model-drift` rightly flagged as unreviewed for Codex: the vendor
+  page (https://learn.chatgpt.com/docs/models) lists it as recommended for
+  ChatGPT sign-in (Pro plans and above), so it joins the Codex
+  `modelDiscoveryCandidates` and `featuredModels`, newest first. The same
+  refresh marks the whole 5.6 family `temperature: "unsupported"` on the
+  OpenAI API, so the `resolveCatalogDefaults` test that proves the Codex
+  override rejects temperature now reads `gpt-5.4`, an id the API still
+  supports it on.
+
 - **A Dynamic Client Registration body without `scope` now yields the full
   self-service scope set (#1267).** An MCP client registering without `scope`
   got the identity scopes alone, so authorizing for `mcp:read` / `mcp:invoke`

--- a/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
+++ b/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
@@ -73,8 +73,12 @@ describe("resolveCatalogDefaults", () => {
 
   describe("provider generation overrides", () => {
     it("keeps the OpenAI API capability while rejecting temperature on Codex", () => {
-      const openai = resolveCatalogDefaults("openai", "gpt-5.6-luna");
-      const codex = resolveCatalogDefaults("codex", "gpt-5.6-luna");
+      // An id the vendored catalog marks `temperature: "supported"` on the
+      // OpenAI API, so the `unsupported` below can only come from the Codex
+      // override. The 5.6 family no longer qualifies: the 2026-09-07 LiteLLM
+      // refresh (#1277) marks it unsupported on the API too.
+      const openai = resolveCatalogDefaults("openai", "gpt-5.4");
+      const codex = resolveCatalogDefaults("codex", "gpt-5.4");
 
       expect(openai.generation?.temperature).toBe("supported");
       expect(codex.generation?.temperature).toBe("unsupported");

--- a/packages/module-codex/src/index.ts
+++ b/packages/module-codex/src/index.ts
@@ -211,7 +211,8 @@ const codexProvider: ModelProviderDefinition = {
   // subscription never serves, so deriving from it would over-list by a wide
   // margin. Reviewed against
   // https://learn.chatgpt.com/docs/models (Codex with ChatGPT sign-in,
-  // fetched 2026-07-27) and re-reviewed whenever
+  // fetched 2026-07-27, re-read 2026-09-07 when `gpt-6-astra` reached the
+  // catalog) and re-reviewed whenever
   // `apps/api/src/data/subscription-watch/chatgpt.json` drifts.
   //
   // That review is no longer trust-based: `apps/api/test/unit/services/
@@ -220,10 +221,12 @@ const codexProvider: ModelProviderDefinition = {
   // serve is recorded — after checking the doc above — in
   // `apps/api/src/data/subscription-watch/reviewed.json`, never just dropped.
   //
-  // Recommended set, newest first. `gpt-5.3-codex-spark` (Pro-only research
-  // preview) is also recommended but is absent from openai.json, so the boot
-  // check forbids featuring it — it lives in the candidate list only.
-  featuredModels: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+  // Recommended set, newest first. `gpt-6-astra` is documented for Pro plans
+  // and above — like `gpt-5.3-codex-spark`, which is also recommended but is
+  // absent from openai.json, so the boot check forbids featuring it and it
+  // lives in the candidate list only. A plan that does not serve a featured
+  // id finds out at the first run, as for every other id here.
+  featuredModels: ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
   // OFFLINE validation: the platform issues ZERO Codex API calls to test
   // a credential or discover models. The connection test runs the
   // `validateCredential` hook below (local JWT decode) — its mere presence is
@@ -239,6 +242,7 @@ const codexProvider: ModelProviderDefinition = {
   // `gpt-5.3-codex` are deprecated for ChatGPT sign-in and were dropped from
   // both lists.
   modelDiscoveryCandidates: [
+    "gpt-6-astra",
     "gpt-5.6-sol",
     "gpt-5.6-terra",
     "gpt-5.6-luna",

--- a/packages/module-codex/test/unit/codex-module.test.ts
+++ b/packages/module-codex/test/unit/codex-module.test.ts
@@ -32,7 +32,12 @@ describe("codex module", () => {
 
   it("exposes a non-empty featured catalog", () => {
     const codex = codexModule.modelProviders?.()[0];
-    expect(codex?.featuredModels).toEqual(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
+    expect(codex?.featuredModels).toEqual([
+      "gpt-6-astra",
+      "gpt-5.6-sol",
+      "gpt-5.6-terra",
+      "gpt-5.6-luna",
+    ]);
   });
 });
 


### PR DESCRIPTION
## Why

#1277 (the weekly LiteLLM catalog refresh, merged 2026-09-07 18:53) turned `Unit tests` red on `main` (`ba8a38a99`), and every open PR inherits the red through the merge-tip checkout. Two tests, both data-driven and both doing their job:

- `curated-model-drift` — `gpt-6-astra` reached `openai.json` and nobody had ruled on it for Codex.
- `resolveCatalogDefaults` — the case proving the Codex override rejects temperature read `gpt-5.6-luna`, which the refresh now marks `temperature: "unsupported"` on the OpenAI API too, so `openai.generation.temperature` is no longer `"supported"` and the assertion stopped isolating the override.

## What

- **`gpt-6-astra` is curated for Codex.** The vendor page the list is reviewed against — https://learn.chatgpt.com/docs/models (Codex with ChatGPT sign-in), re-read today — lists it under "Recommended", for Pro plans and above. Added first to `modelDiscoveryCandidates` and `featuredModels` on the `codex` provider (`packages/module-codex/src/index.ts`), review date noted in the comment; `codex-module.test.ts` pins the quartet.
- **The temperature test reads `gpt-5.4`**, the newest Codex candidate the catalog still marks `temperature: "supported"` on the API (`gpt-5.4`, `gpt-5.4-mini`; the whole 5.6 family and `gpt-5.5` are now unsupported). The Luna reasoning-contract case next to it is untouched.
- CHANGELOG `[Unreleased]` → Fixed.

No runtime code path changes beyond the two curated arrays.

## Verification

- `curated-model-drift`, `resolve-catalog-defaults`, `model-providers-registry`, `oauth-model-providers-registry`, `subscription-run-policy`: 52 pass. `packages/module-codex`: 26 pass. tsc (api, module-codex), eslint, prettier clean; pre-push `bun run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
