### PR TITLE
fix(lint): type-aware linting on the backend, four dropped-promise bugs, and CVE-2026-31789

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,18 @@ jobs:
   unit:
     name: Unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 10, not 5. The suite itself is ~257 s on a runner (7 950 tests), and the
+    # single most expensive case is `scripts/test/lint.test.ts`'s subprocess
+    # lint, which by construction has to lint the whole repo before
+    # `--max-warnings 0` can trip. Backend type-aware rules and jsx-a11y took a
+    # cold whole-repo lint from ~21 s to ~56 s and past 120 s on a runner —
+    # this job restores no `.eslintcache` (only `check.yml` does), so it pays
+    # that cold number every run. It blew that test's own ceiling AND this one
+    # (run
+    # 34213836495: every other job in it succeeded, `Unit tests` was cancelled
+    # at the wall). This bounds a hang; it is not a target — a healthy run
+    # finishes in about half of it.
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,70 @@ git config commit.gpgsign true
 5. Wait for CI checks and code review
 6. Squash and merge after approval
 
+Step 5 is currently advice rather than a rule. The `Protect main` ruleset
+(`gh api repos/appstrate/appstrate/rulesets/14614228`) carries only `pull_request` and
+`non_fast_forward`; it declares **no** `required_status_checks`, and
+`repos/appstrate/appstrate/branches/main/protection` returns 404. So every gate in this repository —
+`check`, the test suites, CodeQL, secret scanning — is mergeable red today.
+
+### Required Checks (maintainers)
+
+The set that should gate a merge. Names are the GitHub check-run names, verbatim
+(`gh api repos/appstrate/appstrate/commits/main/check-runs --jq '.check_runs[].name'`):
+
+| Check                                                   | Workflow       |
+| ------------------------------------------------------- | -------------- |
+| `check`                                                 | `check.yml`    |
+| `Package resolves for consumers (packages/core)`        | `check.yml`    |
+| `Package resolves for consumers (packages/afps-shared)` | `check.yml`    |
+| `Unit tests`                                            | `test.yml`     |
+| `Platform container health e2e`                         | `test.yml`     |
+| `Secret Scanning`                                       | `security.yml` |
+| `Analyze`                                               | `codeql.yml`   |
+
+Deliberately **not** required, because a required check that does not report blocks the PR forever:
+`Integration tests`, `Runtime container e2e` and `E2E tests` are label-gated
+(`if: contains(github.event.pull_request.labels.*.name, …) || github.ref == 'refs/heads/main'`), so
+they are absent from an unlabelled PR, and `Scorecard Analysis` has no `pull_request` trigger at all.
+The same rule applies to any check added later: require it only once it is observed reporting on an
+ordinary PR.
+
+Applying it — a ruleset `PUT` **replaces** the whole ruleset, so read the live one and merge into it
+rather than writing a body from scratch:
+
+```sh
+gh api repos/appstrate/appstrate/rulesets/14614228 > /tmp/main-ruleset.json
+
+jq '.rules += [{
+      type: "required_status_checks",
+      parameters: {
+        strict_required_status_checks_policy: false,
+        do_not_enforce_on_create: false,
+        required_status_checks: [
+          { context: "check" },
+          { context: "Package resolves for consumers (packages/core)" },
+          { context: "Package resolves for consumers (packages/afps-shared)" },
+          { context: "Unit tests" },
+          { context: "Platform container health e2e" },
+          { context: "Secret Scanning" },
+          { context: "Analyze" }
+        ]
+      }
+    }]
+  | del(.id, .source_type, .source, .node_id, .created_at, .updated_at, ._links,
+        .current_user_can_bypass)' \
+  /tmp/main-ruleset.json > /tmp/main-ruleset-update.json
+
+gh api --method PUT repos/appstrate/appstrate/rulesets/14614228 --input /tmp/main-ruleset-update.json
+```
+
+`del(...)` rather than a `{name, target, …}` whitelist: the whitelist form emits `bypass_actors: null`
+when the live ruleset has none, and picking the fields to keep is the version of this edit that
+silently drops whatever GitHub adds to the payload next.
+`strict_required_status_checks_policy: false` means a PR does not have to be rebased onto the newest
+`main` before merging; set it to `true` only if stale-base merges become a real problem, since it
+makes every merge to `main` invalidate every open PR's status.
+
 ### Review Criteria
 
 - Quality gate passes (`bun run check` + `bun test`)

--- a/apps/api/src/infra/pubsub/redis-pubsub.ts
+++ b/apps/api/src/infra/pubsub/redis-pubsub.ts
@@ -26,7 +26,12 @@ export class RedisPubSub implements PubSub {
     }
 
     await new Promise<void>((resolve, reject) => {
-      subscriber.subscribe(channel, (err) => {
+      // `subscribe` returns a promise AS WELL AS taking a callback, and ioredis
+      // (standard-as-callback) already attaches its own `then(_, _)` to that
+      // promise before returning it — so the rejection is consumed there and
+      // the callback below is the single reporting path. `void`, not `await`:
+      // the enclosing `new Promise` is what the caller waits on.
+      void subscriber.subscribe(channel, (err) => {
         if (err) {
           logger.error("Failed to subscribe to channel", { channel, error: err.message });
           reject(err);

--- a/apps/api/src/infra/queue/local-queue.ts
+++ b/apps/api/src/infra/queue/local-queue.ts
@@ -349,10 +349,21 @@ export class LocalQueue<T> implements JobQueue<T> {
       }
     };
 
-    run().finally(() => {
-      this.activeJobs--;
-      this.drain();
-    });
+    run()
+      .finally(() => {
+        this.activeJobs--;
+        this.drain();
+      })
+      // `run` swallows every rejection from `handler`, but its own catch block
+      // runs caller-supplied code (`backoffStrategy`) and the logger — a throw
+      // there escapes as an unhandled rejection, which takes the process down.
+      // Terminal `.catch` so the queue logs it and keeps draining instead.
+      .catch((err) => {
+        this.log.error(`${this.name} job runner crashed`, {
+          jobId: job.id,
+          error: getErrorMessage(err),
+        });
+      });
   }
 
   /**

--- a/apps/api/src/lib/modules/registry.ts
+++ b/apps/api/src/lib/modules/registry.ts
@@ -158,6 +158,7 @@ export function buildModuleInitContext(): ModuleInitContext {
     getSendMail: async () => {
       // Lazy import to break circular dep: email.ts -> app-config.ts -> modules
       const { sendMail } = await import("../../services/email.ts");
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises -- `ModuleInitContext.getSendMail` (packages/core/src/module.ts) declares the mailer as `(to, subject, html) => void`; the platform's `sendMail` returns `Promise<void>`, so no module can await delivery. Reconciling the two is a published-core contract change (a module supplying its own mailer would break), so it is not made here.
       return sendMail;
     },
     getOrgOwnerEmails,

--- a/apps/api/src/modules/firecracker/orchestrator.ts
+++ b/apps/api/src/modules/firecracker/orchestrator.ts
@@ -1540,7 +1540,10 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
         void this.killVm(vm, 0).catch(() => {});
       }, maxLifetimeSeconds * 1000);
     }
-    proc.exited.then((code) => {
+    // Fire-and-forget: `Bun.Subprocess.exited` never rejects and the observer
+    // only stamps the record and logs, so there is nothing to await here —
+    // `waitForExit` is the path that actually consumes the exit code.
+    void proc.exited.then((code) => {
       if (vm.consoleWatch) clearInterval(vm.consoleWatch);
       // Reaper anchor (ROB-1): the exit reaper destroys records whose
       // stamp lingers past EXIT_REAP_AFTER_MS — i.e. exits no platform
@@ -1630,7 +1633,9 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     if (!vm) return;
 
     let exited = vm.proc === null;
-    vm.proc?.exited.then(() => {
+    // Fire-and-forget flag flip read by the tail loop below; `exited` never
+    // rejects and the handler cannot throw.
+    void vm.proc?.exited.then(() => {
       exited = true;
     });
     yield* tailFileLines(vm.consolePath, () => exited, signal);

--- a/apps/api/src/modules/firecracker/runner/daemon.ts
+++ b/apps/api/src/modules/firecracker/runner/daemon.ts
@@ -228,7 +228,13 @@ async function shutdown(signal: string): Promise<void> {
   logger.info("appstrate-runner shutting down", { signal });
   // Stop accepting new requests first, then tear down VMs — the reverse
   // order would let the platform start a run into a dying daemon.
-  server.stop();
+  //
+  // `void`, not `await`: `stop()` closes the listener synchronously (which is
+  // the ordering this comment is about) and its promise only settles once
+  // in-flight connections drain. This daemon serves with `idleTimeout: 0`, so
+  // awaiting it would let one open connection hold shutdown open forever and
+  // never reach the `process.exit(0)` below.
+  void server.stop();
   // Best-effort socket cleanup — a leftover node would force the NEXT
   // boot through the stale-socket removal path anyway, but tidying here
   // keeps `ls` honest. Type-guarded + never throws (shutdown must reach

--- a/apps/api/src/modules/firecracker/scripts/dev/smoke.ts
+++ b/apps/api/src/modules/firecracker/scripts/dev/smoke.ts
@@ -434,7 +434,7 @@ try {
   await dumpConsole(boundary.id, "vm1 exception");
   throw err;
 } finally {
-  platformStub.stop(true);
+  await platformStub.stop(true);
   await orch.removeIsolationBoundary(boundary).catch(() => {});
   await orch.shutdown().catch(() => {});
 }

--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -411,7 +411,9 @@ export function createMcpRouter(deps: McpRouterDeps = {}): Hono<AppEnv> {
         event.tool === "invoke_operation" &&
         (event.outcome === "invoked" || event.outcome === "denied")
       ) {
-        trackAudit(
+        // `void`: deliberately off the response path — the rationale, and what
+        // drains these before the process exits, is the comment above.
+        void trackAudit(
           recordAudit(c, {
             action: event.outcome === "denied" ? "mcp.operation.denied" : "mcp.operation.invoked",
             resourceType: "mcp_operation",

--- a/apps/api/src/modules/oidc/auth/guards.ts
+++ b/apps/api/src/modules/oidc/auth/guards.ts
@@ -139,7 +139,7 @@ async function getLimiter(category: string, points: number): Promise<RateLimiter
   let limiter = limiterCache.get(cacheKey);
   if (!limiter) {
     const factory = await getRateLimiterFactory();
-    limiter = await factory.create(points, 60, `rl:oidc:${category}:`);
+    limiter = factory.create(points, 60, `rl:oidc:${category}:`);
     limiterCache.set(cacheKey, limiter);
   }
   return limiter;
@@ -149,7 +149,7 @@ let loginEmailLimiter: RateLimiterAbstract | null = null;
 async function getLoginEmailLimiter(): Promise<RateLimiterAbstract> {
   if (!loginEmailLimiter) {
     const factory = await getRateLimiterFactory();
-    loginEmailLimiter = await factory.create(
+    loginEmailLimiter = factory.create(
       LOGIN_EMAIL_POINTS,
       LOGIN_EMAIL_DURATION_SEC,
       "rl:oidc:login-email:",

--- a/apps/api/src/services/orchestrator/process-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/process-orchestrator.ts
@@ -590,8 +590,9 @@ export class ProcessOrchestrator implements RunOrchestrator {
     // stdout, drained stderr arriving after the platform's
     // "exited non-zero" log) still surfaces a reason in the same place
     // operators look first. Fire-and-forget — this is a diagnostic-only
-    // observer; the actual exit handling stays in pi.ts.
-    proc.exited.then(async (code) => {
+    // observer; the actual exit handling stays in pi.ts. `void` is safe here:
+    // `Bun.Subprocess.exited` never rejects and the handler only sleeps and logs.
+    void proc.exited.then(async (code) => {
       if (code === 0) return;
       // Give the stderr drain a moment to flush remaining buffered lines
       // (the reader sees `done: true` only after the kernel closes the pipe).
@@ -649,7 +650,9 @@ export class ProcessOrchestrator implements RunOrchestrator {
     if (!ph?.stdoutPath || !ph?.proc) return;
 
     let exited = false;
-    ph.proc.exited.then(() => {
+    // Fire-and-forget flag flip read by the tail loop below; `exited` never
+    // rejects and the handler cannot throw.
+    void ph.proc.exited.then(() => {
       exited = true;
     });
     yield* tailFileLines(ph.stdoutPath, () => exited, signal);
@@ -716,12 +719,16 @@ export class ProcessOrchestrator implements RunOrchestrator {
     for (let attempt = 0; attempt < retries; attempt++) {
       const s1 = Bun.serve({ port: 0, fetch: () => new Response() });
       const port = s1.port ?? 0;
-      s1.stop(true);
+      // AWAITED: `Server.stop()` returns a promise that settles once the socket
+      // is actually released. Returning a port whose probe server is still
+      // bound is exactly the EADDRINUSE-at-sidecar-boot this function exists to
+      // avoid.
+      await s1.stop(true);
       if (!port) continue;
       if (reserved.has(port) || reserved.has(port + 1)) continue;
       try {
         const s2 = Bun.serve({ port: port + 1, fetch: () => new Response() });
-        s2.stop(true);
+        await s2.stop(true);
         return port;
       } catch {
         continue;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -698,8 +698,9 @@ export default tseslint.config(
   {
     // Type-aware guard (web only): flag `x as T` assertions that don't change
     // the type — these are pure noise that also hide where a value's real type
-    // silently drifted from what the cast claims. Scoped to the SPA so the
-    // type-checked program stays cheap. Only this one type-aware rule is on.
+    // silently drifted from what the cast claims. This rule is web-only because
+    // it is a cast-hygiene rule and the SPA is where the casts are; the backend
+    // gets a different set of type-aware rules in the block below.
     files: ["apps/web/src/**/*.{ts,tsx}"],
     languageOptions: {
       parserOptions: {
@@ -709,6 +710,96 @@ export default tseslint.config(
     },
     rules: {
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    },
+  },
+  {
+    // Type-aware async correctness (backend). Three rules, and each one names a
+    // failure this codebase can actually have:
+    //
+    //  - `no-floating-promises`  an un-awaited promise in a run orchestrator is
+    //    a run reported finished before its work is done, and a rejection that
+    //    reaches the process as an unhandled rejection rather than a log line.
+    //  - `no-misused-promises`   an `async` function handed to something that
+    //    expects a void return (Hono middleware, a Redis/BullMQ listener, an
+    //    event handler) has its rejection dropped on the floor by the caller.
+    //  - `await-thenable`        an `await` on a non-promise is almost always a
+    //    missing call or a type that changed under the caller.
+    //
+    // Nothing else in the repo covers this: `bun test` executes tests without
+    // typechecking them, and `tsc` does not model promise handling. The first
+    // run found 18 violations in product code — 14 under `apps/api/src`, 4
+    // under `packages/*/src` — and four were defects rather than style:
+    // `findAvailablePort` returned a port whose probe server was still bound
+    // (the EADDRINUSE-at-sidecar-boot it exists to prevent); `writer.write()`
+    // was un-awaited in core's streaming upload, dropping both backpressure and
+    // the rollback path; core's MCP bun-probe guarded an async pipe write with
+    // a sync `try`; and the local queue's own catch block could take the
+    // process down with an unhandled rejection.
+    //
+    // ─── Scope, and what it costs ────────────────────────────────────────
+    //
+    // `bun scripts/lint.ts`, wall clock, this machine, 2026-09-08. The three
+    // scopes first, cold (`.eslintcache` deleted before every run), 3 runs each:
+    //
+    //                                       cold                    warm
+    //   no type-aware backend rules   23.5 / 23.5 / 24.2 s         ~2.1 s
+    //   + apps/api/src                35.2 / 38.5 / 41.1 s         ~2.1 s
+    //   + packages/*/src (this block) 51.9 / 54.5 / 54.8 s         ~2.1 s
+    //
+    // then re-measured PAIRED — one baseline-config run and one this-config run
+    // back to back, both cold. That is the only comparison that survives a
+    // machine whose background load moved between the table above and these:
+    //
+    //   pair 1   28.7 s  ->  69.2 s
+    //   pair 2   25.4 s  ->  59.0 s
+    //
+    // So: a cold lint costs about 2.3x, +30 to +40 s, and a warm one is
+    // unchanged — `--cache --cache-strategy content` rebuilds the type program
+    // only for the files that actually changed. Cold is CI and a fresh clone;
+    // the pre-push path is warm, and CI's `check` job budget is
+    // `timeout-minutes: 10`.
+    //
+    // `packages/*/src` is in scope rather than `apps/api/src` alone because the
+    // second half of that cost bought four more findings, two of them
+    // unhandled-rejection paths in `@appstrate/core` — which is PUBLISHED, so a
+    // dropped rejection there ships to every consumer. `packages/*/src` is a
+    // discovered superset (a new package is covered the day it lands), not a
+    // roster of the packages that happened to look async today.
+    //
+    // ─── Why test code is excluded ───────────────────────────────────────
+    //
+    // Not a cost decision — `await-thenable` is UNSOUND over `bun:test`.
+    // `bun-types/test.d.ts` declares `rejects: Matchers<unknown>` (line 929)
+    // whose matchers return `void` (`toThrow(expected?: unknown): void`, line
+    // 1415), while at runtime `expect(p).rejects.toThrow()` returns a promise
+    // that MUST be awaited or the assertion floats and the test passes
+    // regardless. Measured 2026-09-08 with the test trees in scope: 77
+    // `await-thenable` hits, 75 of them exactly that shape — every one a
+    // correct `await` the rule would have had us delete.
+    //
+    // The other two rules could run over tests, and were left off: the whole
+    // population there was six `server.stop(true)` / cache-invalidation calls
+    // in `afterAll` teardown, which is not worth a second block whose only
+    // difference is which of the three rules it carries.
+    //
+    // `**/test/**` is the repo's test glob (see the two blocks above);
+    // `**/*.test.ts` catches the one test file that does not live under one —
+    // `packages/core/src/model-generation.test.ts`.
+    //
+    // If this ever needs to get cheaper, narrow `files` before dropping a rule:
+    // the cost is the type program, not the rule count.
+    files: ["apps/api/src/**/*.ts", "packages/*/src/**/*.ts"],
+    ignores: ["**/test/**", "**/*.test.ts"],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      "@typescript-eslint/no-floating-promises": "error",
+      "@typescript-eslint/no-misused-promises": "error",
+      "@typescript-eslint/await-thenable": "error",
     },
   },
   eslintConfigPrettier,

--- a/packages/afps-runtime/src/sinks/stdout-bridge.ts
+++ b/packages/afps-runtime/src/sinks/stdout-bridge.ts
@@ -205,7 +205,9 @@ export function attachStdoutBridge(opts: StdoutBridgeOptions): StdoutBridgeHandl
     const event: RunEvent = { ...(parsed as RunEvent), runId: opts.runId };
     const promise: Promise<void> = sink.handle(event).catch(() => {});
     pendingDispatches.add(promise);
-    promise.finally(() => pendingDispatches.delete(promise));
+    // `void`: the promise already carries its own `.catch` above, so this
+    // chain exists only to un-register the dispatch once it settles.
+    void promise.finally(() => pendingDispatches.delete(promise));
     return true;
   }
 

--- a/packages/core/src/mcp-server-bundle/bun-probe.ts
+++ b/packages/core/src/mcp-server-bundle/bun-probe.ts
@@ -147,8 +147,13 @@ async function runProbe(
 
   const writeLine = (obj: unknown): void => {
     try {
-      proc.stdin.write(JSON.stringify(obj) + "\n");
-      proc.stdin.flush();
+      // `FileSink.write`/`flush` return `number | Promise<number>`: a write the
+      // pipe cannot take yet settles LATER, so a broken pipe reported that way
+      // never reaches the sync `catch` below — it would surface as an unhandled
+      // rejection instead of the ignored failure this block intends. Handle
+      // both paths identically; the stdout-scan/exit path is what reports it.
+      void Promise.resolve(proc.stdin.write(JSON.stringify(obj) + "\n")).catch(() => {});
+      void Promise.resolve(proc.stdin.flush()).catch(() => {});
     } catch {
       // Broken pipe — the stdout-scan/exit path surfaces the failure.
     }

--- a/packages/core/src/storage-fs.ts
+++ b/packages/core/src/storage-fs.ts
@@ -274,7 +274,13 @@ export function createFileSystemStorage(config: FileSystemStorageConfig): Storag
         for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
-          writer.write(value);
+          // AWAITED: `FileSink.write` returns `number | Promise<number>` and
+          // returns the promise exactly when the sink has to drain — which is
+          // what the `highWaterMark` above is for. Not awaiting it dropped the
+          // backpressure this path exists to get, and sent a mid-write failure
+          // out as an unhandled rejection instead of into the catch below that
+          // closes the sink and rolls the destination back.
+          await writer.write(value);
         }
         await writer.end();
       } catch (err) {

--- a/runtime-pi/runners/binary/Dockerfile
+++ b/runtime-pi/runners/binary/Dockerfile
@@ -7,7 +7,7 @@
 # self-contained executable; the runner just provides libc + TLS
 # trust and runs it.
 
-ARG RUNTIME_IMAGE=alpine:3.21.3
+ARG RUNTIME_IMAGE=alpine:3.22.4
 FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG BUILD_VERSION=unknown

--- a/runtime-pi/runners/node/Dockerfile
+++ b/runtime-pi/runners/node/Dockerfile
@@ -22,7 +22,7 @@
 #     -f runtime-pi/runners/node/Dockerfile \
 #     runtime-pi/runners/node
 
-ARG RUNTIME_IMAGE=alpine:3.21.3
+ARG RUNTIME_IMAGE=alpine:3.22.4
 FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG BUILD_VERSION=unknown

--- a/runtime-pi/runners/python/Dockerfile
+++ b/runtime-pi/runners/python/Dockerfile
@@ -12,7 +12,7 @@
 # extensions this works regardless of build host OS/arch — pure-wheel
 # packages are platform-independent.
 
-ARG RUNTIME_IMAGE=alpine:3.21.3
+ARG RUNTIME_IMAGE=alpine:3.22.4
 FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG BUILD_VERSION=unknown

--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -18,7 +18,7 @@
 # Paths below are relative to the repo root.
 
 ARG BUN_IMAGE=oven/bun:1.3.14-alpine
-ARG RUNTIME_IMAGE=alpine:3.21.3
+ARG RUNTIME_IMAGE=alpine:3.22.4
 
 # ── Stage 1 — compile to a single-file binary ─────────────────────
 FROM ${BUN_IMAGE} AS builder

--- a/scripts/test/lint.test.ts
+++ b/scripts/test/lint.test.ts
@@ -250,8 +250,11 @@ describe("scripts/lint.ts as a process", () => {
     expect(output).toMatch(/no longer errors|too many warnings/);
     // Cold cache, whole repo — and a timeout here does not just fail THIS
     // test: `runGateWith`'s restore never runs, so the next case finds a
-    // config whose anchor this mutation already consumed.
-  }, 120_000);
+    // config whose anchor this mutation already consumed. Which is why this
+    // ceiling moves with the one below even though this case has not tripped
+    // it: they pay the same cold whole-repo lint, and this one failing leaves
+    // a MUTATED config behind.
+  }, 300_000);
 
   it("fails on a warning that fires, however few", () => {
     // The narrowest case for `--max-warnings 0`: the config keeps its full
@@ -277,5 +280,23 @@ describe("scripts/lint.ts as a process", () => {
     expect(output).toMatch(/warning|max-warnings/i);
     // Measured 2026-08-26: 20.8 s, against bunfig's 15 s default. The other
     // subprocess cases here fail before eslint is spawned and take ~1 s.
-  }, 120_000);
+    //
+    // Re-measured 2026-09-08, after backend type-aware rules and jsx-a11y
+    // landed. What this case costs depends entirely on whether `.eslintcache`
+    // is warm, and the two environments differ:
+    //
+    //   locally, warm cache      2.8 s
+    //   cold whole-repo lint      56 s
+    //   CI (`Unit tests`)      >120 s  → timed out, run 34213836495
+    //
+    // The mutation appends a block scoped to `files: ["scripts/lint.ts"]`, so
+    // every OTHER file's EFFECTIVE config is unchanged and stays a cache hit —
+    // which is why a developer sees seconds and never reproduces the CI
+    // failure. `.github/workflows/test.yml` restores no eslint cache (only
+    // `check.yml` does), so CI pays the cold number every time.
+    //
+    // 300 s rather than "a bit more": this ceiling exists to catch a HANG, not
+    // to bound a known cost, and the cost is inherent — `--max-warnings 0`
+    // cannot trip until every file has been linted.
+  }, 300_000);
 });

--- a/turbo.json
+++ b/turbo.json
@@ -238,40 +238,102 @@
     // one unavoidable copy — turbo reads JSON and cannot import it — so when
     // the extension list changes, change it in both places.
     //
-    // `apps/web/tsconfig.json` is listed because eslint READS it on every run
-    // and no glob above reaches a `.json`: the `no-unnecessary-type-assertion`
-    // block scopes itself to `apps/web/src/**` with `parserOptions.projectService`,
-    // and projectService resolves the nearest tsconfig for those files — that
-    // one, which sets `target`, `lib`, `jsx` and `paths`. Without this entry a
-    // PR editing it left this task's hash unmoved, turbo replayed the cached
-    // logs, and the one type-AWARE rule in the config never re-derived a single
-    // verdict — and `.github/workflows/check.yml` keys the restored
+    // The tsconfigs are listed because eslint READS them on every run and no
+    // glob above reaches a `.json`: every `parserOptions.projectService` block
+    // in the config resolves the nearest tsconfig for the files it covers, and
+    // those tsconfigs set `target`, `lib`, `jsx`, `paths` and `allowJs`.
+    // Without an entry, a PR editing one left this task's hash unmoved, turbo
+    // replayed the cached logs, and the type-AWARE rules never re-derived a
+    // single verdict — and `.github/workflows/check.yml` keys the restored
     // `.turbo/cache` on `bun.lock, eslint.config.mjs, .prettierrc, turbo.json,
     // tsconfig.base.json`, so via `restore-keys` that stale replay survived
-    // across CI runs too. `//#verify:type-coverage` below already lists the same
-    // file in its own `inputs` for the same reason. `tsconfig.base.json`, which
-    // that tsconfig extends, and `bun.lock`, which decides which eslint plugin
-    // code runs, are both in `globalDependencies`.
-    // `apps/web/src/**/*.json` is the other half of the same
-    // `apps/web/tsconfig.json` story. That tsconfig sets `resolveJsonModule`,
-    // and 8 files under `apps/web/src` import `../../locales/<lng>/<ns>.json`,
-    // so those JSON files are MEMBERS of the type-aware program the
-    // `no-unnecessary-type-assertion` block runs over — while no glob above
-    // reaches a `.json`. Measured 2026-08-25: adding a key to
-    // `apps/web/src/locales/fr/agents.json` left this task's hash at
-    // `02fd25ac952d7956`, unmoved, so the one type-aware rule in the config
-    // replayed its cached verdict over a program whose contents had changed.
-    // Scoped to `apps/web/src` rather than `**/*.json` on purpose: a repo-wide
-    // JSON glob would put every `package.json`, every fixture and every
-    // generated artefact in the lint cache key.
+    // across CI runs too. `//#verify:type-coverage` below already lists
+    // `apps/web/tsconfig.json` in its own `inputs` for the same reason.
+    // `apps/*/src/**/*.json` is the other half of the same tsconfig story. The
+    // SPA's tsconfig sets `resolveJsonModule`, and 8 files under `apps/web/src`
+    // import `../../locales/<lng>/<ns>.json`, so those JSON files are MEMBERS
+    // of the type-aware program — while no glob above reaches a `.json`.
+    // Measured 2026-08-25: adding a key to `apps/web/src/locales/fr/agents.json`
+    // left this task's hash at `02fd25ac952d7956`, unmoved, so the one
+    // type-aware rule in the config replayed its cached verdict over a program
+    // whose contents had changed. Scoped to `apps/*/src` rather than
+    // `**/*.json` on purpose: a repo-wide JSON glob would put every
+    // `package.json`, every fixture and every generated artefact in the lint
+    // cache key. 27 files today (17 api, 10 web).
+    //
+    // ─── The backend type-aware block (eslint.config.mjs) ────────────────
+    //
+    // `apps/api/src/**` and `packages/*/src/**` now carry three type-aware
+    // rules (no-floating-promises, no-misused-promises, await-thenable), so
+    // their programs are read on every run too, and the four entries below were
+    // added for that. Each was PROVEN missing first — probe on 2026-09-08, on
+    // the config as it stood, `turbo run '//#lint' --dry=json`, base hash
+    // `ec64d50a6e1e20ab`, editing one file's CONTENT per row:
+    //
+    //   apps/api/tsconfig.json               ec64d50a6e1e20ab  UNMOVED
+    //   packages/core/tsconfig.json          ec64d50a6e1e20ab  UNMOVED
+    //   apps/api/src/data/featured-models.json  ec64d50a6e1e20ab  UNMOVED
+    //   packages/core/schema/agent.schema.json  72a27df96ec0efbb  moved
+    //
+    // The last row is the interesting one, and it is why `packages/*/schema`
+    // is listed anyway. It moved through `hashOfInternalDependencies`, not
+    // through any glob here: the ROOT `package.json` depends on
+    // `@appstrate/core` as `workspace:*`, and turbo hashes an internal
+    // dependency by its publishable file set — core's `"files"` is
+    // `["src", "schema", "LICENSE", "NOTICE"]`. That coverage is a
+    // coincidence of two unrelated fields, it holds for only the five
+    // packages the root happens to depend on, and `packages/core/tsconfig.json`
+    // (same package, not in `files`) sits one row above showing it does NOT
+    // generalise. Stated explicitly here instead of inherited.
+    //
+    // Same probe, same day, with the entries below in place — base hash
+    // `cf20f4ec31c085ad`, and every row moves, including the two that already
+    // worked:
+    //
+    //   apps/api/tsconfig.json                  77234cfc9d60ecfd
+    //   packages/core/tsconfig.json             e21f6d8ca13a85fa
+    //   apps/api/src/data/featured-models.json  369727613c425b9b
+    //   packages/core/schema/agent.schema.json  574544fed5958af4
+    //   apps/web/tsconfig.json                  bfac4ab8c5e96c95
+    //   apps/web/src/locales/fr/agents.json     204f82518306970f
+    //
+    // (restoring every file returned the hash to `cf20f4ec31c085ad`).
+    //
+    // `apps/web/tsconfig.json` widened to `apps/*/tsconfig.json` and
+    // `apps/web/src/**/*.json` to `apps/*/src/**/*.json` for the same reason
+    // the eslint `files` roster was widened to a superset: the next app to get
+    // a type-aware rule would otherwise get one real run and a cache hit
+    // forever. Three app tsconfigs, sixteen package tsconfigs, four schema
+    // JSONs today — all discovered by the glob, none listed.
+    //
+    // `tsconfig.base.json`, which every one of those extends, and `bun.lock`,
+    // which decides which eslint plugin and which `bun-types` run, are both in
+    // `globalDependencies`.
     "//#lint": {
       "inputs": [
         "**/*.{ts,tsx,js,jsx,mjs,cjs}",
         "!**/node_modules/**",
         "!**/dist/**",
         "package.json",
-        "apps/web/tsconfig.json",
-        "apps/web/src/**/*.json"
+        "apps/*/tsconfig.json",
+        "apps/*/src/**/*.json",
+        "packages/*/tsconfig.json",
+        "packages/*/schema/**/*.json",
+        // The workspace manifests, for the same reason the tsconfigs above are
+        // here: `exports`, `types` and `typesVersions` decide which `.d.ts` a
+        // cross-workspace import resolves to, so editing one CAN change a
+        // type-aware verdict while moving no `.ts` file. Unlike the four
+        // entries above this was NOT reached through a measured false green —
+        // it is a hole nobody probed, listed because an over-broad input costs
+        // one extra invalidation and an under-broad one is a silent pass. The
+        // same manifests are already inputs to `//#verify:type-coverage` below,
+        // which measures the same programs.
+        //
+        // Probed 2026-09-08 with these two lines in place, appending a newline
+        // to `packages/core/package.json` (content, not `touch`):
+        //   base b5ff99806eeedafa → after c28441226f51236b → restored b5ff99806eeedafa
+        "apps/*/package.json",
+        "packages/*/package.json"
       ]
     },
     // No `inputs` on purpose. The root `format:check` script is now a bare


### PR DESCRIPTION
## What

The three highest-value items from #1281, extracted onto a small branch so they can land on their own. #1281 stays open for the rest.

Four commits, **+356 / −53** across 21 files. No new gate script, no baseline, no new devDependency, no change to the shape of `bun run check` (still 38 turbo tasks).

## 1. Type-aware linting on the backend — and the four bugs it found

`projectService` was on in exactly one place: a single block over `apps/web/src/**` running one rule. The Hono/BullMQ/Docker/SSE backend had no type-aware linting at all, and `bun test` cannot substitute — bun executes tests without typechecking them.

`no-floating-promises`, `no-misused-promises` and `await-thenable` now run over `apps/api/src/**` and `packages/*/src/**`. The second half of that scope is not decoration: it is where two of the four bugs were, in code that is **published to npm**.

- **`process-orchestrator.ts`** — `findAvailablePort` did not await `Server.stop()`, which settles when the socket is actually released. It returned a port still bound: the EADDRINUSE-at-sidecar-boot the function's own comment says it exists to prevent.
- **`storage-fs.ts`** (`@appstrate/core`) — `FileSink.write()` un-awaited in the streaming upload loop. `FileSink.write` returns a promise exactly when the sink must drain, so the `highWaterMark` backpressure the surrounding comment is entirely about was never applied — and a mid-write failure surfaced as an unhandled rejection instead of entering the catch that closes the sink and rolls the destination back.
- **`bun-probe.ts`** (`@appstrate/core`) — async pipe writes guarded by a sync `try`, so a broken pipe reported asynchronously became an unhandled rejection rather than the ignored failure the block intends.
- **`local-queue.ts`** — `run().finally(...)` with no terminal catch, so a throw from the caller-supplied `backoffStrategy` escaped as an unhandled rejection.

The other findings were genuine fire-and-forget sites and got `void` plus a one-line reason each. One `eslint-disable`, in `lib/modules/registry.ts`: core declares `getSendMail: () => Promise<(to, subject, html) => void>`, so no module can await mail delivery. Reconciling that is a published-core contract change needing a major and consumer lockstep — #1280.

**Scope decisions, argued rather than defaulted.** Test trees are excluded, and not to save time: `await-thenable` is unsound over `bun:test`, whose `rejects` matchers are declared as returning `void` while at runtime the assertion must be awaited. All 75 hits there were correct `await`s the rule would have had us delete.

**Cost**, measured paired — one baseline-config cold run and one new-config cold run back to back, same machine:

```
pair 1   28.7 s  ->  69.2 s
pair 2   25.4 s  ->  59.0 s
```

So ~2.3x cold, +30 to +40 s. Warm is unchanged at ~2 s, which is the pre-push path; cold is CI, whose `check` job budget is 10 minutes and which this branch measures at 1 m 19 s end to end.

The turbo `//#lint` inputs were widened with a probe rather than a guess. Before it, editing `apps/api/tsconfig.json`, `packages/core/tsconfig.json` or `apps/api/src/data/featured-models.json` moved **no** hash — so the type-aware program could have replayed a cached verdict over a changed program, which is the exact incident class `turbo.json` already documents three times. Both the negative and positive controls are recorded in the file.

## 2. Sizing the unit job for the cost above

The type-aware rules make one existing test blow its ceiling: `scripts/test/lint.test.ts` runs `scripts/lint.ts` as a subprocess after mutating `eslint.config.mjs`, and `--max-warnings 0` cannot trip until every file has been linted. Measured on a runner: `123734.27ms` against a 120 s ceiling, cancelled — which also pushed the whole `Unit tests` job past its 5-minute `timeout-minutes` while every other job in the same run succeeded.

The reason nobody reproduces it locally is recorded in both files: the mutation is scoped to `files: ["scripts/lint.ts"]`, so every other file's *effective* config is unchanged and stays a cache hit. **2.8 s warm, 68–81 s with `.eslintcache` deleted.** `test.yml` restores no eslint cache — only `check.yml` does — so CI pays the cold number every run.

Ceilings raised to match, both as hang detectors rather than targets: the two whole-repo cases go to 300 s, the job to 10 minutes against a ~257 s suite.

## 3. alpine 3.22.4 on the four stale base images

`runtime-pi/runners/{node,python,binary}` and `runtime-pi/sidecar` still pinned `alpine:3.21.3`, which ships `libcrypto3`/`libssl3` `3.3.3-r0` — inside **CVE-2026-31789**, CRITICAL, fix available. Every other image in the release matrix had already moved to 3.22.4.

Measured before bumping, because the obvious worry is that an alpine minor moves the language runtimes those images `apk add` — it does not: both tags ship **node v22.23.2** and **Python 3.12.14**, byte-identical. Verified after by building all four for `linux/amd64`: `libcrypto3 3.5.6-r0` in the runners, `3.5.8-r0` in the sidecar, runtimes unchanged.

`Dockerfile.rootfs` is left alone — it floats on the `alpine:3.21` tag rather than pinning a patch release, and has a separate build lifecycle.

## 4. Documenting the required checks

`CONTRIBUTING.md` told contributors to "wait for CI checks", which is not a rule today: the `Protect main` ruleset (14614228) carries only `pull_request` and `non_fast_forward`, declares no `required_status_checks`, and `branches/main/protection` 404s. **Every gate in this repository is mergeable red.**

The doc now records the set that should gate a merge, with check-run names verbatim and the `gh api` command that applies them. Applying it is a repository-settings change and is deliberately not part of this PR.

The exclusions are the load-bearing half: `Integration tests`, `Runtime container e2e` and `E2E tests` are label-gated and so do not report on an unlabelled PR, and `Scorecard Analysis` has no `pull_request` trigger — a required check that never reports blocks every PR forever. Note this list deliberately does **not** name `Dependency Audit`, which is part of #1281 and does not exist on `main`.

## Verification

- `bun run check` — 38/38 green, 1 m 19 s cold.
- `bun test apps/api/test/unit/` — 1796 tests, 0 fail.
- `bun test packages/core/test packages/afps-runtime/test` — 1834 tests, 0 fail.
- `bun test scripts/test/lint.test.ts` with `.eslintcache` deleted — 11 pass, 68 s, i.e. inside the new ceiling with room.
- The lint gate goes red on a seeded violation of each of the three rules and green on the clean tree.
