### PR TITLE
fix: stability audit 2026-09 — OAuth refresh race, buffer dead-head, SSE reconnect, LISTEN recovery, local queue/buffer

### DIFF
--- a/apps/api/src/infra/event-buffer/interface.ts
+++ b/apps/api/src/infra/event-buffer/interface.ts
@@ -15,6 +15,18 @@
 
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 
+/**
+ * Hard cap on buffered events per run. A pathological runner that
+ * permanently skips a sequence would otherwise accumulate every later
+ * event in the buffer until the watchdog finalises the run — sized 100×
+ * above any realistic burst so the happy path never trips this. When
+ * it does trip, we drop the LOWEST-sequenced entries (the stale ones
+ * waiting on the missing gap) so the most recent events are kept.
+ *
+ * Both backends enforce it identically and log the same overflow warning.
+ */
+export const MAX_BUFFER_ENTRIES = 10_000;
+
 export interface BufferedEvent {
   sequence: number;
   event: RunEvent;

--- a/apps/api/src/infra/event-buffer/local-event-buffer.ts
+++ b/apps/api/src/infra/event-buffer/local-event-buffer.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { RunEvent } from "@appstrate/afps-runtime/types";
-import type { EventBuffer, BufferedEvent } from "./interface.ts";
+import { logger } from "../../lib/logger.ts";
+import { MAX_BUFFER_ENTRIES, type EventBuffer, type BufferedEvent } from "./interface.ts";
 
 interface Entry {
   sequence: number;
@@ -27,20 +28,36 @@ export class LocalEventBuffer implements EventBuffer {
   }
 
   async put(runId: string, sequence: number, event: RunEvent, ttlSeconds: number): Promise<void> {
-    const expiresAt = Date.now() + ttlSeconds * 1000;
-    const entry: Entry = { sequence, event, expiresAt };
-    const existing = this.buffers.get(runId);
-    if (!existing) {
+    const entry: Entry = { sequence, event, expiresAt: Date.now() + ttlSeconds * 1000 };
+    const entries = this.buffers.get(runId);
+    if (!entries) {
       this.buffers.set(runId, [entry]);
       return;
     }
-    // Replace any entry with the same sequence (replay safety), then insert
-    // in sorted order so peekLowest is O(1).
-    const filtered = existing.filter((e) => e.sequence !== sequence);
-    const insertIdx = filtered.findIndex((e) => e.sequence > sequence);
-    if (insertIdx === -1) filtered.push(entry);
-    else filtered.splice(insertIdx, 0, entry);
-    this.buffers.set(runId, filtered);
+    // The array is kept sorted by sequence, so binary-search the insert point:
+    // an entry already at that sequence is replaced in place (replay safety),
+    // anything else is spliced in. Keeps peekLowest O(1).
+    let lo = 0;
+    let hi = entries.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      if (entries[mid]!.sequence < sequence) lo = mid + 1;
+      else hi = mid;
+    }
+    if (entries[lo]?.sequence === sequence) entries[lo] = entry;
+    else entries.splice(lo, 0, entry);
+
+    // Same overflow policy as the Redis backend's ZREMRANGEBYRANK: drop the
+    // lowest sequences (stale, waiting on a gap the runner never filled).
+    if (entries.length > MAX_BUFFER_ENTRIES) {
+      const trimmed = entries.length - MAX_BUFFER_ENTRIES;
+      entries.splice(0, trimmed);
+      logger.warn("event buffer overflowed — dropped oldest entries", {
+        runId,
+        trimmed,
+        cap: MAX_BUFFER_ENTRIES,
+      });
+    }
   }
 
   async peekLowest(runId: string): Promise<BufferedEvent | null> {
@@ -48,8 +65,11 @@ export class LocalEventBuffer implements EventBuffer {
     if (!entries || entries.length === 0) return null;
     const now = Date.now();
     // Drop expired head entries before peeking.
-    while (entries.length > 0 && entries[0]!.expiresAt <= now) {
-      entries.shift();
+    let dropped = 0;
+    while (dropped < entries.length && entries[dropped]!.expiresAt <= now) dropped++;
+    if (dropped > 0) {
+      entries.splice(0, dropped);
+      this.logExpiredDrop(runId, dropped);
     }
     if (entries.length === 0) {
       this.buffers.delete(runId);
@@ -81,8 +101,15 @@ export class LocalEventBuffer implements EventBuffer {
     const now = Date.now();
     for (const [runId, entries] of this.buffers) {
       const keep = entries.filter((e) => e.expiresAt > now);
+      const dropped = entries.length - keep.length;
+      if (dropped === 0) continue;
       if (keep.length === 0) this.buffers.delete(runId);
-      else if (keep.length !== entries.length) this.buffers.set(runId, keep);
+      else this.buffers.set(runId, keep);
+      this.logExpiredDrop(runId, dropped);
     }
+  }
+
+  private logExpiredDrop(runId: string, dropped: number): void {
+    logger.warn("event buffer dropped expired entries", { runId, dropped });
   }
 }

--- a/apps/api/src/infra/event-buffer/redis-event-buffer.ts
+++ b/apps/api/src/infra/event-buffer/redis-event-buffer.ts
@@ -3,19 +3,9 @@
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import { getRedisConnection } from "../../lib/redis.ts";
 import { logger } from "../../lib/logger.ts";
-import type { EventBuffer, BufferedEvent } from "./interface.ts";
+import { MAX_BUFFER_ENTRIES, type EventBuffer, type BufferedEvent } from "./interface.ts";
 
 const KEY_PREFIX = "appstrate:remote-run:buffer:";
-
-/**
- * Hard cap on buffered events per run. A pathological runner that
- * permanently skips a sequence would otherwise accumulate every later
- * event in Redis until the watchdog finalises the run — sized 100×
- * above any realistic burst so the happy path never trips this. When
- * it does trip, we drop the LOWEST-scored entries (the stale ones
- * waiting on the missing gap) so the most recent events are kept.
- */
-const MAX_BUFFER_ENTRIES = 10_000;
 
 /**
  * Redis-backed ordering buffer — a sorted set per run keyed by sequence.

--- a/apps/api/src/infra/queue/local-queue.ts
+++ b/apps/api/src/infra/queue/local-queue.ts
@@ -6,7 +6,8 @@
  *
  * - Jobs are lost on restart (no persistence).
  * - Cron scheduling is evaluated every 30 seconds.
- * - Retry with backoff via setTimeout.
+ * - Retry with backoff via setTimeout — a backing-off job is delayed, not
+ *   active, so it holds no worker slot.
  */
 
 import { logger } from "../../lib/logger.ts";
@@ -55,24 +56,21 @@ const MAX_CRON_CATCHUP_PER_POLL = 5;
 
 /**
  * Default budget `shutdown()` gives in-flight work to finish, and the window a
- * sleeping retry has to be due within to be kept — see `shutdown()`. This is
+ * delayed retry has to be due within to be kept — see `shutdown()`. This is
  * the PRODUCTION value, applied whenever a caller does not ask for another.
  */
 const SHUTDOWN_GRACE_MS = 10_000;
 
-/** A job parked on its retry timer, waiting for the next attempt to start. */
-interface SleepingRetry {
+/** A job parked on its backoff timer, waiting for the next attempt to start. */
+interface DelayedJob<T> {
   /** Epoch ms at which the next attempt is due to start. */
   resumeAt: number;
-  /** Job identity, for the abandon log line. */
-  jobId: string;
-  /**
-   * The `attemptsMade` the pending attempt would carry — 1 for the first
-   * retry, i.e. the count of attempts that have already failed.
-   */
-  attempt: number;
-  /** Cancels the timer and releases the `run()` awaiting it. */
-  abandon: () => void;
+  /** The attempt to run, already carrying its incremented `attemptsMade`. */
+  job: QueueJob<T>;
+  /** Per-job options, carried across the delay so `attempts` survives it. */
+  opts?: JobAddOptions;
+  /** Cancels the pending attempt. */
+  timer: ReturnType<typeof setTimeout>;
 }
 
 export class LocalQueue<T> implements JobQueue<T> {
@@ -85,11 +83,13 @@ export class LocalQueue<T> implements JobQueue<T> {
   private drainInterval: ReturnType<typeof setInterval> | null = null;
   private shuttingDown = false;
   /**
-   * Jobs currently sleeping between retry attempts. Such a job still counts
-   * towards `activeJobs`, so `shutdown()` has to be able to release the ones
-   * that cannot finish inside its budget — see the comment there.
+   * Jobs parked on a backoff timer between attempts. A delayed job holds NO
+   * worker slot — it is released the moment the attempt fails, matching BullMQ,
+   * where backoff moves the job to `delayed` and frees the worker. It still
+   * counts towards `count()`, and `shutdown()` releases the ones that cannot
+   * run inside its budget — see the comment there.
    */
-  private sleepingRetries = new Set<SleepingRetry>();
+  private delayed = new Set<DelayedJob<T>>();
   /**
    * Epoch ms by which `shutdown()` stops waiting, or `null` while running
    * normally. A retry is only armed when its attempt is due before this.
@@ -176,14 +176,14 @@ export class LocalQueue<T> implements JobQueue<T> {
   }
 
   async count(): Promise<number> {
-    return this.pending.length + this.activeJobs;
+    return this.pending.length + this.activeJobs + this.delayed.size;
   }
 
   /**
-   * @param graceMs - How long draining may take, and the window a sleeping
+   * @param graceMs - How long draining may take, and the window a delayed
    *   retry must be due within to be kept. Defaults to the production
    *   {@link SHUTDOWN_GRACE_MS}. Pass `0` to tear down immediately: every
-   *   sleeper is released and nothing is waited on. A test that resets a
+   *   parked attempt is released and nothing is waited on. A test that resets a
    *   process-global worker wants that — with a production budget it would
    *   sit and drain jobs enqueued by other test files.
    */
@@ -194,30 +194,29 @@ export class LocalQueue<T> implements JobQueue<T> {
     this.cronInterval = null;
     this.drainInterval = null;
 
-    // Draining is budgeted, and the budget covers backoff too. A job merely
-    // SLEEPING between attempts counts as active (its `run()` awaits the retry
-    // timer), so a job on a long — or effectively endless — retry schedule
-    // would otherwise hold `activeJobs` above zero and pin the loop below to
-    // the full grace period on every shutdown. But a retry due *inside* the
-    // budget is work that would have completed, and consumers like
+    // Draining is budgeted, and the budget covers backoff too. A delayed job
+    // holds no worker slot, but the wait loop below still counts it: a job on a
+    // long — or effectively endless — retry schedule would otherwise pin that
+    // loop to the full grace period on every shutdown. And a retry due *inside*
+    // the budget is work that would have completed — consumers like
     // `llm-usage-retry` queue billable rows precisely because losing them is
-    // silent: dropping those would recreate the loss window they exist to
-    // close. So we release only the sleepers that cannot possibly run in time,
-    // and each release is logged. With `graceMs` of 0 there is no time at all
-    // and every sleeper goes, which is the teardown a test wants.
+    // silent, so dropping those would recreate the loss window they exist to
+    // close. We release only the attempts that cannot possibly run in time, and
+    // each release is logged. With `graceMs` of 0 there is no time at all and
+    // every one goes, which is the teardown a test wants.
     const deadline = Date.now() + graceMs;
     this.shutdownDeadline = deadline;
 
-    for (const sleeper of [...this.sleepingRetries]) {
-      if (sleeper.resumeAt <= deadline) continue;
-      this.abandonRetry(sleeper);
+    for (const entry of [...this.delayed]) {
+      if (entry.resumeAt <= deadline) continue;
+      this.abandonRetry(entry);
     }
 
-    // The same rule, applied to jobs that never STARTED. `drain()` returns
-    // early once `shuttingDown` is set, so everything still queued was dropped
-    // here — with no log line, which is exactly the silent loss the sleeper
-    // pass above exists to prevent. It is the same billable rows: consumers
-    // like `llm-usage-retry` run at `concurrency: 4`, so more than four
+    // The same rule, applied to jobs that never STARTED. Once the budget is
+    // spent `drain()` starts nothing, so everything still queued was dropped
+    // here — with no log line, which is exactly the silent loss the pass above
+    // exists to prevent. It is the same billable rows: consumers like
+    // `llm-usage-retry` run at `concurrency: 4`, so more than four
     // simultaneous failures leave the excess sitting in `pending`.
     //
     // Run them within the same budget, then abandon the remainder loudly.
@@ -233,13 +232,24 @@ export class LocalQueue<T> implements JobQueue<T> {
       const item = this.pending.shift()!;
       this.executeJob(item.job, item.opts);
     }
-    for (const item of this.pending.splice(0)) {
-      this.logAbandonedPending(item.job);
+    this.abandonPending();
+
+    // Wait for in-flight handlers — and for the retries kept above, which
+    // re-enter `pending` when their timer fires — to finish.
+    while ((this.activeJobs > 0 || this.delayed.size > 0) && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 200));
     }
 
-    // Wait for in-flight handlers — and for the retries kept above — to finish.
-    while (this.activeJobs > 0 && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 200));
+    // Budget spent: anything still parked, or re-entered past the deadline, is
+    // work being thrown away — name each one rather than lose it silently.
+    for (const entry of [...this.delayed]) this.abandonRetry(entry);
+    this.abandonPending();
+  }
+
+  /** Drop everything still queued, naming each job. */
+  private abandonPending(): void {
+    for (const item of this.pending.splice(0)) {
+      this.logAbandonedPending(item.job);
     }
   }
 
@@ -271,10 +281,14 @@ export class LocalQueue<T> implements JobQueue<T> {
   }
 
   /** Log + release a retry already parked on its timer. */
-  private abandonRetry(sleeper: SleepingRetry): void {
-    this.sleepingRetries.delete(sleeper);
-    this.logAbandonedRetry(sleeper);
-    sleeper.abandon();
+  private abandonRetry(entry: DelayedJob<T>): void {
+    this.delayed.delete(entry);
+    clearTimeout(entry.timer);
+    this.logAbandonedRetry({
+      jobId: entry.job.id,
+      attempt: entry.job.attemptsMade,
+      resumeAt: entry.resumeAt,
+    });
   }
 
   // ---------------------------------------------------------------------------
@@ -282,7 +296,10 @@ export class LocalQueue<T> implements JobQueue<T> {
   // ---------------------------------------------------------------------------
 
   private drain(): void {
-    if (!this.handler || this.shuttingDown) return;
+    if (!this.handler) return;
+    // Shutdown keeps starting work until its budget is spent: a retry whose
+    // timer fires inside it is work that would have completed.
+    if (this.shuttingDown && Date.now() >= (this.shutdownDeadline ?? 0)) return;
     const maxConcurrency = this.workerOpts?.concurrency ?? 5;
 
     while (this.pending.length > 0 && this.activeJobs < maxConcurrency) {
@@ -301,73 +318,69 @@ export class LocalQueue<T> implements JobQueue<T> {
     const maxAttempts = opts?.attempts ?? this.defaultJobOptions?.attempts ?? 1;
     const backoffStrategy = this.workerOpts?.backoffStrategy;
 
-    const run = async (currentJob: QueueJob<T>): Promise<void> => {
+    const run = async (): Promise<void> => {
       try {
-        await handler(currentJob);
+        await handler(job);
       } catch (err) {
         if (err instanceof PermanentJobError) {
           this.log.warn(`${this.name} job permanently failed`, {
-            jobId: currentJob.id,
+            jobId: job.id,
             error: err.message,
           });
           return;
         }
 
-        const nextAttempt = currentJob.attemptsMade + 1;
-        if (nextAttempt < maxAttempts) {
-          const delay = backoffStrategy ? backoffStrategy(nextAttempt) : 1000 * nextAttempt;
-          this.log.warn(`${this.name} job failed, retrying in ${delay}ms`, {
-            jobId: currentJob.id,
-            attempt: nextAttempt,
+        const nextAttempt = job.attemptsMade + 1;
+        if (nextAttempt >= maxAttempts) {
+          this.log.error(`${this.name} job failed after ${maxAttempts} attempts`, {
+            jobId: job.id,
             error: getErrorMessage(err),
-          });
-          // Schedule retry — await a timer so the outer .finally() waits.
-          // Registered in `sleepingRetries` so `shutdown()` can release it if
-          // the attempt falls outside the shutdown budget; otherwise the wait
-          // there blocks on a job that is doing nothing but counting down.
-          await new Promise<void>((resolve) => {
-            const resumeAt = Date.now() + delay;
-            // Already shutting down and the attempt lands past the deadline:
-            // arming the timer would only leak past the process. Drop it here,
-            // with the same log line an already-parked sleeper gets.
-            if (this.shutdownDeadline !== null && resumeAt > this.shutdownDeadline) {
-              this.logAbandonedRetry({ jobId: currentJob.id, attempt: nextAttempt, resumeAt });
-              resolve();
-              return;
-            }
-            const timer = setTimeout(() => {
-              this.sleepingRetries.delete(sleeper);
-              const retryJob: QueueJob<T> = { ...currentJob, attemptsMade: nextAttempt };
-              run(retryJob).then(resolve, resolve);
-            }, delay);
-            timer.unref?.();
-            // Declared after the timer so `abandon` can close over it; the
-            // callback above only dereferences `sleeper` once it fires.
-            const sleeper: SleepingRetry = {
-              resumeAt,
-              jobId: currentJob.id,
-              attempt: nextAttempt,
-              abandon: () => {
-                clearTimeout(timer);
-                resolve();
-              },
-            };
-            this.sleepingRetries.add(sleeper);
           });
           return;
         }
 
-        this.log.error(`${this.name} job failed after ${maxAttempts} attempts`, {
-          jobId: currentJob.id,
+        const delay = backoffStrategy ? backoffStrategy(nextAttempt) : 1000 * nextAttempt;
+        this.log.warn(`${this.name} job failed, retrying in ${delay}ms`, {
+          jobId: job.id,
+          attempt: nextAttempt,
           error: getErrorMessage(err),
         });
+        this.scheduleRetry({ ...job, attemptsMade: nextAttempt }, opts, delay);
       }
     };
 
-    run(job).finally(() => {
+    run().finally(() => {
       this.activeJobs--;
       this.drain();
     });
+  }
+
+  /**
+   * Park a failed job on its backoff timer. When the timer fires the attempt
+   * re-enters `pending` at the TAIL, behind jobs added meanwhile — the ordering
+   * BullMQ gives a delayed job rejoining wait. `opts` travels with it, so a
+   * per-job `attempts` survives the delay instead of falling back to the queue
+   * default.
+   */
+  private scheduleRetry(job: QueueJob<T>, opts: JobAddOptions | undefined, delay: number): void {
+    const resumeAt = Date.now() + delay;
+    // Already shutting down and the attempt lands past the deadline: arming the
+    // timer would only leak past the process. Drop it here, with the same log
+    // line an already-parked attempt gets.
+    if (this.shutdownDeadline !== null && resumeAt > this.shutdownDeadline) {
+      this.logAbandonedRetry({ jobId: job.id, attempt: job.attemptsMade, resumeAt });
+      return;
+    }
+    const timer = setTimeout(() => {
+      this.delayed.delete(entry);
+      this.pending.push({ job, opts });
+      this.drain();
+    }, delay);
+    timer.unref?.();
+    // Declared after the timer so the callback can close over it; the callback
+    // only dereferences `entry` once it fires.
+    const entry: DelayedJob<T> = { resumeAt, job, opts, timer };
+    this.delayed.add(entry);
   }
 
   /**

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -703,25 +703,28 @@ async function warnOnUnserveableApiVersionPins(): Promise<void> {
 let realtimeRetryArmed = false;
 
 /**
- * Bounded retry (1 s / 5 s / 25 s) of the realtime LISTEN install, armed once per
- * process. Fire-and-forget: readiness never waits on it, and `/health` reports
- * `checks.realtime: degraded` until an attempt lands.
+ * Retry the realtime LISTEN install until it lands, armed once per process.
+ * Exponential backoff capped at 60 s: giving up would leave a process whose
+ * every dashboard SSE is silent for its whole life, with `/health` reporting
+ * `checks.realtime: degraded` and nothing acting on it. Fire-and-forget:
+ * readiness never waits on it.
  */
 function retryRealtimeInBackground(): void {
   if (realtimeRetryArmed) return;
   realtimeRetryArmed = true;
   void (async () => {
-    for (const delayMs of [1_000, 5_000, 25_000]) {
+    for (let delayMs = 1_000; ; delayMs = Math.min(delayMs * 2, 60_000)) {
       // Unref'd: a pending retry must never hold the process (or a test run) open.
       await new Promise<void>((resolve) => {
         setTimeout(resolve, delayMs).unref?.();
       });
       try {
         await initRealtime();
+        logger.info("Realtime LISTEN channels initialized after retry");
         return;
       } catch (err) {
         logger.error("Realtime LISTEN retry failed", {
-          delayMs,
+          nextDelayMs: Math.min(delayMs * 2, 60_000),
           error: getErrorMessage(err),
         });
       }

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -234,17 +234,20 @@ export async function bootBackground(): Promise<{ agentsHealthy: boolean }> {
 
   // Parallel init: NOTIFY triggers and realtime are independent
   await Promise.all([
+    // `error`, not `warn`: without the triggers or without the LISTEN install
+    // every dashboard SSE is silent for the life of the process.
     createNotifyTriggers(db)
       .then(() => logger.info("NOTIFY triggers installed"))
       .catch((err) => {
-        logger.warn("Could not install NOTIFY triggers", {
+        logger.error("Could not install NOTIFY triggers", {
           error: getErrorMessage(err),
         });
       }),
     initRealtime().catch((err) => {
-      logger.warn("Could not initialize realtime LISTEN", {
+      logger.error("Could not initialize realtime LISTEN", {
         error: getErrorMessage(err),
       });
+      retryRealtimeInBackground();
     }),
     // Cross-replica cache invalidation rides the same LISTEN client. Without
     // it every `@appstrate/core/cache` invalidation stays process-local and
@@ -695,6 +698,35 @@ async function warnOnUnserveableApiVersionPins(): Promise<void> {
       orgs: offenders.map((o) => ({ orgId: o.id, pinnedVersion: o.apiVersion })),
     },
   );
+}
+
+let realtimeRetryArmed = false;
+
+/**
+ * Bounded retry (1 s / 5 s / 25 s) of the realtime LISTEN install, armed once per
+ * process. Fire-and-forget: readiness never waits on it, and `/health` reports
+ * `checks.realtime: degraded` until an attempt lands.
+ */
+function retryRealtimeInBackground(): void {
+  if (realtimeRetryArmed) return;
+  realtimeRetryArmed = true;
+  void (async () => {
+    for (const delayMs of [1_000, 5_000, 25_000]) {
+      // Unref'd: a pending retry must never hold the process (or a test run) open.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, delayMs).unref?.();
+      });
+      try {
+        await initRealtime();
+        return;
+      } catch (err) {
+        logger.error("Realtime LISTEN retry failed", {
+          delayMs,
+          error: getErrorMessage(err),
+        });
+      }
+    }
+  })();
 }
 
 /**

--- a/apps/api/src/lib/deduped-refresh.ts
+++ b/apps/api/src/lib/deduped-refresh.ts
@@ -6,12 +6,14 @@
  * Both the integration-connection refresh path and the model-provider refresh
  * path guard concurrent refreshes the same way:
  *
- *   1. **In-process singleflight** — a `Map<key, Promise>` collapses callers
- *      WITHIN a single API instance.
- *   2. **Distributed Redis lock** (`withRedisLock`, `ttlSeconds: 45`,
- *      `acquireTimeoutMs: 30_000`) — serializes ACROSS instances so a rotating
- *      `refresh_token` isn't double-spent (which would falsely flag a valid
- *      credential `needsReconnection`). No-op on Tier 0/1 (single instance).
+ *   1. **In-process singleflight + per-key serialization** — one
+ *      `Map<flightKey, Promise>` collapses callers sharing a flight key, and a
+ *      second `Map<key, Promise>` chains every flight for the same credential
+ *      so the two flight keys can never exchange concurrently.
+ *   2. **Distributed Redis lock** (`withRedisLock`) — serializes ACROSS
+ *      instances so a rotating `refresh_token` isn't double-spent (which would
+ *      falsely flag a valid credential `needsReconnection`). No-op on Tier 0/1
+ *      (single instance, where layer 1 already serializes).
  *   3. **Post-acquire re-read** — after winning the lock, re-read the stored
  *      row; if the token is now fresh enough, return it without burning the
  *      (possibly just-rotated) `refresh_token`.
@@ -22,7 +24,7 @@
  * still happens either way — it is what lets the exchange spend the freshest
  * `refresh_token` rather than double-spending a rotated one.
  *
- * This helper owns the singleflight Map + `withRedisLock` + the re-read
+ * This helper owns both Maps + `withRedisLock` + the re-read
  * short-circuit + `finally` cleanup. Each caller supplies its own row-read +
  * freshness predicate (`reReadFreshness`) and the actual upstream exchange
  * (`doRefresh`) as callbacks, keeping table-specific concerns out of here.
@@ -32,8 +34,17 @@ import { withRedisLock } from "./distributed-lock.ts";
 
 /** Distributed-lock TTL in seconds — sized as `30s network timeout` + slack. */
 const REFRESH_LOCK_TTL_SECONDS = 45;
-/** How long to wait for the distributed lock before proceeding unlocked. */
-const REFRESH_LOCK_ACQUIRE_TIMEOUT_MS = 30_000;
+/**
+ * How long to wait for the distributed lock before proceeding unlocked.
+ * Derived from the TTL so the two cannot drift apart: a waiter gives up only
+ * once the holder's lock has definitively expired (holder presumed dead),
+ * never at the holder's worst-case exchange duration. Trade-off: a sidecar
+ * caller queued behind a wedged holder waits up to ~50 s before proceeding —
+ * and a forced flight chained behind a proactive one pays that twice, once per
+ * hop (~50 s acquire + the 30 s exchange timeout in `@appstrate/connect`), so
+ * the honest worst case is ≈160 s. Bounded, but not one lock wait.
+ */
+const REFRESH_LOCK_ACQUIRE_TIMEOUT_MS = REFRESH_LOCK_TTL_SECONDS * 1_000 + 5_000;
 
 interface DedupedRefreshOptions<T> {
   /** Redis lock key (e.g. `oauth-refresh:${id}` / `intg-refresh:${id}`). */
@@ -47,9 +58,7 @@ interface DedupedRefreshOptions<T> {
    * skipping the callback: the re-read has a second job (picking up a peer's
    * just-rotated `refresh_token`) that a forced refresh needs even more.
    *
-   * Also partitions the singleflight — forced and proactive callers never
-   * share a flight, because a flight applies only its originator's verdict.
-   * See {@link dedupedRefresh}.
+   * Also partitions the singleflight — see {@link dedupedRefresh}.
    */
   force?: boolean;
   /**
@@ -63,68 +72,57 @@ interface DedupedRefreshOptions<T> {
   doRefresh: () => Promise<T>;
 }
 
-/** Per-key in-flight singleflight map, keyed by the caller's dedup key. */
+/** Per-flight-key in-flight singleflight map (`key` / `key:force`). */
 const inflightRefreshes = new Map<string, Promise<unknown>>();
+/** Tail of the serialization chain per credential `key`, never rejecting. */
+const refreshChains = new Map<string, Promise<unknown>>();
 
 /**
  * Coalesce a refresh for `key` through the in-process singleflight + the
  * cross-instance Redis lock, with a post-acquire freshness short-circuit.
  *
- * Concurrent callers sharing a flight key share the same in-flight promise.
- * The entry is deleted in `finally`.
+ * `force` IS part of the flight key: a flight applies only its originator's
+ * verdict, so a forced caller joining a proactive flight would be handed back
+ * the very token that just 401'd it — short-circuited on freshness by that
+ * flight's post-acquire re-read, with no upstream exchange at all.
  *
- * **`force` IS part of the flight key**, and that is the whole point of this
- * helper: a flight carries its originator's `force` verdict all the way to
- * `reReadFreshness`, so joining someone else's flight means inheriting their
- * verdict. Sharing one flight across both kinds put back the exact defect the
- * `force` flag exists to prevent — a forced caller receiving the token that
- * just 401'd it, with no upstream exchange at all:
- *
- *   instance B refreshes and writes a token; instance A's PROACTIVE caller is
- *   meanwhile queued on the Redis lock; A's flight wins the lock, re-reads,
- *   finds the token comfortably unexpired and short-circuits. A FORCED caller
- *   that joined that flight — it holds upstream proof this very token is dead
- *   — is handed it back and told `{status:"refreshed"}`.
- *
- * Narrower than the bug the flag was introduced for (bounded by the lock wait
- * rather than the token's remaining lifetime, and it needs ≥2 instances for
- * the re-read to find anything new), but the same silent-success shape, and a
- * comment claiming otherwise is worth less than no comment.
- *
- * The cost of splitting is one extra upstream exchange in the single case
- * where a forced and a proactive refresh for the same credential overlap: the
- * forced flight queues on the SAME Redis lock (`opts.lockKey` is unchanged),
- * so the two are still serialized across instances — no concurrent double-spend
- * of a rotating `refresh_token` — and the forced flight's own re-read picks up
- * whatever the proactive one just wrote before exchanging against it. Forced
- * callers still collapse with each other, which is the storm that matters:
- * every in-flight sidecar call 401ing at once is one exchange, not N.
+ * The resulting forced/proactive pair is chained per `key` (`refreshChains`
+ * in-process, the Redis lock across instances), so the split costs one EXTRA
+ * exchange when the two overlap, never a concurrent one.
  */
 export function dedupedRefresh<T>(key: string, opts: DedupedRefreshOptions<T>): Promise<T> {
   const flightKey = opts.force === true ? `${key}:force` : key;
   const cached = inflightRefreshes.get(flightKey) as Promise<T> | undefined;
   if (cached) return cached;
 
-  const promise = withRedisLock(
-    opts.lockKey,
-    {
-      ttlSeconds: REFRESH_LOCK_TTL_SECONDS,
-      acquireTimeoutMs: REFRESH_LOCK_ACQUIRE_TIMEOUT_MS,
-      label: opts.lockLabel,
-    },
-    async () => {
-      // A peer instance may have refreshed while we waited for the lock. If
-      // the stored token is now comfortably unexpired, return it without
-      // burning the (possibly just-rotated) refresh_token — unless the caller
-      // forced this refresh, in which case remaining lifetime says nothing
-      // about whether the token still works.
-      const fresh = await opts.reReadFreshness({ force: opts.force === true });
-      if (fresh !== null) return fresh;
-      return opts.doRefresh();
-    },
+  const previous = refreshChains.get(key) ?? Promise.resolve();
+  const promise = previous.then(() =>
+    withRedisLock(
+      opts.lockKey,
+      {
+        ttlSeconds: REFRESH_LOCK_TTL_SECONDS,
+        acquireTimeoutMs: REFRESH_LOCK_ACQUIRE_TIMEOUT_MS,
+        label: opts.lockLabel,
+      },
+      async () => {
+        // A peer instance may have refreshed while we waited for the lock. If
+        // the stored token is now comfortably unexpired, return it without
+        // burning the (possibly just-rotated) refresh_token — unless the caller
+        // forced this refresh, in which case remaining lifetime says nothing
+        // about whether the token still works.
+        const fresh = await opts.reReadFreshness({ force: opts.force === true });
+        if (fresh !== null) return fresh;
+        return opts.doRefresh();
+      },
+    ),
   );
+  // The chain tail swallows rejections: a failed exchange must not cascade
+  // into every later refresh of the same credential.
+  const tail = promise.catch(() => {});
   inflightRefreshes.set(flightKey, promise);
+  refreshChains.set(key, tail);
   return promise.finally(() => {
     inflightRefreshes.delete(flightKey);
+    if (refreshChains.get(key) === tail) refreshChains.delete(key);
   });
 }

--- a/apps/api/src/lib/distributed-lock.ts
+++ b/apps/api/src/lib/distributed-lock.ts
@@ -12,8 +12,10 @@
  * lock (plus a re-read of the stored credential after acquisition) collapses
  * those concurrent refreshes to one upstream exchange.
  *
- * On Tier 0/1 (no Redis) the platform is single-instance by definition, so the
- * caller's in-process singleflight is sufficient and the lock is skipped.
+ * On Tier 0/1 (no Redis) the platform is single-instance by definition, and
+ * `dedupedRefresh` already serializes every flight for one credential in
+ * process (per-key chain, not just the singleflight map), so the lock adds
+ * nothing and is skipped.
  */
 
 import { hasRedis } from "../infra/mode.ts";
@@ -46,8 +48,9 @@ interface RedisLockOptions {
  * Run `fn` while holding the Redis lock `key`. When Redis is absent the lock
  * is a no-op and `fn` runs directly. If the lock can't be acquired within
  * `acquireTimeoutMs`, logs a warning and runs `fn` anyway (availability over
- * strict mutual exclusion — the in-process singleflight still bounds the
- * blast radius, and the TTL guarantees the lock can't wedge forever).
+ * strict mutual exclusion — the caller's per-key in-process serialization
+ * still bounds the blast radius, and the TTL guarantees the lock can't wedge
+ * forever).
  */
 export async function withRedisLock<T>(
   key: string,

--- a/apps/api/src/openapi/paths/health.ts
+++ b/apps/api/src/openapi/paths/health.ts
@@ -43,6 +43,14 @@ export const healthPaths = {
                           status: { type: "string", enum: ["healthy", "degraded"] },
                         },
                       },
+                      realtime: {
+                        type: "object",
+                        description:
+                          "PG LISTEN fan-out behind the realtime SSE streams. `degraded` when a channel failed to install. Advisory: not part of the top-level `status`.",
+                        properties: {
+                          status: { type: "string", enum: ["healthy", "degraded"] },
+                        },
+                      },
                     },
                   },
                 },
@@ -54,6 +62,7 @@ export const healthPaths = {
                 checks: {
                   database: { status: "healthy", latency_ms: 2.3 },
                   agents: { status: "healthy" },
+                  realtime: { status: "healthy" },
                 },
               },
             },

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -4,6 +4,7 @@ import { Hono, type MiddlewareHandler } from "hono";
 import { sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { getVersionInfo } from "../lib/version.ts";
+import { realtimeReady } from "../services/realtime.ts";
 import { ApiError } from "../lib/errors.ts";
 
 const startedAt = Date.now();
@@ -89,8 +90,18 @@ healthRouter.get("/health", async (c) => {
     status: agentsHealthy ? "healthy" : "degraded",
   };
 
-  const hasUnhealthy = Object.values(checks).some((c) => c.status === "unhealthy");
-  const allHealthy = Object.values(checks).every((c) => c.status === "healthy");
+  // Advisory, kept OUT of the `status` rollup below: the container HEALTHCHECK
+  // restarts the instance unless `status === "healthy"`, and a silent SSE
+  // fan-out must not restart-loop an API that serves every other route.
+  checks.realtime = {
+    status: realtimeReady() ? "healthy" : "degraded",
+  };
+
+  const gating = Object.entries(checks)
+    .filter(([name]) => name !== "realtime")
+    .map(([, check]) => check);
+  const hasUnhealthy = gating.some((c) => c.status === "unhealthy");
+  const allHealthy = gating.every((c) => c.status === "healthy");
   const status = hasUnhealthy ? "unhealthy" : allHealthy ? "healthy" : "degraded";
   const httpStatus = hasUnhealthy ? 503 : 200;
 

--- a/apps/api/src/services/realtime.ts
+++ b/apps/api/src/services/realtime.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { listenClient } from "@appstrate/db/client";
+import { listenClient, type ListenClient } from "@appstrate/db/client";
 import { logger } from "../lib/logger.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import {
@@ -57,7 +57,6 @@ type Subscriber = {
 };
 
 const subscribers = new Map<string, Subscriber>();
-let initialized = false;
 
 /**
  * Channel gate — the cheapest possible check, so it runs FIRST in every
@@ -99,207 +98,245 @@ function snakeToCamel(obj: Record<string, unknown>): Record<string, unknown> {
   return result;
 }
 
+function handleRunUpdate(payload: string): void {
+  try {
+    if (!anyAccepts("run_update")) return;
+    const raw = JSON.parse(payload) as Record<string, unknown>;
+    const parsed = runUpdateEventSchema.safeParse(snakeToCamel(raw));
+    if (!parsed.success) {
+      logger.error("run_update payload failed schema validation", {
+        issues: parsed.error.issues,
+      });
+      return;
+    }
+    for (const sub of subscribers.values()) {
+      if (!accepts(sub, "run_update")) continue;
+      if (sub.filter.orgId !== raw.org_id) continue;
+      if (sub.filter.spaceId !== raw.space_id) continue;
+      if (sub.filter.runId && sub.filter.runId !== raw.id) continue;
+      if (sub.filter.packageId && sub.filter.packageId !== raw.package_id) continue;
+      // Actor gate: an end-user subscription (endUserId set) receives ONLY
+      // its own runs — org+space scope alone would leak every other
+      // end-user's runs on a non-pinned SSE. Dashboard members / API keys
+      // (endUserId undefined) legitimately see every run in the space, so they
+      // keep the org/space gate above. The `run_update` NOTIFY payload carries
+      // `end_user_id` (packages/db/src/notify.ts), so the match is exact.
+      // Mirrors the `connection_update` channel's actor filter below.
+      if (sub.filter.endUserId !== undefined && raw.end_user_id !== sub.filter.endUserId) {
+        continue;
+      }
+      sub.send({ event: "run_update", data: parsed.data });
+    }
+  } catch (err) {
+    logger.error("Failed to parse run_update payload", {
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+function handleRunLogInsert(payload: string): void {
+  try {
+    // The firehose. Every `run_logs` INSERT lands here; when no open stream
+    // declared the `run_log` channel we drop it before paying for the parse.
+    if (!anyAccepts("run_log")) return;
+    const raw = JSON.parse(payload) as Record<string, unknown>;
+    const parsed = runLogEventSchema.safeParse(snakeToCamel(raw));
+    if (!parsed.success) {
+      logger.error("run_log payload failed schema validation", {
+        issues: parsed.error.issues,
+      });
+      return;
+    }
+    for (const sub of subscribers.values()) {
+      if (!accepts(sub, "run_log")) continue;
+      if (sub.filter.orgId !== raw.org_id) continue;
+      if (sub.filter.spaceId !== raw.space_id) continue;
+      if (sub.filter.runId && sub.filter.runId !== raw.run_id) continue;
+      if (!sub.filter.isAdmin && raw.level === "debug") continue;
+      // Actor gate: the `run_log_insert` NOTIFY payload carries no
+      // `end_user_id` (packages/db/src/notify.ts — notify_run_log_insert()
+      // emits only org/space/run scope), so an end-user subscription cannot be
+      // proven to own this log row. Skip rather than leak another end-user's
+      // logs (same "skip rather than leak" posture as `connection_update`).
+      // Dashboard members / API keys (endUserId undefined) are unaffected.
+      // Per-end-user log streaming would need `end_user_id` added to the
+      // trigger payload (a DB migration — see the report).
+      if (sub.filter.endUserId !== undefined) continue;
+      sub.send({ event: "run_log", data: parsed.data });
+    }
+  } catch (err) {
+    logger.error("Failed to parse run_log_insert payload", {
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+// `run_metric` carries the running cumulative cost + token usage
+// emitted by the event sink after each `appstrate.metric` event,
+// throttled per run by the broadcaster. Routed to the same
+// org/space/run filters as `run_update` and `run_log_insert`
+// — no new isolation rule. The scope filters here are the ONLY
+// tenant gate for this channel; do not relax without updating the
+// broadcaster payload contract.
+function handleRunMetric(payload: string): void {
+  try {
+    if (!anyAccepts("run_metric")) return;
+    const raw = JSON.parse(payload) as Record<string, unknown>;
+    const parsed = runMetricEventSchema.safeParse(snakeToCamel(raw));
+    if (!parsed.success) {
+      logger.error("run_metric payload failed schema validation", {
+        issues: parsed.error.issues,
+      });
+      return;
+    }
+    for (const sub of subscribers.values()) {
+      if (!accepts(sub, "run_metric")) continue;
+      if (sub.filter.orgId !== raw.org_id) continue;
+      if (sub.filter.spaceId !== raw.space_id) continue;
+      if (sub.filter.runId && sub.filter.runId !== raw.run_id) continue;
+      if (sub.filter.packageId && sub.filter.packageId !== raw.package_id) continue;
+      // Actor gate: the `run_metric` NOTIFY payload carries no `end_user_id`
+      // (packages/db/src/notify.ts — RunMetricNotifyPayload has org/space/run/
+      // package scope only), so an end-user subscription cannot be proven to
+      // own this metric row. Skip rather than leak another end-user's cost /
+      // token metrics. Dashboard members / API keys (endUserId undefined) are
+      // unaffected. Per-end-user metric streaming would need `end_user_id`
+      // added to the broadcast payload (a DB migration — see the report).
+      if (sub.filter.endUserId !== undefined) continue;
+      sub.send({ event: "run_metric", data: parsed.data });
+    }
+  } catch (err) {
+    logger.error("Failed to parse run_metric payload", {
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+// `connection_update` carries every INSERT/UPDATE/DELETE on
+// `integration_connections` so the dashboard can patch its caches in
+// real time — the orange "Reconnection required" badge, the agent
+// page's member picker verdict, the integration detail's connection
+// row all read off React Query keys that this event invalidates.
+//
+// Filter is per-space; the subscriber owns its actor identity
+// (set at SSE auth time) so a member only sees their own rows. The
+// payload deliberately omits `org_id` (the table has none) — tenant
+// isolation is bound to the upstream SSE auth gate proving
+// `spaceId ∈ orgId`.
+function handleConnectionUpdate(payload: string): void {
+  try {
+    if (!anyAccepts("connection_update")) return;
+    const raw = JSON.parse(payload) as Record<string, unknown>;
+    const parsed = connectionUpdateEventSchema.safeParse(snakeToCamel(raw));
+    if (!parsed.success) {
+      logger.error("connection_update payload failed schema validation", {
+        issues: parsed.error.issues,
+      });
+      return;
+    }
+    const data = parsed.data;
+    for (const sub of subscribers.values()) {
+      if (!accepts(sub, "connection_update")) continue;
+      if (sub.filter.spaceId !== raw.space_id) continue;
+      // Actor filter: only fan out rows the subscriber owns. Without
+      // this, every member of a space would receive every other
+      // member's connection events (org-wide cache pollution).
+      if (sub.filter.userId !== undefined) {
+        if (raw.user_id !== sub.filter.userId) continue;
+      } else if (sub.filter.endUserId !== undefined) {
+        if (raw.end_user_id !== sub.filter.endUserId) continue;
+      } else {
+        // No actor filter on the subscription — skip rather than leak.
+        continue;
+      }
+      sub.send({ event: "connection_update", data });
+    }
+  } catch (err) {
+    logger.error("Failed to parse connection_update payload", {
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+// `chat_session_update` is a space-emitted change SIGNAL from the
+// chat module (packages/module-chat/src/realtime.ts): the payload carries
+// only the owner identity, and the client refetches the session list.
+// Chat sessions are strictly user-owned (org+user scoped, no space
+// dimension), so fan-out gates on org + exact user match. End-user
+// subscriptions never receive chat frames (chat has no end-user surface);
+// subscriptions without an actor are skipped rather than leaked to.
+function handleChatSessionUpdate(payload: string): void {
+  try {
+    if (!anyAccepts("chat_session_update")) return;
+    const raw = JSON.parse(payload) as Record<string, unknown>;
+    const parsed = chatSessionUpdateEventSchema.safeParse(snakeToCamel(raw));
+    if (!parsed.success) {
+      logger.error("chat_session_update payload failed schema validation", {
+        issues: parsed.error.issues,
+        raw,
+      });
+      return;
+    }
+    for (const sub of subscribers.values()) {
+      if (!accepts(sub, "chat_session_update")) continue;
+      if (sub.filter.orgId !== raw.org_id) continue;
+      if (sub.filter.userId === undefined || sub.filter.userId !== raw.user_id) continue;
+      sub.send({ event: "chat_session_update", data: parsed.data });
+    }
+  } catch (err) {
+    logger.error("Failed to parse chat_session_update payload", {
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+/** Every PG channel the fan-out listens on, with the handler installed for it. */
+const LISTEN_SPECS: Record<string, (payload: string) => void> = {
+  run_update: handleRunUpdate,
+  run_log_insert: handleRunLogInsert,
+  run_metric: handleRunMetric,
+  connection_update: handleConnectionUpdate,
+  chat_session_update: handleChatSessionUpdate,
+};
+
+/** One installation: the in-flight (or settled) init, and the channels `listen` resolved for. */
+type RealtimeInitState = { promise: Promise<void> | null; installed: Set<string> };
+
+const initState: RealtimeInitState = { promise: null, installed: new Set() };
+
+async function installChannels(
+  listen: ListenClient["listen"],
+  installed: Set<string>,
+): Promise<void> {
+  for (const [channel, handler] of Object.entries(LISTEN_SPECS)) {
+    if (installed.has(channel)) continue;
+    // Marked only AFTER the ack: flagging first loses the retry, and
+    // re-listening a resolved channel doubles the fan-out.
+    await listen(channel, handler);
+    installed.add(channel);
+  }
+  logger.info("Realtime LISTEN channels initialized", { channels: installed.size });
+}
+
 /**
- * Initialize PG LISTEN channels for run_update and run_log_insert.
- * Safe to call multiple times — only initializes once.
+ * Install the PG LISTEN channels the realtime fan-out reads. Concurrent callers
+ * share the in-flight promise; a rejection drops it so the next call retries only
+ * the missing channels. `listen` and the state are injected in tests.
  */
-export async function initRealtime(): Promise<void> {
-  if (initialized) return;
-  initialized = true;
-
-  await listenClient.listen("run_update", (payload) => {
-    try {
-      if (!anyAccepts("run_update")) return;
-      const raw = JSON.parse(payload) as Record<string, unknown>;
-      const parsed = runUpdateEventSchema.safeParse(snakeToCamel(raw));
-      if (!parsed.success) {
-        logger.error("run_update payload failed schema validation", {
-          issues: parsed.error.issues,
-        });
-        return;
-      }
-      for (const sub of subscribers.values()) {
-        if (!accepts(sub, "run_update")) continue;
-        if (sub.filter.orgId !== raw.org_id) continue;
-        if (sub.filter.spaceId !== raw.space_id) continue;
-        if (sub.filter.runId && sub.filter.runId !== raw.id) continue;
-        if (sub.filter.packageId && sub.filter.packageId !== raw.package_id) continue;
-        // Actor gate: an end-user subscription (endUserId set) receives ONLY
-        // its own runs — org+space scope alone would leak every other
-        // end-user's runs on a non-pinned SSE. Dashboard members / API keys
-        // (endUserId undefined) legitimately see every run in the space, so they
-        // keep the org/space gate above. The `run_update` NOTIFY payload carries
-        // `end_user_id` (packages/db/src/notify.ts), so the match is exact.
-        // Mirrors the `connection_update` channel's actor filter below.
-        if (sub.filter.endUserId !== undefined && raw.end_user_id !== sub.filter.endUserId) {
-          continue;
-        }
-        sub.send({ event: "run_update", data: parsed.data });
-      }
-    } catch (err) {
-      logger.error("Failed to parse run_update payload", {
-        error: getErrorMessage(err),
-      });
-    }
+export function initRealtime(
+  listen: ListenClient["listen"] = listenClient.listen,
+  state: RealtimeInitState = initState,
+): Promise<void> {
+  state.promise ??= installChannels(listen, state.installed).catch((err: unknown) => {
+    state.promise = null;
+    throw err;
   });
+  return state.promise;
+}
 
-  await listenClient.listen("run_log_insert", (payload) => {
-    try {
-      // The firehose. Every `run_logs` INSERT lands here; when no open stream
-      // declared the `run_log` channel we drop it before paying for the parse.
-      if (!anyAccepts("run_log")) return;
-      const raw = JSON.parse(payload) as Record<string, unknown>;
-      const parsed = runLogEventSchema.safeParse(snakeToCamel(raw));
-      if (!parsed.success) {
-        logger.error("run_log payload failed schema validation", {
-          issues: parsed.error.issues,
-        });
-        return;
-      }
-      for (const sub of subscribers.values()) {
-        if (!accepts(sub, "run_log")) continue;
-        if (sub.filter.orgId !== raw.org_id) continue;
-        if (sub.filter.spaceId !== raw.space_id) continue;
-        if (sub.filter.runId && sub.filter.runId !== raw.run_id) continue;
-        if (!sub.filter.isAdmin && raw.level === "debug") continue;
-        // Actor gate: the `run_log_insert` NOTIFY payload carries no
-        // `end_user_id` (packages/db/src/notify.ts — notify_run_log_insert()
-        // emits only org/space/run scope), so an end-user subscription cannot be
-        // proven to own this log row. Skip rather than leak another end-user's
-        // logs (same "skip rather than leak" posture as `connection_update`).
-        // Dashboard members / API keys (endUserId undefined) are unaffected.
-        // Per-end-user log streaming would need `end_user_id` added to the
-        // trigger payload (a DB migration — see the report).
-        if (sub.filter.endUserId !== undefined) continue;
-        sub.send({ event: "run_log", data: parsed.data });
-      }
-    } catch (err) {
-      logger.error("Failed to parse run_log_insert payload", {
-        error: getErrorMessage(err),
-      });
-    }
-  });
-
-  // `run_metric` carries the running cumulative cost + token usage
-  // emitted by the event sink after each `appstrate.metric` event,
-  // throttled per run by the broadcaster. Routed to the same
-  // org/space/run filters as `run_update` and `run_log_insert`
-  // — no new isolation rule. The scope filters here are the ONLY
-  // tenant gate for this channel; do not relax without updating the
-  // broadcaster payload contract.
-  await listenClient.listen("run_metric", (payload) => {
-    try {
-      if (!anyAccepts("run_metric")) return;
-      const raw = JSON.parse(payload) as Record<string, unknown>;
-      const parsed = runMetricEventSchema.safeParse(snakeToCamel(raw));
-      if (!parsed.success) {
-        logger.error("run_metric payload failed schema validation", {
-          issues: parsed.error.issues,
-        });
-        return;
-      }
-      for (const sub of subscribers.values()) {
-        if (!accepts(sub, "run_metric")) continue;
-        if (sub.filter.orgId !== raw.org_id) continue;
-        if (sub.filter.spaceId !== raw.space_id) continue;
-        if (sub.filter.runId && sub.filter.runId !== raw.run_id) continue;
-        if (sub.filter.packageId && sub.filter.packageId !== raw.package_id) continue;
-        // Actor gate: the `run_metric` NOTIFY payload carries no `end_user_id`
-        // (packages/db/src/notify.ts — RunMetricNotifyPayload has org/space/run/
-        // package scope only), so an end-user subscription cannot be proven to
-        // own this metric row. Skip rather than leak another end-user's cost /
-        // token metrics. Dashboard members / API keys (endUserId undefined) are
-        // unaffected. Per-end-user metric streaming would need `end_user_id`
-        // added to the broadcast payload (a DB migration — see the report).
-        if (sub.filter.endUserId !== undefined) continue;
-        sub.send({ event: "run_metric", data: parsed.data });
-      }
-    } catch (err) {
-      logger.error("Failed to parse run_metric payload", {
-        error: getErrorMessage(err),
-      });
-    }
-  });
-
-  // `connection_update` carries every INSERT/UPDATE/DELETE on
-  // `integration_connections` so the dashboard can patch its caches in
-  // real time — the orange "Reconnection required" badge, the agent
-  // page's member picker verdict, the integration detail's connection
-  // row all read off React Query keys that this event invalidates.
-  //
-  // Filter is per-space; the subscriber owns its actor identity
-  // (set at SSE auth time) so a member only sees their own rows. The
-  // payload deliberately omits `org_id` (the table has none) — tenant
-  // isolation is bound to the upstream SSE auth gate proving
-  // `spaceId ∈ orgId`.
-  await listenClient.listen("connection_update", (payload) => {
-    try {
-      if (!anyAccepts("connection_update")) return;
-      const raw = JSON.parse(payload) as Record<string, unknown>;
-      const parsed = connectionUpdateEventSchema.safeParse(snakeToCamel(raw));
-      if (!parsed.success) {
-        logger.error("connection_update payload failed schema validation", {
-          issues: parsed.error.issues,
-        });
-        return;
-      }
-      const data = parsed.data;
-      for (const sub of subscribers.values()) {
-        if (!accepts(sub, "connection_update")) continue;
-        if (sub.filter.spaceId !== raw.space_id) continue;
-        // Actor filter: only fan out rows the subscriber owns. Without
-        // this, every member of a space would receive every other
-        // member's connection events (org-wide cache pollution).
-        if (sub.filter.userId !== undefined) {
-          if (raw.user_id !== sub.filter.userId) continue;
-        } else if (sub.filter.endUserId !== undefined) {
-          if (raw.end_user_id !== sub.filter.endUserId) continue;
-        } else {
-          // No actor filter on the subscription — skip rather than leak.
-          continue;
-        }
-        sub.send({ event: "connection_update", data });
-      }
-    } catch (err) {
-      logger.error("Failed to parse connection_update payload", {
-        error: getErrorMessage(err),
-      });
-    }
-  });
-
-  // `chat_session_update` is a space-emitted change SIGNAL from the
-  // chat module (packages/module-chat/src/realtime.ts): the payload carries
-  // only the owner identity, and the client refetches the session list.
-  // Chat sessions are strictly user-owned (org+user scoped, no space
-  // dimension), so fan-out gates on org + exact user match. End-user
-  // subscriptions never receive chat frames (chat has no end-user surface);
-  // subscriptions without an actor are skipped rather than leaked to.
-  await listenClient.listen("chat_session_update", (payload) => {
-    try {
-      if (!anyAccepts("chat_session_update")) return;
-      const raw = JSON.parse(payload) as Record<string, unknown>;
-      const parsed = chatSessionUpdateEventSchema.safeParse(snakeToCamel(raw));
-      if (!parsed.success) {
-        logger.error("chat_session_update payload failed schema validation", {
-          issues: parsed.error.issues,
-          raw,
-        });
-        return;
-      }
-      for (const sub of subscribers.values()) {
-        if (!accepts(sub, "chat_session_update")) continue;
-        if (sub.filter.orgId !== raw.org_id) continue;
-        if (sub.filter.userId === undefined || sub.filter.userId !== raw.user_id) continue;
-        sub.send({ event: "chat_session_update", data: parsed.data });
-      }
-    } catch (err) {
-      logger.error("Failed to parse chat_session_update payload", {
-        error: getErrorMessage(err),
-      });
-    }
-  });
-
-  logger.info("Realtime LISTEN channels initialized");
+/** Is every LISTEN channel installed? Read by `/health` (`checks.realtime`). */
+export function realtimeReady(): boolean {
+  return initState.installed.size === Object.keys(LISTEN_SPECS).length;
 }
 
 export function addSubscriber(sub: Subscriber): void {

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -31,6 +31,7 @@ import { emptyRunResult, type RunResult } from "@appstrate/afps-runtime/runner";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "../lib/logger.ts";
 import { getCache, getEventBuffer } from "../infra/index.ts";
+import type { EventBuffer } from "../infra/event-buffer/interface.ts";
 import { getEnv } from "@appstrate/env";
 import {
   runWithSpan,
@@ -817,6 +818,19 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
       err: getErrorMessage(err),
     });
   });
+
+  // 8. Drop whatever the gap drain in step 1 could not commit. The sink is
+  //    closed, so no drain will ever look at this buffer again and its entries
+  //    would linger until TTL. Best-effort: a failed clear costs memory (or
+  //    Redis keys) for the TTL window, never correctness.
+  await getEventBuffer()
+    .then((buffer) => buffer.clear(run.id))
+    .catch((err) => {
+      logger.warn("finalize: event buffer clear failed (run already terminal)", {
+        runId: run.id,
+        err: getErrorMessage(err),
+      });
+    });
 }
 
 /**
@@ -1138,6 +1152,31 @@ async function bufferEvent(runId: string, sequence: number, event: RunEvent): Pr
   await buffer.put(runId, sequence, event, ttlSeconds);
 }
 
+/**
+ * Drop a spent buffer entry. The Postgres commit is authoritative, so a failed
+ * removal must never throw out of ingestion — it would burn the replay key and
+ * 500 a POST whose event is already persisted. Returns false when the entry
+ * survived: the drain must then stop, since the very same head would be re-read
+ * on the next iteration forever.
+ */
+async function dropBufferedEvent(
+  buffer: EventBuffer,
+  runId: string,
+  sequence: number,
+): Promise<boolean> {
+  try {
+    await buffer.remove(runId, sequence);
+    return true;
+  } catch (err) {
+    logger.warn("drain could not remove a spent buffered event", {
+      runId,
+      sequence,
+      err: getErrorMessage(err),
+    });
+    return false;
+  }
+}
+
 async function drainBufferedEvents(
   run: RunSinkContext,
   opts: { allowGaps?: boolean } = {},
@@ -1149,6 +1188,18 @@ async function drainBufferedEvents(
     if (!head) return;
 
     const next = run.lastEventSequence + 1;
+
+    if (head.sequence < next) {
+      // Committed on a prior drain (its removal failed, or a stale-snapshot
+      // POST re-inserted it); keeping it blocks the whole buffer.
+      logger.warn("drain dropped an already-persisted buffered event", {
+        runId: run.id,
+        sequence: head.sequence,
+        lastEventSequence: run.lastEventSequence,
+      });
+      if (!(await dropBufferedEvent(buffer, run.id, head.sequence))) return;
+      continue;
+    }
 
     if (head.sequence === next) {
       const outcome = await persistEventAndAdvance(run, head.event, head.sequence);
@@ -1162,7 +1213,7 @@ async function drainBufferedEvents(
       // `claimed` persisted the event; `lost_race` means another drainer
       // claimed this exact sequence (its event is persisted) — in both
       // cases the buffered copy is spent.
-      await buffer.remove(run.id, head.sequence);
+      if (!(await dropBufferedEvent(buffer, run.id, head.sequence))) return;
       continue;
     }
 
@@ -1179,7 +1230,7 @@ async function drainBufferedEvents(
         logger.debug("gap drain stopped — sink closed mid-drain", { runId: run.id });
         return;
       }
-      await buffer.remove(run.id, head.sequence);
+      if (!(await dropBufferedEvent(buffer, run.id, head.sequence))) return;
       continue;
     }
 

--- a/apps/api/test/integration/middleware/boot-gate.test.ts
+++ b/apps/api/test/integration/middleware/boot-gate.test.ts
@@ -30,6 +30,7 @@ import healthRouter, {
   markServerReady,
   _resetServerReadyForTesting,
 } from "../../../src/routes/health.ts";
+import { initRealtime } from "../../../src/services/realtime.ts";
 import { errorHandler } from "../../../src/middleware/error-handler.ts";
 import type { AppEnv } from "../../../src/types/index.ts";
 
@@ -123,6 +124,9 @@ describe("boot gate", () => {
 
   it("reports healthy once boot and the agents orchestrator are ready", async () => {
     const app = buildGatedApp();
+    // The rollup also reads `checks.realtime`, which boot installs; do the same
+    // here so this asserts the agents dimension it is about.
+    await initRealtime();
     markServerReady({ agentsHealthy: true });
 
     const res = await app.request("/health");

--- a/apps/api/test/integration/routes/health.test.ts
+++ b/apps/api/test/integration/routes/health.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, afterAll } from "bun:test";
 import { getTestApp } from "../../helpers/app.ts";
+import { initRealtime } from "../../../src/services/realtime.ts";
 import { truncateAll } from "../../helpers/db.ts";
 
 const app = getTestApp();
@@ -83,6 +84,19 @@ describe("GET /health", () => {
     expect(body.checks).toHaveProperty("agents");
     expect(body.checks.agents).toHaveProperty("status");
     expect(["healthy", "degraded"]).toContain(body.checks.agents.status);
+  });
+
+  // The whole test process shares the LISTEN state, so install the channels
+  // here rather than depend on which suite ran first.
+  it("reports realtime healthy once every channel is listening, never answering 503", async () => {
+    await initRealtime();
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.checks.realtime.status).toBe("healthy");
+    // The rollup is computed over the readiness-gating checks only: `agents` is
+    // degraded here (getTestApp skips boot), realtime is not consulted.
+    expect(body.status).toBe("degraded");
   });
 
   it("returns HTTP 200 when database is reachable", async () => {

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -50,8 +50,10 @@ import {
   activeRunMetricThrottleCount,
 } from "../../../src/services/run-metric-broadcaster.ts";
 import { getRunFull } from "../../../src/services/state/runs.ts";
+import { getEventBuffer } from "../../../src/infra/index.ts";
 import { recordLlmUsage } from "../../../src/services/llm-usage-ledger.ts";
 import type { RunArtifactsSummary } from "@appstrate/db/schema";
+import type { RunEvent } from "@appstrate/afps-runtime/types";
 import type { AppstrateModule, ModelCost, RunStatusChangeParams } from "@appstrate/core/module";
 import type { TokenPricingStatus } from "@appstrate/afps-runtime/runner";
 
@@ -148,6 +150,11 @@ function buildEnvelope(
     data,
     sequence,
   };
+}
+
+/** The already-decoded shape `drainBufferedEvents` reads back out of the buffer. */
+function bufferedProgress(runId: string, message: string): RunEvent {
+  return { type: "appstrate.progress", runId, timestamp: Date.now(), message };
 }
 
 describe("POST /api/runs/:runId/events — ingestion without Redis-specific coupling", () => {
@@ -413,6 +420,110 @@ describe("POST /api/runs/:runId/events — ingestion without Redis-specific coup
       (l) => typeof l.message === "string" && l.message.startsWith("gap-"),
     );
     expect(gapLogs.length).toBe(10);
+  });
+
+  // Regression for the dead buffer head. `buffer.remove` runs OUTSIDE the
+  // transaction that commits the event, so a committed sequence can survive in
+  // the buffer (failed removal, or a stale-snapshot POST re-inserting it).
+  // The drain used to treat that head as a gap and bail, stranding every later
+  // event — including under `allowGaps`, so finalize could not rescue them.
+  it("drains past a buffered head the run already persisted", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/ingest-agent");
+
+    const first = await postEvent(
+      runId,
+      buildEnvelope(runId, "appstrate.progress", { message: "head-1", timestamp: Date.now() }, 1),
+    );
+    expect(first.status).toBe(200);
+
+    // seq=1 is committed; plant it back in the buffer, ahead of the seq=2 it strands.
+    const buffer = await getEventBuffer();
+    await buffer.put(runId, 1, bufferedProgress(runId, "dead-head-1"), 60);
+    await buffer.put(runId, 2, bufferedProgress(runId, "stranded-2"), 60);
+
+    const res = await postEvent(
+      runId,
+      buildEnvelope(runId, "appstrate.progress", { message: "live-3", timestamp: Date.now() }, 3),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { outcome: string }).outcome).toBe("persisted");
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.lastEventSequence).toBe(3);
+
+    const logs = await db.select().from(runLogs).where(eq(runLogs.runId, runId));
+    const messages = logs.map((l) => l.message);
+    expect(messages).toContain("stranded-2");
+    expect(messages).toContain("live-3");
+    expect(await buffer.peekLowest(runId)).toBeNull();
+  });
+
+  it("finalize drains past a buffered head the run already persisted", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/ingest-agent");
+
+    const first = await postEvent(
+      runId,
+      buildEnvelope(runId, "appstrate.progress", { message: "head-1", timestamp: Date.now() }, 1),
+    );
+    expect(first.status).toBe(200);
+
+    const buffer = await getEventBuffer();
+    await buffer.put(runId, 1, bufferedProgress(runId, "dead-head-1"), 60);
+    await buffer.put(runId, 2, bufferedProgress(runId, "stranded-2"), 60);
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      durationMs: 100,
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.lastEventSequence).toBe(2);
+    expect(row?.sinkClosedAt).not.toBeNull();
+
+    const logs = await db.select().from(runLogs).where(eq(runLogs.runId, runId));
+    expect(logs.map((l) => l.message)).toContain("stranded-2");
+    // Post-CAS cleanup: nothing will ever drain this buffer again.
+    expect(await buffer.peekLowest(runId)).toBeNull();
+  });
+
+  // The Postgres commit is authoritative — a buffer removal that fails after it
+  // must not throw out of ingestion. It used to bubble up to `ingestRunEvent`,
+  // which released the replay key and answered 500 for an event already on disk.
+  it("answers 200 when the buffer removal fails after a committed drain", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/ingest-agent");
+
+    await postEvent(
+      runId,
+      buildEnvelope(runId, "appstrate.progress", { message: "head-1", timestamp: Date.now() }, 1),
+    );
+    const buffered = await postEvent(
+      runId,
+      buildEnvelope(runId, "appstrate.progress", { message: "ooo-3", timestamp: Date.now() }, 3),
+    );
+    expect(((await buffered.json()) as { outcome: string }).outcome).toBe("buffered");
+
+    const buffer = await getEventBuffer();
+    const remove = buffer.remove.bind(buffer);
+    buffer.remove = () => Promise.reject(new Error("buffer backend unavailable"));
+    try {
+      const res = await postEvent(
+        runId,
+        buildEnvelope(runId, "appstrate.progress", { message: "fill-2", timestamp: Date.now() }, 2),
+      );
+      expect(res.status).toBe(200);
+    } finally {
+      buffer.remove = remove;
+      await buffer.clear(runId);
+    }
+
+    // Both the fast-path event and the drained one committed.
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.lastEventSequence).toBe(3);
+
+    const logs = await db.select().from(runLogs).where(eq(runLogs.runId, runId));
+    expect(logs.map((l) => l.message)).toContain("ooo-3");
   });
 
   // Regression for the HttpSink off-by-one: the first event emitted by

--- a/apps/api/test/integration/services/integration-token-refresh.test.ts
+++ b/apps/api/test/integration/services/integration-token-refresh.test.ts
@@ -33,12 +33,21 @@ import { recordIntegrationRefreshFailure } from "../../../src/services/integrati
 interface TokenServer {
   url: string;
   setResponse: (body: Record<string, unknown>, status?: number) => void;
+  /** Hold each request open, so overlapping exchanges are observable. */
+  setDelayMs: (ms: number) => void;
+  /** Highest number of exchanges this server ever served at the same time. */
+  maxConcurrent: () => number;
+  /** Forget that peak, so an assertion measures only what follows. */
+  resetPeak: () => void;
   stop: () => void;
 }
 
 function startTokenServer(): TokenServer {
   let nextBody: Record<string, unknown> = {};
   let nextStatus = 200;
+  let delayMs = 0;
+  let inFlight = 0;
+  let peak = 0;
   const server = (
     globalThis as unknown as {
       Bun: {
@@ -52,17 +61,29 @@ function startTokenServer(): TokenServer {
   ).Bun.serve({
     port: 0,
     hostname: "127.0.0.1",
-    fetch: () =>
-      new Response(JSON.stringify(nextBody), {
+    fetch: async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+      inFlight -= 1;
+      return new Response(JSON.stringify(nextBody), {
         status: nextStatus,
         headers: { "Content-Type": "application/json" },
-      }),
+      });
+    },
   });
   return {
     url: `http://${server.hostname}:${server.port}/token`,
     setResponse: (body, status = 200) => {
       nextBody = body;
       nextStatus = status;
+    },
+    setDelayMs: (ms) => {
+      delayMs = ms;
+    },
+    maxConcurrent: () => peak,
+    resetPeak: () => {
+      peak = 0;
     },
     stop: () => server.stop(),
   };
@@ -254,6 +275,38 @@ describe("forceRefreshIntegrationConnection — Phase 6 scope-shrink awareness",
     );
 
     expect(result.fields.access_token).toBe("old-access");
+  });
+
+  it("never exchanges concurrently for a forced and a proactive refresh of one connection", async () => {
+    // Expiry INSIDE the 5-minute lead window, so the proactive caller has no
+    // short-circuit either when it starts: both flights want the endpoint, and
+    // only the per-key serialization in `dedupedRefresh` keeps them apart.
+    const connId = await seedConnection(["read"], new Date(Date.now() + 2 * 60_000));
+    token.setResponse({ access_token: "rotated", expires_in: 3600 });
+    token.setDelayMs(50);
+    // The assertion below must measure these two flights and nothing else.
+    token.resetPeak();
+
+    const encrypted = (await fetchEncrypted(connId))!;
+    const refreshCtx = { tokenEndpoint: token.url, clientId: "cid", clientSecret: "csec" };
+    const [forced, proactive] = await Promise.all([
+      forceRefreshIntegrationConnection(connId, PACKAGE_ID, "primary", encrypted, refreshCtx),
+      forceRefreshIntegrationConnection(connId, PACKAGE_ID, "primary", encrypted, refreshCtx, {
+        force: false,
+      }),
+    ]);
+
+    expect(forced.fields.access_token).toBe("rotated");
+    // The proactive flight re-reads after the forced one wrote, so it answers
+    // from the row instead of spending the refresh_token a second time.
+    expect(proactive.fields.access_token).toBe("rotated");
+    expect(token.maxConcurrent()).toBe(1);
+
+    const [row] = await db
+      .select({ needsReconnection: integrationConnections.needsReconnection })
+      .from(integrationConnections)
+      .where(eq(integrationConnections.id, connId));
+    expect(row!.needsReconnection).toBe(false);
   });
 
   it("treats scope creep (response wider than stored) as non-shrink", async () => {

--- a/apps/api/test/integration/services/realtime.test.ts
+++ b/apps/api/test/integration/services/realtime.test.ts
@@ -631,6 +631,50 @@ describe("realtime service (integration)", () => {
   // ── initRealtime idempotency ────────────────────────────────
 
   describe("initRealtime idempotency", () => {
+    /** A fresh installation state, so an injected failure never touches the real fan-out. */
+    function freshState() {
+      return { promise: null, installed: new Set<string>() };
+    }
+
+    it("retries only the channels whose listen failed", async () => {
+      const seen: string[] = [];
+      const state = freshState();
+      const failOnMetric = async (channel: string) => {
+        seen.push(channel);
+        if (channel === "run_metric") throw new Error("listen refused");
+      };
+
+      await expect(initRealtime(failOnMetric, state)).rejects.toThrow("listen refused");
+      expect(seen).toEqual(["run_update", "run_log_insert", "run_metric"]);
+
+      seen.length = 0;
+      await initRealtime(async (channel: string) => {
+        seen.push(channel);
+      }, state);
+      // The two channels that resolved are NOT listened to again — a second
+      // handler on the same channel would double every frame.
+      expect(seen).toEqual(["run_metric", "connection_update", "chat_session_update"]);
+    });
+
+    it("listens on each channel exactly once under concurrent callers", async () => {
+      const seen: string[] = [];
+      const state = freshState();
+      const slowListen = async (channel: string) => {
+        seen.push(channel);
+        await Bun.sleep(5);
+      };
+
+      await Promise.all([initRealtime(slowListen, state), initRealtime(slowListen, state)]);
+
+      expect(seen).toEqual([
+        "run_update",
+        "run_log_insert",
+        "run_metric",
+        "connection_update",
+        "chat_session_update",
+      ]);
+    });
+
     it("calling initRealtime multiple times does not duplicate listeners", async () => {
       // initRealtime was already called in beforeAll. Call it again.
       await initRealtime();

--- a/apps/api/test/unit/deduped-refresh.test.ts
+++ b/apps/api/test/unit/deduped-refresh.test.ts
@@ -15,7 +15,8 @@
  * upstream exchange at all.
  *
  * Tier 0 has no Redis, so `withRedisLock` is a pass-through here and what is
- * exercised is exactly the in-process singleflight map.
+ * exercised is exactly the in-process halves: the singleflight map and the
+ * per-key serialization chain.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -118,6 +119,71 @@ describe("dedupedRefresh", () => {
 
     expect(await Promise.all(all)).toEqual(["STORED", "STORED"]);
     expect(reReads).toBe(1);
+  });
+
+  it("serializes a forced and a proactive flight for the same key", async () => {
+    const gate = deferred();
+    let stored = "STALE";
+    let storedIsFresh = false;
+    let exchanges = 0;
+    let inFlight = 0;
+    let peak = 0;
+
+    const run = (force: boolean) =>
+      dedupedRefresh<string>("cred_serialized", {
+        lockKey: "test:cred_serialized",
+        lockLabel: "test",
+        force,
+        // The proactive verdict: hand back the stored row when a peer (here,
+        // the forced flight) has already written a fresh token to it.
+        reReadFreshness: async ({ force: f }) => (!f && storedIsFresh ? `STORED:${stored}` : null),
+        doRefresh: async () => {
+          inFlight += 1;
+          peak = Math.max(peak, inFlight);
+          await gate.promise;
+          exchanges += 1;
+          stored = `ROTATED-${exchanges}`;
+          storedIsFresh = true;
+          inFlight -= 1;
+          return stored;
+        },
+      });
+
+    // The forced flight is held inside `doRefresh` while the proactive one is
+    // created: unserialized, the proactive re-read would run against the row
+    // as it stands BEFORE the rotation and exchange a second time.
+    const forced = run(true);
+    const proactive = run(false);
+    gate.resolve();
+
+    expect(await forced).toBe("ROTATED-1");
+    expect(await proactive).toBe("STORED:ROTATED-1");
+    expect(peak).toBe(1);
+    expect(exchanges).toBe(1);
+  });
+
+  it("a rejected flight does not block the next flight on the same key", async () => {
+    const run = (force: boolean, fail: boolean) =>
+      dedupedRefresh<string>("cred_rejected", {
+        lockKey: "test:cred_rejected",
+        lockLabel: "test",
+        force,
+        reReadFreshness: async () => null,
+        doRefresh: async () => {
+          if (fail) throw new Error("upstream 503");
+          return "EXCHANGED";
+        },
+      });
+
+    const failing = run(true, true);
+    const following = run(false, false);
+
+    await expect(failing).rejects.toThrow("upstream 503");
+    expect(await following).toBe("EXCHANGED");
+
+    // The chain is released once it settles — a later flight runs immediately
+    // rather than waiting on a tail that will never be cleared.
+    expect(await run(true, false)).toBe("EXCHANGED");
   });
 
   it("releases the flight so a later forced caller runs its own refresh", async () => {

--- a/apps/api/test/unit/infra/event-buffer.test.ts
+++ b/apps/api/test/unit/infra/event-buffer.test.ts
@@ -10,9 +10,11 @@
  * silently stalling every run at status="running" in dev mode.
  */
 
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, spyOn, beforeEach, afterEach } from "bun:test";
 import { describeRequiresRedis } from "../../helpers/tier.ts";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
+import { logger } from "../../../src/lib/logger.ts";
+import { MAX_BUFFER_ENTRIES } from "../../../src/infra/event-buffer/interface.ts";
 import { LocalEventBuffer } from "../../../src/infra/event-buffer/local-event-buffer.ts";
 import { RedisEventBuffer } from "../../../src/infra/event-buffer/redis-event-buffer.ts";
 
@@ -26,6 +28,16 @@ function mkEvent(seq: number): RunEvent {
 }
 
 describe("LocalEventBuffer", () => {
+  let warnSpy: ReturnType<typeof spyOn<typeof logger, "warn">>;
+
+  beforeEach(() => {
+    warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   it("peekLowest returns null on an empty buffer", async () => {
     const buf = new LocalEventBuffer();
     expect(await buf.peekLowest("r1")).toBeNull();
@@ -139,6 +151,67 @@ describe("LocalEventBuffer", () => {
     expect((h2?.event as unknown as { message: string }).message).toBe("event-100");
     await buf.shutdown();
   });
+
+  it("caps the buffer at MAX_BUFFER_ENTRIES, dropping the lowest sequences", async () => {
+    const buf = new LocalEventBuffer();
+    try {
+      for (let seq = 1; seq <= MAX_BUFFER_ENTRIES + 10; seq++) {
+        await buf.put("r1", seq, mkEvent(seq), 60);
+      }
+
+      // The 10 lowest were evicted, so the head is the 11th sequence.
+      expect((await buf.peekLowest("r1"))?.sequence).toBe(11);
+      expect(warnSpy).toHaveBeenCalledWith("event buffer overflowed — dropped oldest entries", {
+        runId: "r1",
+        trimmed: 1,
+        cap: MAX_BUFFER_ENTRIES,
+      });
+    } finally {
+      await buf.shutdown();
+    }
+  });
+
+  it("stays strictly ordered after a trim, whatever the insert order", async () => {
+    const buf = new LocalEventBuffer();
+    try {
+      // Descending inserts: every put lands at the head and every trim evicts
+      // the entry that just arrived, the worst case for the insertion path.
+      for (let seq = MAX_BUFFER_ENTRIES + 10; seq >= 1; seq--) {
+        await buf.put("r1", seq, mkEvent(seq), 60);
+      }
+
+      const drained: number[] = [];
+      for (;;) {
+        const head = await buf.peekLowest("r1");
+        if (!head) break;
+        drained.push(head.sequence);
+        await buf.remove("r1", head.sequence);
+      }
+
+      expect(drained.length).toBe(MAX_BUFFER_ENTRIES);
+      expect(drained[0]).toBe(11);
+      expect(drained.every((seq, i) => i === 0 || seq > drained[i - 1]!)).toBe(true);
+    } finally {
+      await buf.shutdown();
+    }
+  });
+
+  it("logs the entries it drops on expiry", async () => {
+    const buf = new LocalEventBuffer();
+    try {
+      await buf.put("r1", 1, mkEvent(1), 0); // immediately expired
+      await buf.put("r1", 2, mkEvent(2), 0);
+      await new Promise((r) => setTimeout(r, 5));
+
+      expect(await buf.peekLowest("r1")).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith("event buffer dropped expired entries", {
+        runId: "r1",
+        dropped: 2,
+      });
+    } finally {
+      await buf.shutdown();
+    }
+  });
 });
 
 describeRequiresRedis("RedisEventBuffer", () => {
@@ -187,4 +260,31 @@ describeRequiresRedis("RedisEventBuffer", () => {
       await buf.shutdown();
     }
   });
+
+  // The cap (ZREMRANGEBYRANK on every put) had no coverage. Same case as the
+  // local backend's: MAX+10 ascending sequences, lowest ones evicted. The
+  // count is not re-checked by draining — that would cost two extra round
+  // trips per entry, and with distinct ascending sequences a head at 11
+  // already pins it: exactly 10 members were removed from the bottom.
+  it("caps the sorted set at MAX_BUFFER_ENTRIES, dropping the lowest sequences", async () => {
+    const runId = `r_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const buf = new RedisEventBuffer();
+    try {
+      for (let seq = 1; seq <= MAX_BUFFER_ENTRIES + 10; seq++) {
+        await buf.put(runId, seq, mkEvent(seq), 60);
+      }
+
+      const drained: number[] = [];
+      for (let i = 0; i < 3; i++) {
+        const head = await buf.peekLowest(runId);
+        if (!head) break;
+        drained.push(head.sequence);
+        await buf.remove(runId, head.sequence);
+      }
+      expect(drained).toEqual([11, 12, 13]);
+    } finally {
+      await buf.clear(runId);
+      await buf.shutdown();
+    }
+  }, 60_000);
 });

--- a/apps/api/test/unit/local-queue-shutdown.test.ts
+++ b/apps/api/test/unit/local-queue-shutdown.test.ts
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Tests for `LocalQueue.shutdown()` and its interaction with retry backoff.
+ * Tests for `LocalQueue` retry backoff — a backing-off job is DELAYED, not
+ * active — and for how `shutdown()` treats one.
  *
- * A job sleeping between attempts counts as active — its `run()` awaits the
- * retry timer — so shutdown has to decide what to do with it. Both halves of
- * that decision are load-bearing:
+ * A job between attempts holds no worker slot (BullMQ semantics: backoff moves
+ * the job to `delayed` and frees the worker, and the attempt rejoins the wait
+ * list at the tail when it comes due). It is still work the process owes, so
+ * shutdown has to decide what to do with it. Both halves of that decision are
+ * load-bearing:
  *
  *  - A retry due INSIDE the shutdown budget is work that would have completed.
  *    `llm-usage-retry` puts billable `llm_usage` rows on this queue precisely
@@ -68,9 +71,9 @@ function recordingLogger(): RecordingLogger {
 
 /**
  * The line the queue emits when it parks a failed job on its retry timer. It is
- * written on the same synchronous run as the `sleepingRetries` registration, so
- * seeing it is exactly "the sleeper exists and `shutdown()` can find it" — the
- * readiness these tests need before they call `shutdown()`.
+ * written on the same synchronous run as the `delayed` registration, so seeing
+ * it is exactly "the parked attempt exists and `shutdown()` can find it" — the
+ * readiness these tests need before they act on it.
  */
 const RETRY_SCHEDULED = "job failed, retrying in";
 
@@ -89,6 +92,93 @@ function signal(): { fired: Promise<void>; fire: () => void } {
 }
 
 const tick = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Poll until the queue reports empty. `count()` spans pending + active +
+ * delayed, so reaching 0 also proves no parked attempt was leaked.
+ */
+async function drained(q: { count(): Promise<number> }): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while ((await q.count()) > 0) {
+    if (Date.now() > deadline) throw new Error("queue did not drain within 5s");
+    await tick(10);
+  }
+}
+
+describe("LocalQueue — backoff does not hold a worker slot", () => {
+  it("runs the next queued job while a failed one waits out its backoff", async () => {
+    const { logger, emitted } = recordingLogger();
+    const q = new LocalQueue<{ v: string }>("test-delayed", undefined, logger);
+    const order: string[] = [];
+
+    q.process(
+      async (job: QueueJob<{ v: string }>) => {
+        order.push(`${job.data.v}#${job.attemptsMade}`);
+        if (job.data.v === "bad" && job.attemptsMade === 0) throw new Error("transient");
+      },
+      { concurrency: 1, backoffStrategy: () => 200 },
+    );
+
+    await q.add("job", { v: "bad" }, { attempts: 2 });
+    await emitted(RETRY_SCHEDULED);
+    await q.add("job", { v: "healthy" });
+
+    await drained(q);
+
+    // CONTROL: while the sleeping retry held the only slot, the healthy job
+    // could not start until the backoff elapsed — `["bad#0", "bad#1",
+    // "healthy#0"]`. The retry now rejoins at the TAIL, behind the newcomer.
+    expect(order).toEqual(["bad#0", "healthy#0", "bad#1"]);
+  });
+
+  it("counts a parked attempt once, and releases it when it runs", async () => {
+    const { logger, emitted } = recordingLogger();
+    const q = new LocalQueue<{ v: string }>("test-delayed-count", undefined, logger);
+    const attempts: number[] = [];
+
+    q.process(
+      async (job: QueueJob<{ v: string }>) => {
+        attempts.push(job.attemptsMade);
+        if (job.attemptsMade === 0) throw new Error("transient");
+      },
+      { concurrency: 1, backoffStrategy: () => 400 },
+    );
+
+    await q.add("job", { v: "x" }, { attempts: 2 });
+    await emitted(RETRY_SCHEDULED);
+    await tick(50); // the slot is released a microtask later; 350ms of backoff left
+
+    // Delayed, not active, and counted exactly once — a double count, or an
+    // entry left in the set after the timer fires, keeps `drained` from ever
+    // seeing 0 below.
+    expect(await q.count()).toBe(1);
+
+    await drained(q);
+    expect(attempts).toEqual([0, 1]);
+  });
+
+  it("carries per-job `attempts` across the backoff, over the queue default", async () => {
+    const { logger } = recordingLogger();
+    const q = new LocalQueue<{ v: string }>("test-delayed-attempts", { attempts: 1 }, logger);
+    const attempts: number[] = [];
+
+    q.process(
+      async (job: QueueJob<{ v: string }>) => {
+        attempts.push(job.attemptsMade);
+        throw new Error("transient");
+      },
+      { backoffStrategy: () => 20 },
+    );
+
+    await q.add("job", { v: "x" }, { attempts: 3 });
+    await drained(q);
+
+    // CONTROL: if `opts` did not travel with the re-enqueued attempt, the
+    // queue default of 1 would apply from the second one on and this is [0, 1].
+    // `llm-usage-retry` rides on exactly this — 288 attempts, per job.
+    expect(attempts).toEqual([0, 1, 2]);
+  });
+});
 
 describe("LocalQueue.shutdown — retries inside the budget", () => {
   // CONTROL for the whole file: before the budget check existed, `shutdown()`
@@ -315,5 +405,90 @@ describe("LocalQueue.shutdown — jobs that never started", () => {
     // for it — so assert on what actually ran, not on the queue depth.)
     await tick(80);
     expect(ran).toEqual([1]);
+  });
+});
+
+/**
+ * Deny the event loop for `ms`, synchronously. Models the process being busy
+ * past its own shutdown deadline — the only way a timer armed BEFORE the
+ * deadline can fire after it, deterministically.
+ */
+function blockEventLoop(ms: number): void {
+  const end = Date.now() + ms;
+  while (Date.now() < end) {
+    // spin — denying the loop is the point, efficiency is not
+  }
+}
+
+describe("LocalQueue.shutdown — a retry re-enqueued mid-shutdown", () => {
+  it("runs an attempt that comes due inside the budget, after the queued work", async () => {
+    const { lines, logger, emitted } = recordingLogger();
+    const q = new LocalQueue<{ v: string }>("test-shutdown-delayed", undefined, logger);
+    const ran: string[] = [];
+
+    q.process(
+      async (job: QueueJob<{ v: string }>) => {
+        ran.push(`${job.data.v}#${job.attemptsMade}`);
+        if (job.data.v === "bad" && job.attemptsMade === 0) throw new Error("transient");
+      },
+      { concurrency: 1, backoffStrategy: () => 300 },
+    );
+
+    await q.add("job", { v: "bad" }, { attempts: 2 });
+    await emitted(RETRY_SCHEDULED);
+    await q.add("job", { v: "queued" });
+
+    await q.shutdown();
+
+    // The attempt re-enters `pending` while shutdown is already waiting, and
+    // still runs: `drain()` keeps starting work until the budget is spent.
+    // Nothing was thrown away, so nothing was logged as abandoned.
+    expect(ran).toEqual(["bad#0", "queued#0", "bad#1"]);
+    expect(abandonLines(lines)).toHaveLength(0);
+    expect(await q.count()).toBe(0);
+  });
+});
+
+describe("LocalQueue.shutdown — a retry that comes due past the deadline", () => {
+  /**
+   * The attempt is due inside the budget, so the pre-sweep keeps it — but the
+   * process stalls and the timer only fires once the budget is spent. It
+   * re-enters `pending`, finds `drain()` closed, and would sit there unrun and
+   * unreported: the silent loss this whole file exists to prevent.
+   */
+  it("reports an attempt that re-entered the queue after the budget was spent", async () => {
+    const { lines, logger, emitted } = recordingLogger();
+    const q = new LocalQueue<{ v: string }>("test-late-retry", undefined, logger);
+    const attempts: number[] = [];
+
+    q.process(
+      async (job: QueueJob<{ v: string }>) => {
+        attempts.push(job.attemptsMade);
+        throw new Error("transient");
+      },
+      { concurrency: 1, backoffStrategy: () => 60 },
+    );
+
+    await q.add("job", { v: "x" }, { attempts: 5 });
+    await emitted(RETRY_SCHEDULED);
+
+    // Not awaited yet: `shutdown()` runs up to its first await (deadline set,
+    // the attempt kept because it is due in 60ms of a 150ms budget), then the
+    // loop is denied for 400ms — well past both the deadline and the timer.
+    const shutdown = q.shutdown(150);
+    blockEventLoop(400);
+    await shutdown;
+
+    // The attempt never ran, and it is named exactly once.
+    expect(attempts).toEqual([0]);
+    const abandoned = abandonLines(lines);
+    expect(abandoned).toHaveLength(1);
+    expect(abandoned[0]!.msg).toContain("never started");
+    expect(abandoned[0]!.data).toMatchObject({ queue: "test-late-retry", jobName: "job" });
+
+    // Nothing left behind: no queued item, no armed timer.
+    expect(await q.count()).toBe(0);
+    await tick(200);
+    expect(attempts).toEqual([0]);
   });
 });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -20312,6 +20312,9 @@ export interface operations {
                      *         },
                      *         "agents": {
                      *           "status": "healthy"
+                     *         },
+                     *         "realtime": {
+                     *           "status": "healthy"
                      *         }
                      *       }
                      *     }
@@ -20332,6 +20335,11 @@ export interface operations {
                             };
                             /** @description Agent runtime readiness established during platform boot. */
                             agents?: {
+                                /** @enum {string} */
+                                status?: "healthy" | "degraded";
+                            };
+                            /** @description PG LISTEN fan-out behind the realtime SSE streams. `degraded` when a channel failed to install. Advisory: not part of the top-level `status`. */
+                            realtime?: {
                                 /** @enum {string} */
                                 status?: "healthy" | "degraded";
                             };

--- a/apps/web/src/components/test/request-fanout.test.ts
+++ b/apps/web/src/components/test/request-fanout.test.ts
@@ -11,7 +11,9 @@
  *  3. the notification queries polling every 30s, which is only safe to slow
  *     down while the realtime stream reconciles them on (re)connect — the SSE
  *     protocol has no replay, so dropping the reconnect-side invalidation would
- *     leave a badge stale for a full poll interval.
+ *     leave a badge stale for a full poll interval;
+ *  4. the run caches, reconciled on the same reconnect for the same reason, and
+ *     on RE-connects only (the first one races the mount's own queries).
  *
  * Source-scanned rather than rendered: these modules import the SPA's typed API
  * client, which uses `import.meta.glob` and cannot be evaluated by the bun test
@@ -21,6 +23,7 @@
 import { describe, it, expect } from "bun:test";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import { broadRunKeys } from "../../hooks/use-global-run-sync.ts";
 
 const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf-8");
 
@@ -98,5 +101,41 @@ describe("notification freshness", () => {
   it("still invalidates them on a terminal run seen live", () => {
     expect(GLOBAL_SYNC).toContain("TERMINAL_RUN_STATUSES.has(status)");
     expect([...GLOBAL_SYNC.matchAll(/invalidateNotificationQueries\(/g)].length).toBeGreaterThan(1);
+  });
+});
+
+describe("run cache reconciliation on reconnect", () => {
+  // Same protocol gap as the badges, run side: `run_update` frames missed while
+  // the stream was down left the page reading "running" under a bell that said
+  // "finished".
+  it("reconciles on RE-connect only, before reading frames", () => {
+    const connectStart = GLOBAL_SYNC.indexOf("const connectOnce = async () => {");
+    const readerStart = GLOBAL_SYNC.indexOf("const reader = res.body.getReader();");
+    expect(connectStart).toBeGreaterThan(-1);
+    expect(readerStart).toBeGreaterThan(connectStart);
+
+    // The guard: the FIRST connect races the mount's own queries, so
+    // reconciling there would double every one of them. Matched on the
+    // identifiers, not a formatted line — prettier reflows the latter.
+    const onConnect = GLOBAL_SYNC.slice(connectStart, readerStart);
+    expect(onConnect).toContain("hasConnectedOnce");
+    expect(onConnect).toContain("reconcileRunQueries(qcRef.current, orgId)");
+    expect(onConnect).toContain("handleConnectionUpdate(qcRef.current)");
+    expect(GLOBAL_SYNC).toContain("let hasConnectedOnce = false;");
+  });
+
+  it("covers every run family except the logs, identically on both paths", () => {
+    // One list feeds the per-event throttle AND the reconnect reconciliation,
+    // so the latter cannot drift into a silent subset of the former.
+    const keys = broadRunKeys("org_1").map((key) => JSON.stringify(key));
+    expect(keys).toEqual([
+      '["paginated-runs"]',
+      '["agents","org_1"]',
+      '["packages","agents","org_1"]',
+      '["get","/api/runs"]',
+    ]);
+    // The run-detail page appends live frames into the log cache; refetching
+    // it would drop the per-turn breadcrumbs it holds.
+    expect(keys.some((key) => key.startsWith('["run-logs"'))).toBe(false);
   });
 });

--- a/apps/web/src/hooks/test/broad-invalidator.test.ts
+++ b/apps/web/src/hooks/test/broad-invalidator.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `createBroadInvalidator` — the throttle behind the run-list refreshes.
+ *
+ * It used to re-arm its timer on every event (a trailing debounce), so a
+ * sustained stream of `run_update` frames flushed NOTHING: `["agents"]`,
+ * `["packages"]` and `["paginated-runs"]` stayed stale for as long as runs kept
+ * moving, which is exactly when those lists matter. The property pinned below
+ * is the throttle's: flush latency bounded by `delayMs` at any event rate,
+ * bursts still collapsed into one flush.
+ */
+
+import { describe, it, expect, jest, beforeEach, afterEach } from "bun:test";
+import type { QueryClient } from "@tanstack/react-query";
+import { createBroadInvalidator } from "../use-global-run-sync.ts";
+
+const DELAY_MS = 2000;
+
+/** Records the keys the invalidator asks React Query to refetch. */
+function recordingClient() {
+  const keys: unknown[][] = [];
+  const qc = {
+    invalidateQueries: ({ queryKey }: { queryKey: unknown[] }) => {
+      keys.push(queryKey);
+    },
+  } as unknown as QueryClient;
+  return { keys, getQueryClient: () => qc };
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("createBroadInvalidator", () => {
+  it("keeps flushing under a sustained 1 Hz stream", () => {
+    const { keys, getQueryClient } = recordingClient();
+    const broad = createBroadInvalidator(getQueryClient, DELAY_MS);
+
+    for (let i = 0; i < 60; i++) {
+      broad.schedule(["paginated-runs"]);
+      jest.advanceTimersByTime(1000);
+    }
+
+    // 60s of traffic through a 2s throttle: one flush every other event, so
+    // exactly 30. The debounce this replaced produced 0 on the same input —
+    // that is the negative control.
+    expect(keys.length).toBe(30);
+    broad.dispose();
+  });
+
+  it("collapses a burst into one flush, one invalidation per distinct key", () => {
+    const { keys, getQueryClient } = recordingClient();
+    const broad = createBroadInvalidator(getQueryClient, DELAY_MS);
+
+    for (let i = 0; i < 10; i++) {
+      broad.schedule(["agents", "org_1"]);
+      broad.schedule(["paginated-runs"]);
+      jest.advanceTimersByTime(10);
+    }
+    expect(keys).toEqual([]);
+
+    jest.advanceTimersByTime(DELAY_MS);
+    expect(keys).toEqual([["agents", "org_1"], ["paginated-runs"]]);
+    broad.dispose();
+  });
+
+  it("cancels an armed flush on dispose (unmount)", () => {
+    const { keys, getQueryClient } = recordingClient();
+    const broad = createBroadInvalidator(getQueryClient, DELAY_MS);
+
+    broad.schedule(["paginated-runs"]);
+    broad.dispose();
+    jest.advanceTimersByTime(DELAY_MS * 2);
+
+    expect(keys).toEqual([]);
+  });
+});

--- a/apps/web/src/hooks/test/run-detail-patch.test.ts
+++ b/apps/web/src/hooks/test/run-detail-patch.test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `patchRunDetail` — the single writer of the run-detail cache from a
+ * `run_update` frame, shared by the global stream and the per-run stream
+ * (whose every connection opens with a status snapshot).
+ *
+ * Asserted against a REAL `QueryClient`: the two things that can silently
+ * break are React Query's key matching and the camelCase→`RunWireDto` field
+ * mapping, and a stub would fake both.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import type { EnrichedRun, RunUpdateEvent } from "@appstrate/shared-types";
+import { patchRunDetail } from "../use-global-run-sync.ts";
+import { runKeys } from "../../lib/query-keys.ts";
+
+const ORG = "org_1";
+const SPACE = "spc_1";
+const RUN = "run_1";
+
+const FRAME: RunUpdateEvent = {
+  operation: "UPDATE",
+  id: RUN,
+  packageId: "@acme/agent",
+  status: "success",
+  userId: "usr_1",
+  endUserId: null,
+  orgId: ORG,
+  spaceId: SPACE,
+  scheduleId: null,
+  error: null,
+  startedAt: "2026-09-07T10:00:00.000Z",
+  completedAt: "2026-09-07T10:00:42.000Z",
+  duration: 42_000,
+};
+
+describe("patchRunDetail", () => {
+  it("writes the frame onto the cached run under the RunWireDto field names", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(runKeys.detail(ORG, SPACE, RUN), {
+      id: RUN,
+      status: "running",
+      started_at: null,
+      completed_at: null,
+      duration: null,
+    });
+
+    patchRunDetail(qc, ORG, SPACE, FRAME);
+
+    const run = qc.getQueryData<EnrichedRun>(runKeys.detail(ORG, SPACE, RUN));
+    expect(run?.status).toBe("success");
+    // Snake, not `startedAt`: a naive spread would add camel keys next to the
+    // stale snake ones and the page would render the old timestamps forever.
+    expect(run?.started_at).toBe(FRAME.startedAt);
+    expect(run?.completed_at).toBe(FRAME.completedAt);
+    expect(run?.duration).toBe(42_000);
+    expect(run).not.toHaveProperty("startedAt");
+  });
+
+  it("drops a non-terminal frame landing on a terminal cached run", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(runKeys.detail(ORG, SPACE, RUN), {
+      id: RUN,
+      status: "success",
+      started_at: FRAME.startedAt,
+      completed_at: FRAME.completedAt,
+      duration: 42_000,
+    });
+
+    // `openRealtimeStream` subscribes BEFORE its snapshot SELECT runs, so the
+    // snapshot can be older than a `run_update` already pushed to the same
+    // subscriber. A terminal run emits nothing more, so a blind spread would
+    // leave the detail page reading "running" for a finished run, forever.
+    const stale = patchRunDetail(qc, ORG, SPACE, {
+      ...FRAME,
+      status: "running",
+      completedAt: null,
+      duration: null,
+    });
+
+    expect(stale).toBeNull();
+    const run = qc.getQueryData<EnrichedRun>(runKeys.detail(ORG, SPACE, RUN));
+    expect(run?.status).toBe("success");
+    expect(run?.completed_at).toBe(FRAME.completedAt);
+    expect(run?.duration).toBe(42_000);
+  });
+
+  it("applies a terminal frame over a live cached run", () => {
+    const qc = new QueryClient();
+    qc.setQueryData(runKeys.detail(ORG, SPACE, RUN), { id: RUN, status: "running" });
+
+    expect(patchRunDetail(qc, ORG, SPACE, FRAME)).not.toBeNull();
+    expect(qc.getQueryData<EnrichedRun>(runKeys.detail(ORG, SPACE, RUN))?.status).toBe("success");
+  });
+
+  it("does not materialize a run nothing has cached", () => {
+    const qc = new QueryClient();
+
+    patchRunDetail(qc, ORG, SPACE, FRAME);
+
+    // The frame carries 13 of ~30 fields; caching it as a full row would make
+    // the detail page render a run with no agent name, no cost and no counts.
+    expect(qc.getQueryData(runKeys.detail(ORG, SPACE, RUN))).toBeUndefined();
+  });
+});

--- a/apps/web/src/hooks/use-global-run-sync.ts
+++ b/apps/web/src/hooks/use-global-run-sync.ts
@@ -20,6 +20,7 @@ import {
 } from "../lib/query-keys";
 import {
   type EnrichedRun,
+  type RunUpdateEvent,
   TERMINAL_RUN_STATUSES,
   runUpdateEventSchema,
   runUpdateToRunPatch,
@@ -29,12 +30,13 @@ import {
  * Patch caches when an `integration_connections` row changes (INSERT /
  * UPDATE / DELETE) — drives the live "Reconnection required" badge on
  * the connections page, the agent picker verdict, the integration detail
- * connection list, and the agent status cards. Without this they refresh
- * only on window focus and stay stale across tabs.
+ * connection list, and the agent status cards. `refetchOnWindowFocus` is
+ * globally false (`main.tsx`), so these caches move on exactly two things:
+ * a live frame here, and the reconnect reconciliation in `connectOnce`.
  *
  * Server-side actor filter in `services/realtime.ts:connection_update`
- * means we only see our own rows; cross-actor invalidations (e.g.
- * someone else sharing a connection) still rely on a focus refetch,
+ * means we only see our own rows; a cross-actor change (e.g. someone else
+ * sharing a connection) reaches this tab at the next reconnect or mutation,
  * which is acceptable because the run-time resolver gate enforces the
  * server-side truth anyway.
  */
@@ -104,7 +106,7 @@ function readContextChatSessionId(init: unknown): unknown {
  * change (message persisted, read marker advanced on another device, rename,
  * delete, `generating` flip). Signal-only frame → invalidate, the list GET is
  * the single source of the session DTO. Deliberately NOT routed through the
- * debounced broad invalidator: chat emits a handful of frames per turn (not a
+ * throttled broad invalidator: chat emits a handful of frames per turn (not a
  * per-log firehose like runs) and the unread badge / spinner should react
  * instantly. The key is the module's `SESSIONS_QUERY_KEY` (re-exported from
  * `@appstrate/module-chat/unread`, already imported by the nav badge);
@@ -134,19 +136,22 @@ function parseChatSessionId(raw: string): string | undefined {
 }
 
 /**
- * Trailing debounce (~2s) for the BROAD query invalidations triggered by
- * `run_update` events. A running agent emits frequent updates; the run/runs
- * caches are already patched in place (cheap), but invalidating
- * `["agents"]` / `["packages"]` / `["paginated-runs"]` on every event caused
- * a refetch fan-out per SSE message. Collapsing bursts into one trailing
- * flush keeps lists fresh at a fraction of the request volume.
+ * Throttle (~2s) for the BROAD invalidations a `run_update` triggers: the run
+ * caches are patched in place (cheap), a refetch fan-out per SSE message is
+ * not. The trigger's `WHEN` clause (`packages/db/src/notify.ts`) only fires on
+ * a status/timestamp transition, so this collapses bursts, not a firehose.
  */
 interface BroadInvalidator {
   schedule: (key: readonly unknown[]) => void;
   dispose: () => void;
 }
 
-function createBroadInvalidator(
+/**
+ * Exported for its test. The budget this buys: under sustained traffic at most
+ * 4 broad invalidations per `delayMs` per open tab — one per `broadRunKeys`
+ * entry — against zero under the debounce it replaced, which never flushed.
+ */
+export function createBroadInvalidator(
   getQueryClient: () => QueryClient,
   delayMs = 2000,
 ): BroadInvalidator {
@@ -165,8 +170,8 @@ function createBroadInvalidator(
   return {
     schedule(key) {
       pending.set(JSON.stringify(key), key);
-      if (timer) clearTimeout(timer);
-      timer = setTimeout(flush, delayMs);
+      // Throttle, not debounce: arm on the first event, let the burst accumulate.
+      if (!timer) timer = setTimeout(flush, delayMs);
     },
     dispose() {
       if (timer) clearTimeout(timer);
@@ -174,6 +179,62 @@ function createBroadInvalidator(
       pending.clear();
     },
   };
+}
+
+/**
+ * Single writer of the run-detail cache from a `run_update` frame; returns the
+ * patch to reuse on the run's list rows, or `null` when the frame is dropped:
+ * a per-connection snapshot can predate a live frame, and status only moves on.
+ */
+export function patchRunDetail(
+  qc: QueryClient,
+  orgId: string,
+  spaceId: string,
+  evt: RunUpdateEvent,
+): Partial<EnrichedRun> | null {
+  const key = runKeys.detail(orgId, spaceId, evt.id);
+  const cached = qc.getQueryData<EnrichedRun>(key);
+  if (
+    cached &&
+    TERMINAL_RUN_STATUSES.has(cached.status) &&
+    !TERMINAL_RUN_STATUSES.has(evt.status)
+  ) {
+    return null;
+  }
+  const patch = runUpdateToRunPatch(evt);
+  qc.setQueryData<EnrichedRun>(key, (prev) => (prev ? { ...prev, ...patch } : prev));
+  return patch;
+}
+
+/**
+ * The list/agent caches a `run_update` moves but cannot patch in place. ONE
+ * list, fed to the per-event throttle AND to the reconnect reconciliation, so
+ * the latter cannot drift into a silent subset of the former. Exported for its
+ * test.
+ */
+export function broadRunKeys(orgId: string): readonly (readonly unknown[])[] {
+  return [
+    paginatedRunsKeys.all,
+    agentsKeys.inOrg(orgId),
+    // Agent detail caches are keyed ["packages","agents",orgId,spaceId,id], so
+    // the org-scoped prefix is what refreshes an agent's config/model tabs.
+    packageKeys.familyInOrg("agents", orgId),
+    // The chat context sidebar reads this typed collection, not paginated-runs.
+    ["get", "/api/runs"],
+  ];
+}
+
+/**
+ * Refetch the run families after a stream gap. Run LOGS are deliberately absent:
+ * the run-detail page appends live frames into that cache and a refetch would
+ * drop the per-turn breadcrumbs it holds (see `invalidateRunLogs`).
+ */
+function reconcileRunQueries(qc: QueryClient, orgId: string) {
+  // Run detail/list caches are patched in place by live frames, so only a gap
+  // needs them refetched — they are not part of the per-event throttle.
+  for (const queryKey of [runKeys.all, runsKeys.all, ...broadRunKeys(orgId)]) {
+    qc.invalidateQueries({ queryKey });
+  }
 }
 
 function handleSSEMessage(
@@ -193,13 +254,9 @@ function handleSSEMessage(
   if (!parsed.success) return;
   const evt = parsed.data;
   const { id: runId, packageId, status, scheduleId } = evt;
-  // Map the camelCase wire frame onto RunWireDto field names (started_at /
-  // completed_at are snake there) so the spread actually overwrites them.
-  const patch = runUpdateToRunPatch(evt);
-
-  qc.setQueryData<EnrichedRun>(runKeys.detail(orgId, spaceId, runId), (prev) =>
-    prev ? { ...prev, ...patch } : prev,
-  );
+  const patch = patchRunDetail(qc, orgId, spaceId, evt);
+  // Frame dropped as stale — the list rows below must not regress either.
+  if (!patch) return;
 
   // Only the per-agent run list is keyed by packageId (nullable on the wire
   // once a run's package is deleted — ON DELETE SET NULL).
@@ -219,17 +276,9 @@ function handleSSEMessage(
     }
   }
 
-  // Broad invalidations are debounced (trailing ~2s) — the in-place cache
-  // patches above keep the visible run data live in the meantime.
-  broad.schedule(agentsKeys.inOrg(orgId));
-  // Agent detail caches are keyed ["packages","agents",orgId,spaceId,id]
-  // (plural path, spaceId before id) — invalidate by the org-scoped
-  // prefix so a run status change refreshes the agent's config/model tabs.
-  broad.schedule(packageKeys.familyInOrg("agents", orgId));
-  broad.schedule(paginatedRunsKeys.all);
-  // The chat context sidebar uses the typed global collection with a
-  // `chat_session_id` filter rather than the legacy paginated-runs hook.
-  broad.schedule(["get", "/api/runs"]);
+  // Broad invalidations are throttled (~2s) — the in-place cache patches above
+  // keep the visible run data live in the meantime.
+  for (const key of broadRunKeys(orgId)) broad.schedule(key);
 
   // Invalidate schedule-specific caches
   if (scheduleId) {
@@ -239,9 +288,6 @@ function handleSSEMessage(
   }
 
   if (TERMINAL_RUN_STATUSES.has(status)) {
-    // NOTE: ["paginated-runs"] is NOT invalidated here — the debounced
-    // broad invalidation above already covers it for this same event
-    // (it used to be invalidated twice per terminal run).
     invalidateNotificationQueries(qc);
     qc.invalidateQueries({ queryKey: runsKeys.all });
     qc.invalidateQueries({ queryKey: runKeys.all });
@@ -278,6 +324,10 @@ export function useGlobalRunSync() {
     const BASE_DELAY_MS = 1000;
     const MAX_DELAY_MS = 30_000;
     let attempt = 0;
+    // Only a RE-connect has a gap; the first races the mount's own queries.
+    let hasConnectedOnce = false;
+    let lastReconcileAt = 0;
+    const RECONCILE_MIN_INTERVAL_MS = 10_000;
 
     const sleep = (ms: number) =>
       new Promise<void>((resolve) => {
@@ -324,6 +374,17 @@ export function useGlobalRunSync() {
       // run MISSED while the stream was down is caught here, on reconnect —
       // seconds after connectivity returns, not at the next poll tick.
       invalidateNotificationQueries(qcRef.current);
+      // Same reasoning for the run caches, which are patched frame by frame —
+      // rate-limited because the server writes a frame on every connection, so a
+      // repeatedly dropped stream would reconcile at ~1 Hz and storm itself.
+      const now = Date.now();
+      if (hasConnectedOnce && now - lastReconcileAt >= RECONCILE_MIN_INTERVAL_MS) {
+        lastReconcileAt = now;
+        reconcileRunQueries(qcRef.current, orgId);
+        // `connection_update` frames were missed on the same stream.
+        handleConnectionUpdate(qcRef.current);
+      }
+      hasConnectedOnce = true;
 
       const reader = res.body.getReader();
       const decoder = new TextDecoder();
@@ -366,7 +427,10 @@ export function useGlobalRunSync() {
           // Failed to connect — fall through to the backoff below.
         }
         if (controller.signal.aborted) break;
-        const delay = Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS);
+        // Jitter — de-synchronize reconnect stampedes (every tab reconnects
+        // at once after a redeploy).
+        const delay =
+          Math.min(BASE_DELAY_MS * 2 ** attempt, MAX_DELAY_MS) * (0.5 + Math.random() * 0.5);
         attempt++;
         await sleep(delay);
       }

--- a/apps/web/src/hooks/use-realtime.ts
+++ b/apps/web/src/hooks/use-realtime.ts
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   runLogEventSchema,
   runMetricEventSchema,
+  runUpdateEventSchema,
   type RunLogEvent,
   type RunMetricEvent,
 } from "@appstrate/shared-types";
 import { getCurrentOrgId } from "../stores/org-store";
 import { getCurrentSpaceId } from "./use-current-space";
+import { patchRunDetail } from "./use-global-run-sync";
 
 // Re-export so existing consumers (run-detail.tsx) keep importing the metric
 // event type from here; the source of truth is the shared Zod schema.
@@ -33,10 +36,12 @@ function safeJsonParse(text: string): unknown {
  * single SSE connection. Pass any subset of handlers — the connection
  * dispatches by event type and skips channels with no listener attached.
  *
- * Status patches are NOT served here: they arrive on the global stream
- * (`useGlobalRunSync`), which writes the same run cache key.
+ * `run_update` is dispatched here rather than by a caller: the route answers
+ * every connection with a status snapshot, applied to the same run cache key
+ * the global stream writes — closing the gap when that stream missed a frame.
  */
 export function useRunRealtime(runId: string | null | undefined, handlers: RunRealtimeHandlers) {
+  const qc = useQueryClient();
   const handlersRef = useRef(handlers);
   useEffect(() => {
     handlersRef.current = handlers;
@@ -48,16 +53,20 @@ export function useRunRealtime(runId: string | null | undefined, handlers: RunRe
     const spaceId = getCurrentSpaceId();
     if (!orgId || !spaceId) return;
 
-    // Only the two run channels dispatched below are declared: the per-run
-    // stream would otherwise also carry `run_update` (status, already served
-    // by the global stream), `connection_update` (every connection row the
-    // caller owns) and `chat_session_update` for a page that listens to none
-    // of them. `verbose=true` is still required — it is what keeps
+    // Only the three run channels dispatched below are declared: the per-run
+    // stream would otherwise also carry `connection_update` (every connection
+    // row the caller owns) and `chat_session_update` for a page that listens
+    // to neither. `verbose=true` is still required — it is what keeps
     // `run_log.data` in the payload.
     const es = new EventSource(
-      `/api/realtime/runs/${runId}?orgId=${encodeURIComponent(orgId)}&spaceId=${encodeURIComponent(spaceId)}&verbose=true&channels=run_log,run_metric`,
+      `/api/realtime/runs/${runId}?orgId=${encodeURIComponent(orgId)}&spaceId=${encodeURIComponent(spaceId)}&verbose=true&channels=run_update,run_log,run_metric`,
       { withCredentials: true },
     );
+
+    es.addEventListener("run_update", (e) => {
+      const parsed = runUpdateEventSchema.safeParse(safeJsonParse(e.data));
+      if (parsed.success) patchRunDetail(qc, orgId, spaceId, parsed.data);
+    });
 
     es.addEventListener("run_log", (e) => {
       const parsed = runLogEventSchema.safeParse(safeJsonParse(e.data));
@@ -72,5 +81,5 @@ export function useRunRealtime(runId: string | null | undefined, handlers: RunRe
     return () => {
       es.close();
     };
-  }, [runId]);
+  }, [runId, qc]);
 }

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -75,7 +75,22 @@ async function initPostgres(): Promise<Db> {
     await listenConn.end();
   };
   _listenClient = {
-    listen: (channel, handler) => listenConn.listen(channel, handler) as unknown as Promise<void>,
+    listen: async (channel, handler) => {
+      try {
+        await listenConn.listen(channel, handler);
+      } catch (err) {
+        // postgres.js 3.4.9 registers the channel BEFORE awaiting the LISTEN
+        // acknowledgement (src/index.js:165-195) and keeps the memoised rejected
+        // promise, so a retry would push a second handler onto that dead entry and
+        // re-await the same rejection. Drop it so the retry re-issues LISTEN with
+        // exactly one handler. (The `unlisten` postgres.js returns is only handed
+        // back on success, so it cannot clean this up.)
+        const channels = (listenConn.listen as unknown as { channels?: Record<string, unknown> })
+          .channels;
+        if (channels && channel in channels) delete channels[channel];
+        throw err;
+      }
+    },
   };
 
   return drizzle(queryClient, { schema }) as unknown as Db;

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -3,6 +3,7 @@
 import type { PgDatabase, PgQueryResultHKT } from "drizzle-orm/pg-core";
 import { getEnv } from "@appstrate/env";
 import * as schema from "./schema/index.ts";
+import { createListenClient, type ListenClient } from "./listen-client.ts";
 
 const env = getEnv();
 
@@ -13,9 +14,7 @@ export const isEmbeddedDb = !env.DATABASE_URL;
 export type Db = PgDatabase<PgQueryResultHKT, typeof schema>;
 
 /** Postgres.js listen client or PGlite notification handler. */
-export interface ListenClient {
-  listen(channel: string, handler: (payload: string) => void): Promise<void>;
-}
+export type { ListenClient };
 
 // ---------------------------------------------------------------------------
 // Initialization
@@ -74,24 +73,7 @@ async function initPostgres(): Promise<Db> {
     await queryClient.end();
     await listenConn.end();
   };
-  _listenClient = {
-    listen: async (channel, handler) => {
-      try {
-        await listenConn.listen(channel, handler);
-      } catch (err) {
-        // postgres.js 3.4.9 registers the channel BEFORE awaiting the LISTEN
-        // acknowledgement (src/index.js:165-195) and keeps the memoised rejected
-        // promise, so a retry would push a second handler onto that dead entry and
-        // re-await the same rejection. Drop it so the retry re-issues LISTEN with
-        // exactly one handler. (The `unlisten` postgres.js returns is only handed
-        // back on success, so it cannot clean this up.)
-        const channels = (listenConn.listen as unknown as { channels?: Record<string, unknown> })
-          .channels;
-        if (channels && channel in channels) delete channels[channel];
-        throw err;
-      }
-    },
-  };
+  _listenClient = createListenClient(listenConn);
 
   return drizzle(queryClient, { schema }) as unknown as Db;
 }

--- a/packages/db/src/listen-client.ts
+++ b/packages/db/src/listen-client.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Sql } from "postgres";
+
+export interface ListenClient {
+  listen(channel: string, handler: (payload: string) => void): Promise<void>;
+}
+
+/**
+ * Wrap a postgres.js connection's `listen` so a rejected LISTEN can be retried.
+ *
+ * postgres.js 3.4.9 registers the channel BEFORE awaiting the LISTEN
+ * acknowledgement (src/index.js:165-195) and keeps the memoised rejected
+ * promise, so a retry would push a second handler onto that dead entry and
+ * re-await the same rejection. The wrapper drops the entry so the retry
+ * re-issues LISTEN with exactly one handler. (The `unlisten` postgres.js
+ * returns is only handed back on success, so it cannot clean this up.)
+ *
+ * The cleanup reaches into a private field. If a postgres.js upgrade moves it,
+ * the rejection is rethrown with that fact attached: the boot log then says
+ * the retries are stacking handlers instead of silently doing so.
+ */
+export function createListenClient(conn: Sql): ListenClient {
+  return {
+    listen: async (channel, handler) => {
+      try {
+        await conn.listen(channel, handler);
+      } catch (err) {
+        const channels = (conn.listen as unknown as { channels?: Record<string, unknown> })
+          .channels;
+        if (!channels) {
+          throw new Error(
+            `LISTEN "${channel}" failed and postgres.js no longer exposes listen.channels: ` +
+              "the stale registration cannot be cleared, a retry would stack handlers",
+            { cause: err },
+          );
+        }
+        delete channels[channel];
+        throw err;
+      }
+    },
+  };
+}

--- a/packages/db/test/listen-client.test.ts
+++ b/packages/db/test/listen-client.test.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `createListenClient` guards a postgres.js private: a rejected LISTEN leaves
+ * its channel registered (src/index.js:165-195), so a bare retry stacks a
+ * second handler onto the dead entry and re-awaits the same rejection. This
+ * runs against a real server (PGlite has no such registration to leak), and
+ * asserts on that private on purpose — it exists to notice the day a postgres.js
+ * upgrade moves it.
+ *
+ * The failing channel carries a NUL byte: the server rejects the LISTEN
+ * ("insufficient data left in message") while the connection stays usable, so
+ * no other suite sharing the database is affected.
+ */
+
+import { describe, it, expect, afterAll } from "bun:test";
+import postgres from "postgres";
+import { createListenClient } from "../src/listen-client.ts";
+
+const describeRequiresPostgres = describe.skipIf(!process.env.DATABASE_URL);
+
+describeRequiresPostgres("createListenClient (postgres.js stale LISTEN registration)", () => {
+  const conn = postgres(process.env.DATABASE_URL!, { max: 1, idle_timeout: 0, max_lifetime: 0 });
+  const channels = () =>
+    (conn.listen as unknown as { channels?: Record<string, { listeners: unknown[] }> }).channels;
+
+  afterAll(async () => {
+    await conn.end();
+  });
+
+  it("clears the registration a rejected LISTEN leaves behind, so a retry does not stack handlers", async () => {
+    const channel = "stale\0listen";
+    const client = createListenClient(conn);
+
+    await expect(client.listen(channel, () => {})).rejects.toThrow();
+    expect(channels()?.[channel]).toBeUndefined();
+
+    // Second attempt re-issues LISTEN with one handler, not two on a dead entry.
+    await expect(client.listen(channel, () => {})).rejects.toThrow();
+    expect(channels()?.[channel]).toBeUndefined();
+
+    // Negative control: the bare postgres.js call keeps the entry and stacks.
+    await expect(conn.listen(channel, () => {})).rejects.toThrow();
+    await expect(conn.listen(channel, () => {})).rejects.toThrow();
+    expect(channels()?.[channel]?.listeners).toHaveLength(2);
+    delete channels()![channel];
+
+    // The connection survived the rejections.
+    await client.listen("stale_listen_ok", () => {});
+    expect(channels()?.["stale_listen_ok"]?.listeners).toHaveLength(1);
+  });
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1020,9 +1020,9 @@ export {
   chatSessionUpdateEventSchema,
   runUpdateToRunPatch,
 } from "./realtime-events.ts";
-// `RunUpdateEvent` is deliberately absent: the last consumer outside
-// `realtime-events.ts` went with the run-detail page's unused `run_update`
-// listener. It is still live *inside* that module (`RealtimeEvent`'s union arm
-// and `runUpdateToRunPatch`'s parameter), so it stays exported there — this
-// barrel just no longer re-publishes a name nothing imports.
-export type { RunLogEvent, RunMetricEvent, RealtimeEvent } from "./realtime-events.ts";
+export type {
+  RunLogEvent,
+  RunMetricEvent,
+  RunUpdateEvent,
+  RealtimeEvent,
+} from "./realtime-events.ts";

--- a/scripts/health-container-e2e.sh
+++ b/scripts/health-container-e2e.sh
@@ -107,7 +107,8 @@ positive_body=$(wait_for_health_body healthy)
 jq -e '
   .status == "healthy" and
   .checks.database.status == "healthy" and
-  .checks.agents.status == "healthy"
+  .checks.agents.status == "healthy" and
+  .checks.realtime.status == "healthy"
 ' <<<"$positive_body" >/dev/null
 positive_id=$(compose ps -q appstrate)
 wait_for_docker_health "$positive_id" healthy


### PR DESCRIPTION
## Summary

Seven stability findings from the 2026-09-07 audit, each independently verified against the code before implementation (six read-only Opus passes), then implemented as six commits and put through two blind review passes (adversarial correctness + slim/DRY). No migration, no env var, no wire-contract change beyond one new advisory field on `/health`.

| # | Finding | Verdict | Commit |
| --- | --- | --- | --- |
| 1 | OAuth: forced + proactive refresh can spend the same refresh token concurrently (no-Redis pass-through; 30 s acquire timeout under a 45 s TTL) | Confirmed | `fix(oauth)` |
| 2 | Ingestion: a buffered event at/below the committed cursor blocks the whole buffer, including the finalize gap drain; under Redis the key TTL is refreshed on every put so it never expires | Confirmed, worse than reported | `fix(ingestion)` |
| 3 | SSE reconnect reconciles chat + notifications only; runs stay "running" after a missed terminal frame | Confirmed | `fix(web)` |
| 4 | Trailing debounce re-armed on every event never flushes under sustained traffic | Confirmed (mechanism), probability overstated: the PG trigger only fires on status transitions | `fix(web)` |
| 5 | `initRealtime` flags itself initialized before awaiting LISTEN; a first failure is permanent and invisible | Confirmed, narrower blast radius (`?wait=`, cancel, cache bus unaffected) | `fix(realtime)` |
| 6 | LocalQueue holds a worker slot during backoff; `llm-usage-retry` (4 slots, 288 attempts ≈ 24 h) is the worst case, not webhooks | Confirmed | `fix(queue)` |
| 7 | Local event buffer: no cap, O(N) insert; expiry drops are silent | Partially confirmed: N is bounded ≈ 13k by rate-limit × TTL; the real gap is silent drops | `fix(event-buffer)` |

## What changed

- **oauth** — per-credential promise chain in `dedupedRefresh` (both flight keys and their verdicts kept); lock acquire timeout derived from the TTL (TTL + 5 s) so the lock-less fallback only runs once the holder is presumed dead.
- **ingestion** — drain drops a head below the cursor and continues; buffer removal after a committed persist is best-effort; `buffer.clear()` wired at finalize (was dead code).
- **web** — reconnect invalidates run/list/agent/connection caches (re-connections only, ≤ 1/10 s); one key list feeds the per-event throttle and the reconnect path; per-run stream subscribes to the `run_update` snapshot the server already sends, applied monotonically (a non-terminal frame never overwrites a terminal cached status); jittered backoff; debounce → throttle.
- **realtime** — shared init promise + installed-channel set; `listen`/state injectable; postgres.js stale channel registration dropped on rejection (otherwise a retry stacks a second handler); boot logs at `error` and retries the install until it lands (exponential backoff capped at 60 s, unref'd, armed once per process); `/health` gains `checks.realtime` — **advisory, excluded from the `status` rollup** because the container HEALTHCHECK restarts the instance unless `status === "healthy"`.
- **queue** — backing-off jobs are `delayed`, not `active` (BullMQ semantics); `count()` includes them; shutdown names every attempt it throws away, including one re-entering `pending` after the deadline.
- **event-buffer** — shared `MAX_BUFFER_ENTRIES` with the same overflow policy and warning as Redis; expiry drops logged; binary-search insert (put() at 32k entries: 1 832 ms → 23 ms cumulative in the audit's benchmark).

## Review triage

Adversarial pass raised 1 blocker (health rollup → Docker restart loop) and 6 should-fix; 4 fixed (S1 postgres.js stale registration, S2 monotone snapshot, S3 reconnect rate limit, S6 compounded latency documented), 2 declined with reason:

- S5 (aggregate the dead-head warn, purge prefix in one Redis call): a dead head is by construction a single entry (the one whose removal failed); a long stale prefix needs repeated stale-snapshot POSTs of already-persisted sequences, which the replay branch already absorbs. Kept per-entry warn.
- N5 (Redis cap test does 10k puts): cap is a module constant; a seam only for the test was not worth it. Runs only under the Redis tier.

Slim pass: ~100 lines of restated comments removed; one real drift fixed (reconnect reconciliation omitted the agent-package family the per-event path invalidates).

## Test plan

- `bun run check` — 38/38 tasks, exit 0
- API: 171 pass / 2 skip (Redis-only) across the 10 touched suites, `TEST_TIER=0`
- Web: 754 pass / 70 files
- Each new test was negative-controlled against the pre-fix code (documented in the agent reports; e.g. throttle test yields 0 flushes on the old debounce, concurrency test yields `maxConcurrent: 2` without the chain).
- postgres.js stale-registration cleanup: extracted to `createListenClient(conn)` and covered on the PostgreSQL tier (`packages/db/test/listen-client.test.ts`, runs in the unit job) — a NUL-byte channel name makes the server reject the LISTEN while the connection stays usable; the bare postgres.js call is the negative control (two listeners stack). If a postgres.js upgrade hides `listen.channels`, the rejection is rethrown saying so instead of the cleanup silently becoming a no-op.
- `scripts/health-container-e2e.sh` positive path now asserts `.checks.realtime.status == "healthy"` (CI health job).

## Deploy notes

None required. `/health` consumers see a new `checks.realtime` field; `status` semantics are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

