### PR TITLE
fix(connect): surface the missing-OAuth-client refusal on the hosted portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -538,6 +538,22 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
 
 ### Fixed
 
+- **The hosted connect portal names the missing OAuth client instead of a
+  generic "please try again" 502 (#1263).** Opening a `connect_url` for an
+  oauth2 auth in a space with no registered client — and no system client or
+  auto-provisioning to fall back to — rendered "Could not start the connection.
+  Please try again." with a 502, although the condition is a configuration gap
+  that no retry can clear. The programmatic `POST …/connect/oauth2` already
+  answered the same case with a 403 naming the action ("Administrator must
+  register OAuth client credentials…"); the catch around the hosted dispatch
+  swallowed that error, and the auto-provisioning failure written to be shown
+  verbatim with it. A client-side (4xx) refusal from the OAuth strategy now
+  reaches the popup with its own status and detail, and the single-use link is
+  handed back rather than burned — nothing was minted on its strength — so a
+  retry once the client is registered works from the very same link instead of
+  the previous second misleading "This connect link has already been used."
+  Transient and unknown failures keep the generic wording, the 502 and the burn.
+
 - **Deleting an organization reserves the deletion before any module tears
   anything down (migration `0058`).** `DELETE /api/orgs/:orgId` checked
   deletability without a lock, emitted `onOrgDelete` — where modules cancel a

--- a/apps/api/src/openapi/paths/integrations.ts
+++ b/apps/api/src/openapi/paths/integrations.ts
@@ -993,13 +993,21 @@ export const integrationsPaths = {
         // returns c.html(popupHtmlError(...), 400|410)), so each condition now
         // maps to exactly one status.
         "302": { description: "Redirect to the provider OAuth screen or the hosted form." },
-        "400": { description: "Missing token (HTML error page)." },
+        "400": {
+          description:
+            "Missing token, or the oauth2 auth declares neither an issuer nor explicit endpoints (HTML error page). The link stays reusable.",
+        },
+        "403": {
+          description:
+            "The space has no OAuth client registered for this auth and none could be auto-provisioned; the page names the action to take (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint.",
+        },
         "410": { description: "Invalid, expired, or already-used token (HTML error page)." },
         "500": {
           description: "Integration cannot be connected / unexpected failure (HTML error page).",
         },
         "502": {
-          description: "Upstream provider failed to start the connection (HTML error page).",
+          description:
+            "Upstream provider failed to start the connection — transient (HTML error page). The link is burned; re-mint to retry.",
         },
       },
     },

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -40,6 +40,7 @@
  */
 
 import { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
 import { z } from "zod";
 import {
   handleIntegrationOAuthCallback,
@@ -108,6 +109,7 @@ import {
   buildConnectUrl,
   readConnectToken,
   consumeJti,
+  releaseJti,
   setConnectPageCookie,
   readConnectPageCookie,
   clearConnectPageCookie,
@@ -920,13 +922,25 @@ export function createIntegrationsRouter() {
       if (!strategy.begin) {
         return c.html(popupHtmlError("This integration cannot be connected.", {}), 500);
       }
-      // `begin` can throw on a transient/structural fault (OAuth client removed
-      // between mint and click, provider discovery error, network). Without this
-      // guard the throw escapes to the global error handler, which renders raw
-      // `application/problem+json` inside the popup instead of the friendly
-      // popupHtmlError page every other failure path here returns. The jti is
-      // already burned, so the user re-mints (one click) — surface a readable
-      // error rather than a JSON blob.
+      // `begin` throws for two different reasons, and the popup must tell them
+      // apart (issue #1263). Without a guard at all the throw escapes to the
+      // global error handler, which renders raw `application/problem+json`
+      // inside the popup instead of the friendly popupHtmlError page every
+      // other failure path here returns.
+      //
+      //  1. A client-side `ApiError` (4xx): the space has no OAuth client for
+      //     this auth, auto-DCR against the provider was refused, the manifest
+      //     declares no issuer/endpoints. Permanent until someone acts, and the
+      //     `detail` names that action — the same message the programmatic
+      //     `POST …/connect/oauth2` already returns as its 403. Render it with
+      //     its own status, and hand the jti back: nothing was minted on the
+      //     strength of this click, so a retry once the admin has registered
+      //     the client can reuse the very same link instead of re-minting.
+      //  2. Anything else (provider discovery error, network, an unexpected
+      //     throw): transient or unknown. Keep the generic wording, keep the
+      //     502, keep the jti burned — an unknown failure may have gone half
+      //     way (a state row minted), and the burn is what stops a replay from
+      //     re-entering that flow. The user re-mints (one click).
       let result: Awaited<ReturnType<NonNullable<typeof strategy.begin>>>;
       try {
         result = await strategy.begin(
@@ -940,6 +954,19 @@ export function createIntegrationsRouter() {
           { scopes, forceAccountSelect: claims.force_account_select ?? false },
         );
       } catch (err) {
+        if (err instanceof ApiError && err.status >= 400 && err.status < 500) {
+          logger.warn("Hosted connect OAuth begin refused", {
+            status: err.status,
+            code: err.code,
+            detail: err.message,
+            packageId: claims.package_id,
+            authKey: claims.auth_key,
+          });
+          await releaseJti(claims.jti);
+          // `err.message` is the problem `detail` — the public half of an
+          // ApiError by contract (never `cause`), and popupHtmlError escapes it.
+          return c.html(popupHtmlError(err.message, {}), err.status as ContentfulStatusCode);
+        }
         logger.error("Hosted connect OAuth begin failed", {
           err: String(err),
           packageId: claims.package_id,

--- a/apps/api/src/services/connect/connect-session.ts
+++ b/apps/api/src/services/connect/connect-session.ts
@@ -96,6 +96,30 @@ export async function consumeJti(jti: string, expSeconds: number): Promise<boole
 }
 
 /**
+ * Hand a consumed `jti` back so the same link can be clicked again.
+ *
+ * Only for a click that was consumed and then failed BEFORE anything was
+ * granted or minted on the strength of it — the missing-OAuth-client case of
+ * issue #1263, where the user has to wait for an admin and then retry. The
+ * failed click is then indistinguishable from no click at all, so the replay
+ * guard has nothing to protect; the token's own `exp` keeps bounding reuse.
+ * Never call this after a partial success (a state row or provider redirect
+ * issued): the burn is what stops a replay from re-entering that flow.
+ *
+ * Best-effort: a cache fault here must not mask the error being rendered, so
+ * it is swallowed — the worst case is the pre-#1263 behaviour (link burned,
+ * one re-mint).
+ */
+export async function releaseJti(jti: string): Promise<void> {
+  try {
+    const cache = await getCache();
+    await cache.del(JTI_PREFIX + jti);
+  } catch {
+    // Degrades to a burned link — the caller's error page stays actionable.
+  }
+}
+
+/**
  * After the capability token is consumed, mint a fresh page-cookie token
  * (new jti, CSRF nonce, same context) and set it as an httpOnly, SameSite=Strict
  * cookie scoped to the hosted connect path. Returns the CSRF nonce for the page

--- a/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
+++ b/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
@@ -276,3 +276,148 @@ describe("hosted connect portal — dispatch + submit", () => {
     expect(all).toHaveLength(1);
   });
 });
+
+/**
+ * Classic (confidential) oauth2 auth — needs a pre-registered client per
+ * space. Same shape as the `google` auth in `integrations.test.ts`.
+ */
+function oauthManifest(name = "@myorg/gsuite"): IntegrationManifest {
+  return {
+    type: "integration",
+    schema_version: "0.1",
+    name,
+    version: "0.1.0",
+    display_name: "Google Workspace",
+    description: "Google Workspace integration",
+    icon: "logos:google",
+    source: { kind: "local", server: { name, version: "^0.1.0" } },
+    auths: {
+      google: {
+        type: "oauth2",
+        authorization_endpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+        token_endpoint: "https://oauth2.googleapis.com/token",
+        default_scopes: ["openid", "email"],
+        authorized_uris: ["https://www.googleapis.com/**"],
+        delivery: {
+          http: {
+            in: "header",
+            name: "Authorization",
+            prefix: "Bearer ",
+            value: "{$credential.access_token}",
+          },
+        },
+      },
+    },
+  } as unknown as IntegrationManifest;
+}
+
+/**
+ * Remote MCP oauth2 auth with no pre-registered client (auto-DCR path). The
+ * `.invalid` TLD (RFC 6761) makes discovery fail fast, so provisioning fails
+ * without a live authorization server — same fixture as `integrations.test.ts`.
+ */
+function remoteMcpManifest(name = "@myorg/remote-mcp"): IntegrationManifest {
+  return {
+    type: "integration",
+    schema_version: "0.1",
+    name,
+    version: "1.0.0",
+    display_name: "Remote MCP",
+    description: "Remote MCP integration with MCP-spec auto-DCR",
+    source: {
+      kind: "remote",
+      remote: { url: "https://mcp.invalid/mcp", transport: "streamable-http" },
+    },
+    auths: {
+      oauth: {
+        type: "oauth2",
+        issuer: "https://mcp.invalid",
+        token_endpoint_auth_method: "none",
+        default_scopes: ["read", "write"],
+        authorized_uris: ["https://mcp.invalid/**"],
+        delivery: {
+          http: {
+            in: "header",
+            name: "Authorization",
+            prefix: "Bearer ",
+            value: "{$credential.access_token}",
+          },
+        },
+        _meta: { "dev.appstrate/oauth": { scope_separator: " " } },
+      },
+    },
+  } as unknown as IntegrationManifest;
+}
+
+async function startConnect(token: string): Promise<Response> {
+  return app.request(`/api/integrations/connect/start?token=${encodeURIComponent(token)}`, {
+    redirect: "manual",
+  });
+}
+
+describe("hosted connect portal — oauth2 dispatch without a client (issue #1263)", () => {
+  let ctx: TestContext;
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "myorg" });
+    await seedIntegration(ctx.orgId, oauthManifest("@myorg/gsuite"));
+  });
+
+  it("renders the actionable 403 the programmatic path returns, not a generic 502", async () => {
+    const token = await mintSession(ctx, "@myorg/gsuite", "google");
+    const res = await startConnect(token);
+    // Parity with `POST …/connect/oauth2` on the same space: same status, same
+    // detail, naming the action to take.
+    expect(res.status).toBe(403);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("Administrator must register OAuth client credentials");
+    expect(html).toContain("@myorg/gsuite");
+    expect(html).not.toContain("Please try again");
+  });
+
+  it("keeps the link reusable: a second click is the same 403, not 'already used'", async () => {
+    const token = await mintSession(ctx, "@myorg/gsuite", "google");
+    expect((await startConnect(token)).status).toBe(403);
+    const again = await startConnect(token);
+    expect(again.status).toBe(403);
+    expect(await again.text()).not.toContain("already been used");
+  });
+
+  it("lets the same link succeed once an administrator registers a client", async () => {
+    const token = await mintSession(ctx, "@myorg/gsuite", "google");
+    expect((await startConnect(token)).status).toBe(403);
+
+    const registered = await app.request(
+      "/api/integrations/@myorg/gsuite/auths/google/oauth-clients",
+      {
+        method: "POST",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: "abc", client_secret: "shh" }),
+      },
+    );
+    expect(registered.status).toBe(201);
+
+    // The very same link now dispatches to the provider — no re-mint.
+    const res = await startConnect(token);
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.get("location")!);
+    expect(location.origin).toBe("https://accounts.google.com");
+    expect(location.searchParams.get("client_id")).toBe("abc");
+
+    // …and the successful click is the one that burns it.
+    expect((await startConnect(token)).status).toBe(410);
+  });
+
+  it("renders the auto-provisioning failure verbatim for a remote MCP auth", async () => {
+    await seedIntegration(ctx.orgId, remoteMcpManifest("@myorg/remote-mcp"));
+    const token = await mintSession(ctx, "@myorg/remote-mcp", "oauth");
+    const res = await startConnect(token);
+    expect(res.status).toBe(403);
+    const html = await res.text();
+    // The remedy authored by the provisioning step reaches the user — the
+    // message the generic catch used to swallow.
+    expect(html).toContain("Could not automatically provision an OAuth client");
+    expect(html).toContain("@myorg/remote-mcp");
+  });
+});

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -10970,8 +10970,15 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing token (HTML error page). */
+            /** @description Missing token, or the oauth2 auth declares neither an issuer nor explicit endpoints (HTML error page). The link stays reusable. */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The space has no OAuth client registered for this auth and none could be auto-provisioned; the page names the action to take (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint. */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -10991,7 +10998,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Upstream provider failed to start the connection (HTML error page). */
+            /** @description Upstream provider failed to start the connection — transient (HTML error page). The link is burned; re-mint to retry. */
             502: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/core/test/connect-handshake.test.ts
+++ b/packages/core/test/connect-handshake.test.ts
@@ -408,15 +408,19 @@ describe("completionMatches — the payloads the platform emits", () => {
   });
 
   it("delivers the context-less /connect/start errors to everyone", () => {
-    // integrations.ts:864/866/876/880/898/925 — popupHtmlError(msg, {}), emitted
+    // routes/integrations.ts `/connect/start` — popupHtmlError(msg, {}), emitted
     // before the token resolved a package or a state. This is the carve-out, and
     // it is the reason a surface with no context can still show an error at all.
+    // The last two are the OAuth `begin` refusals: the configuration detail an
+    // ApiError carries (#1263, rendered verbatim with its 4xx) and the generic
+    // 502 wording every other failure keeps.
     for (const msg of [
       "Missing connect token",
       "This connect link is invalid or expired.",
       "This integration is no longer available.",
       "This connect link has already been used.",
       "This integration cannot be connected.",
+      "Administrator must register OAuth client credentials for '@acme/gmail' auth 'primary' before connection",
       "Could not start the connection. Please try again.",
     ]) {
       const contextLess = detail({ ok: false, error: msg });


### PR DESCRIPTION
Closes #1263

## Problem

`GET /api/integrations/connect/start` wrapped `strategy.begin` in a catch that rendered **every** failure as "Could not start the connection. Please try again." with a 502. A space with no OAuth client registered for the auth — and no system client or auto-provisioning to fall back to — is a permanent configuration gap that no retry can clear. The programmatic `POST …/connect/oauth2` already answers the same case with a 403 naming the action (`Administrator must register OAuth client credentials for '…' auth '…' before connection`); the hosted dispatch swallowed that `ApiError`, and with it the auto-DCR failure message (`Could not automatically provision an OAuth client … (HTTP N): <reason>`) that was written to be rendered verbatim.

Because the single-use jti was consumed before `begin`, a second click on the same link then said "This connect link has already been used." — a second misleading message for the same root cause.

## Fix

- **`routes/integrations.ts` `/connect/start`** — the catch now distinguishes the two classes it used to merge:
  1. a client-side `ApiError` (4xx) from `begin` — missing client, refused auto-DCR, manifest without issuer/endpoints — is rendered with **its own status and detail** (`popupHtmlError` escapes it; `message` is the public problem `detail` by contract, never `cause`), and the jti is **handed back**;
  2. anything else (discovery error, network, unexpected throw) keeps the generic wording, the 502 and the burn.
- **`services/connect/connect-session.ts`** — new `releaseJti(jti)`: best-effort `cache.del`, swallowing a cache fault so it can never mask the error being rendered (worst case = pre-#1263 behaviour, one re-mint).
- **OpenAPI** declares the 403 and the widened 400 on `/connect/start`; `apps/web/src/api/schema.d.ts` regenerated.
- **CHANGELOG** `[Unreleased] › Fixed`.

### Why release rather than reorder `consumeJti` after `begin`

`begin` has side effects — DCR client registration and an `initiateIntegrationOAuth` state row per call. Consuming after it would let a replayed link mint unbounded state rows before the guard fires. Releasing only on the 4xx branch keeps the failed click equivalent to no click at all: nothing was minted on its strength, so the replay guard has nothing to protect; the token's own `exp` still bounds reuse. The 5xx/unknown branch keeps the burn deliberately — an unknown throw may have gone half way, and the burn is what stops a replay from re-entering that flow.

## Tests

Four new integration tests in `integrations-hosted-connect.test.ts` (all red without the route change — 502 instead of 403 — verified by reverting the route file alone):

- renders the actionable 403 the programmatic path returns, not a generic 502;
- a second click on the same link is the same 403, not "already used";
- the **same link succeeds** (302 to the provider, `client_id` echoed) once an administrator registers a client — and is burned only by that successful click (410 on the next);
- the auto-provisioning failure for a remote MCP auth reaches the user verbatim.

`packages/core/test/connect-handshake.test.ts` gains the config detail in the context-less-error matrix.

## Verification

- `bunx tsc --noEmit` (apps/api) ✅
- eslint + prettier on changed files ✅
- `bun run verify:openapi` — ALL CHECKS PASSED ✅
- `bun run detect:breaking` — 0 breaking ✅
- `bun test` hosted-connect + integrations suites (TEST_TIER=0): 79 pass ✅
- `bun test` core connect-handshake: 34 pass ✅
- full `bun run check` runs in the pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
