### PR TITLE
fix(mcp): resolve the insufficient-scope marker from a single better-auth instance

### DIFF
--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -36,7 +36,22 @@ import type { Context } from "hono";
 import { z } from "zod";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { createResourceServerChallenge } from "@better-auth/oauth-provider";
-import { createInsufficientScopeError } from "@better-auth/core/oauth2";
+// `createInsufficientScopeError` marks the error it returns in a module-level
+// WeakSet, and `createResourceServerChallenge` recognises it by asking
+// `isInsufficientScopeError` — which it imports from `better-auth/oauth2`. The
+// two must therefore come from the SAME `@better-auth/core` instance, or the
+// marker lookup misses and the challenge is silently dropped (a 403 with no
+// `WWW-Authenticate`, so no OAuth step-up for the client).
+//
+// `@better-auth/core` carries real peers (`jose`, `better-call`, `kysely`, …),
+// so a peer skew — `apps/api` on one `jose` range, better-auth's transitive
+// `jose` pinned to another — makes the package manager materialise two peer
+// instances of the same version, and which one `better-auth` links to is
+// install-order dependent. Importing through the `better-auth/*` façade (as
+// `APIError` below already does) pins us to the instance the provider itself
+// uses, whatever the peer graph looks like. Never reach for
+// `@better-auth/core/oauth2` here.
+import { createInsufficientScopeError } from "better-auth/oauth2";
 import { APIError } from "better-auth/api";
 import { createMcpServer } from "@appstrate/mcp-transport";
 import { OPERATION_INDEX_HEADING } from "@appstrate/core/chat-contract";


### PR DESCRIPTION
Fixes the red `Integration tests` job on `main` (run [34325514357](https://github.com/appstrate/appstrate/actions/runs/34325514357), commit `4f1d59d1f`).

## Symptom

`apps/api/src/modules/mcp/test/integration/mcp.test.ts:181` — *"403s an authenticated caller lacking `mcp:read` with an `insufficient_scope` step-up challenge"*. The status is right; the `WWW-Authenticate` header is missing entirely.

## Root cause

`createResourceServerChallenge` (`@better-auth/oauth-provider`) recognises an insufficient-scope error by calling `isInsufficientScopeError`, which it imports from `better-auth/oauth2`. The marker is a **module-level WeakSet** (`@better-auth/core/dist/oauth2/verify.mjs`), so the error has to be minted by the *same* `@better-auth/core` instance. This router minted it through `@better-auth/core/oauth2`.

`@better-auth/core` carries real peer dependencies (`jose`, `better-call`, `kysely`, `nanostores`, …). #1289 moved `apps/api` from `jose ^6.2.7` to `^6.2.12` while better-auth's own transitive `jose` stayed pinned at `6.2.7`, so the package manager materialised **two peer instances of `@better-auth/core@1.7.3`**, differing only in their `jose` link:

| instance | `jose` | resolved by |
| --- | --- | --- |
| `@better-auth+core@1.7.3+0ac899…` | 6.2.12 | `apps/api` |
| `@better-auth+core@1.7.3+53b163…` | 6.2.7 | `better-auth` |

The WeakSet lookup then misses, `createResourceServerChallenge` returns `undefined`, and the responder attaches nothing — 403s carry no generic fallback by design (`apps/api/src/lib/auth-challenges.ts`).

**Impact is not test-only:** an MCP client (Claude Code) that hits a 403 no longer receives the `insufficient_scope` challenge, so it has nothing to step its authorization up from.

### Why the same lockfile was green on the dependabot branch and red on main

Which of the two instances `better-auth` links to is **install-order dependent**. Verified locally on the identical tree:

- `rm -rf node_modules && bun install --frozen-lockfile` (the CI path) → `better-auth` links `+53b163…` → **red**
- `bun install --force` over a warm tree → `better-auth` links `+0ac899…` → **green**

So this was an armed bomb, not a runner flake.

## Fix

Import `createInsufficientScopeError` from `better-auth/oauth2` instead of `@better-auth/core/oauth2`. Both `better-auth` copies present in the tree resolve to the same instance the provider uses, and the file already imports `APIError` through that same façade — which is exactly why the 401 branch (`isAPIError`) kept working while the 403 branch broke. The rationale is recorded at the import so the specifier is not "simplified" back to the core subpath.

An alternative — deduplicating `jose` through root `overrides` — was tried and **rejected**: it does not collapse the two instances (the lockfile keeps `6.2.7` for better-auth's transitive dependency), and it would leave the invariant unguarded.

## Verification

Red-then-green on the exact CI install path (`rm -rf node_modules` + `bun install --frozen-lockfile`):

- before: 19 pass / 1 fail
- after: 20 pass / 0 fail
- `apps/api/src/modules/mcp/**` + `auth-challenges` unit test: 133 pass / 0 fail
- `tsc --noEmit`, eslint, prettier: clean

Labelled `integration` so the job that caught this runs on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)