### PR TITLE
test(ee): live Stripe contract suite, and the drift it found

### DIFF
--- a/.github/workflows/stripe-live.yml
+++ b/.github/workflows/stripe-live.yml
@@ -1,0 +1,75 @@
+# Stripe live contract suite.
+#
+# The EE billing tests run against a hand-written mock. The mock proves what
+# the module SENDS; it cannot prove what Stripe RETURNS, because we wrote those
+# responses ourselves. This job closes that half: it runs
+# `packages/module-ee/test/live` against real Stripe in TEST MODE and fails
+# when a fixture claims a field the live API does not have, or when Stripe stops
+# behaving the way the module bets it does.
+#
+# Without `STRIPE_LIVE_SECRET_KEY` the suite skips itself and this job is green
+# — the same opt-in shape as `scripts/conformance/probes.ts`. That covers fork
+# PRs, which never receive secrets.
+name: Stripe live contract
+
+on:
+  # Weekly, so API drift surfaces on a schedule rather than on the unlucky PR
+  # that happens to bump the SDK.
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+  # Anything that touches the billing module or its Stripe dependency. A
+  # Dependabot bump of `stripe` edits packages/module-ee/package.json, so it
+  # lands here without anyone remembering to label it.
+  pull_request:
+    paths:
+      - "packages/module-ee/**"
+      - ".github/workflows/stripe-live.yml"
+
+concurrency:
+  # One at a time: the suite creates and tears down a customer + subscription in
+  # a shared test account, and two runs interleaving there is a false red.
+  group: stripe-live
+  cancel-in-progress: false
+
+jobs:
+  live:
+    name: Stripe live contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: ./.github/actions/bun-setup
+
+      - name: Cache Bun download cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install
+
+      # `packages/module-ee` declares `postgres: true`, so under TEST_TIER=0 the
+      # harness skips the module and collects none of its tests — including this
+      # suite. The infra is up purely so the suite is allowed to run; it touches
+      # no table.
+      - name: Start test infrastructure
+        run: docker compose -f test/setup/docker-compose.test.yml up -d --wait
+
+      - name: Report coverage state
+        run: |
+          if [ -z "${STRIPE_LIVE_SECRET_KEY}" ]; then
+            echo "::notice::STRIPE_LIVE_SECRET_KEY is not set — the live contract suite will skip itself."
+          fi
+        env:
+          STRIPE_LIVE_SECRET_KEY: ${{ secrets.STRIPE_LIVE_SECRET_KEY }}
+
+      - name: Run Stripe live contract suite
+        run: bun test packages/module-ee/test/live
+        env:
+          STRIPE_LIVE_SECRET_KEY: ${{ secrets.STRIPE_LIVE_SECRET_KEY }}

--- a/packages/module-ee/README.md
+++ b/packages/module-ee/README.md
@@ -587,3 +587,53 @@ the platform's member lookups. Both are plain setters, not mocks. Every
 integration test file calls `useEeTestSeams()` at the top; it is idempotent.
 `test/tables.ts` lists the seven `ee_*` tables, so the root `truncateAll()`
 clears them between tests along with every platform table.
+
+### The Stripe mock, and what it cannot prove
+
+Everything above runs against a hand-written Stripe in `test/helpers/stripe.ts`
+— a `Bun.serve` on port 0 that records every request and answers from fixtures.
+It is the right tool for what the module _sends_: the request bodies are
+asserted (see the plan-change case in
+`test/integration/routes/billing.test.ts`, which pins `items[0][id]` because
+sending the price alone would ADD a second priced item instead of replacing the
+first — a double charge on every plan change).
+
+It cannot prove anything about what Stripe _returns_, or how Stripe _interprets_
+what we sent, because we wrote those answers. The failure mode is not
+theoretical: Stripe moved the billing-cycle end onto the subscription ITEM in
+the 2025-03-31 API version, the fixture kept it at the top level, and
+`subscriptionPeriodEnd` (`src/stripe/webhooks.ts`) — which reads the item — was
+therefore returning `null` in every test that touched it. The confirmation
+e-mail silently fell back to today's date, and no test noticed, because the
+fixture and the assertions were written from the same stale belief.
+
+`test/live/stripe-contract.test.ts` is the other half. It runs against real
+Stripe in **test mode** and checks the two things the mock structurally cannot:
+
+- **Shape** — every key path a fixture claims must exist on the live object.
+  Extra live fields are ignored (the fixtures are deliberately minimal); invented
+  ones fail. This is what turns the next relocation into a red mock rather than a
+  quiet production lie.
+- **Semantics** — that `subscriptions.update` replaces the priced item, that
+  `current_period_end` is a timestamp on the item, that a forged webhook
+  signature raises `StripeSignatureVerificationError` and an unknown id raises
+  `StripeInvalidRequestError` (both classes are branched on in `src/routes/`).
+
+It creates a customer and a subscription and deletes them in `afterAll`, so it
+needs a key that may mutate the account:
+
+```sh
+STRIPE_LIVE_SECRET_KEY=sk_test_… bun test packages/module-ee/test/live
+```
+
+Without that variable the suite skips itself and stays silent — the same opt-in
+shape as `scripts/conformance/probes.ts`. It is deliberately **not**
+`STRIPE_SECRET_KEY`: a developer `.env` holding a working key must never make
+`bun test` start creating objects in an account nobody aimed at. A key that does
+not begin with `sk_test_` is refused outright rather than skipped.
+
+In CI it is `.github/workflows/stripe-live.yml` — weekly, on demand, and on any
+PR touching `packages/module-ee/**` (which includes a Dependabot bump of the
+`stripe` dependency). The repository secret is `STRIPE_LIVE_SECRET_KEY`; until it
+is provisioned the job runs green with the suite skipped, and says so in an
+annotation.

--- a/packages/module-ee/test/helpers/stripe.ts
+++ b/packages/module-ee/test/helpers/stripe.ts
@@ -83,7 +83,7 @@ async function parseBody(req: Request): Promise<Record<string, unknown> | null> 
 
 let customerCounter = 0;
 
-function defaultCustomerResponse(): Record<string, unknown> {
+export function defaultCustomerResponse(): Record<string, unknown> {
   customerCounter++;
   return {
     id: `cus_test_${customerCounter.toString().padStart(3, "0")}`,
@@ -92,7 +92,7 @@ function defaultCustomerResponse(): Record<string, unknown> {
   };
 }
 
-function defaultCheckoutResponse(): Record<string, unknown> {
+export function defaultCheckoutResponse(): Record<string, unknown> {
   return {
     id: `cs_test_${Date.now()}`,
     url: "https://checkout.stripe.com/test",
@@ -100,7 +100,7 @@ function defaultCheckoutResponse(): Record<string, unknown> {
   };
 }
 
-function defaultPortalResponse(): Record<string, unknown> {
+export function defaultPortalResponse(): Record<string, unknown> {
   return {
     id: `bps_test_${Date.now()}`,
     url: "https://billing.stripe.com/test",
@@ -108,7 +108,7 @@ function defaultPortalResponse(): Record<string, unknown> {
   };
 }
 
-function defaultSubscriptionResponse(id: string): Record<string, unknown> {
+export function defaultSubscriptionResponse(id: string): Record<string, unknown> {
   return {
     id,
     object: "subscription",
@@ -119,10 +119,20 @@ function defaultSubscriptionResponse(id: string): Record<string, unknown> {
         {
           id: "si_test_001",
           price: { id: "price_starter_test", product: "prod_test" },
+          // On the ITEM, not the subscription: Stripe moved the billing cycle
+          // end here in the 2025-03-31 API version, and the top-level field is
+          // gone from the live response. `subscriptionPeriodEnd` (src/stripe/
+          // webhooks.ts) reads this path; while the fixture kept the old
+          // placement that read returned `undefined` in every test and the
+          // confirmation email silently fell back to today's date.
+          current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
         },
       ],
     },
-    current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60,
+    // Always an object on the live API, empty when unset. Production calls
+    // `parseStripeMetadata` on it during budget allocation, so the path has to
+    // be here even when the values are not.
+    metadata: {},
     cancel_at_period_end: false,
     customer: "cus_test_001",
   };

--- a/packages/module-ee/test/live/stripe-contract.test.ts
+++ b/packages/module-ee/test/live/stripe-contract.test.ts
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: LicenseRef-Appstrate-Commercial
+
+/**
+ * Stripe contract suite — LIVE, opt-in.
+ *
+ * The EE billing suite talks to a hand-written mock (`packages/module-ee/
+ * test/helpers/stripe.ts`). That mock proves what the module SENDS: every
+ * request is recorded and asserted. It cannot prove what Stripe RETURNS, or
+ * what Stripe does with what we sent — those responses are fixtures we wrote,
+ * so they agree with us by construction and keep agreeing after Stripe has
+ * moved on.
+ *
+ * They have already drifted once. Stripe relocated the billing-cycle end into
+ * the subscription ITEM in the 2025-03-31 API version; the mock kept returning
+ * it at the top level, where the real API no longer has it at all. Production
+ * reads the item (`subscriptionPeriodEnd`, module-ee/src/stripe/webhooks.ts),
+ * so against the mock that read is permanently `undefined` and the confirmation
+ * email silently falls back to today's date. Nothing failed. Nothing could:
+ * the fixture and the assertion were written from the same belief.
+ *
+ * This suite is the missing half. It hits real Stripe in TEST MODE and checks
+ * the two things a mock structurally cannot:
+ *
+ *   1. Shape — every key path the mock claims exists must exist on the live
+ *      object. Extra live fields are fine (the fixtures are deliberately
+ *      minimal); invented ones are not. This is the check that turns the next
+ *      drift into a red mock instead of a quiet production lie.
+ *   2. Semantics — the handful of behaviours the module bets on, above all
+ *      that `subscriptions.update` REPLACES the priced item instead of adding
+ *      one. A mock returns whatever we told it to; only Stripe can say whether
+ *      that call double-charges every customer who changes plan.
+ *
+ * Coverage is opt-in, following `scripts/conformance/probes.ts`: no
+ * `STRIPE_LIVE_SECRET_KEY`, no run, no noise. It is deliberately NOT
+ * `STRIPE_SECRET_KEY` — a developer `.env` holding a working key must never
+ * make `bun test` start creating objects in an account nobody aimed at.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from "bun:test";
+import Stripe from "stripe";
+import {
+  defaultCheckoutResponse,
+  defaultCustomerResponse,
+  defaultPortalResponse,
+  defaultSubscriptionResponse,
+} from "../helpers/stripe.ts";
+
+const SECRET_KEY = process.env.STRIPE_LIVE_SECRET_KEY;
+
+// The account is mutated (customer + subscription created and torn down), so a
+// live key is refused outright rather than skipped: a skip on a mis-set secret
+// reads as "covered" in CI, and the cost of being wrong here is real money.
+if (SECRET_KEY && !SECRET_KEY.startsWith("sk_test_")) {
+  throw new Error(
+    "STRIPE_LIVE_SECRET_KEY must be a TEST-mode key (sk_test_…). " +
+      "This suite creates and cancels subscriptions.",
+  );
+}
+
+/**
+ * Every key path in `mock` that is absent from `live`, or present with a
+ * different JSON type. Walks the MOCK, not the live object: the fixtures carry
+ * only the fields the module reads, and the live object carries dozens more.
+ * Arrays are compared at index 0 — the fixtures never assert beyond the first
+ * element, and neither does production.
+ */
+function driftedPaths(mock: unknown, live: unknown, prefix = ""): string[] {
+  const kind = (v: unknown): string =>
+    v === null ? "null" : Array.isArray(v) ? "array" : typeof v;
+
+  if (kind(mock) !== "object" && kind(mock) !== "array") {
+    return kind(mock) === kind(live) ? [] : [`${prefix} (mock ${kind(mock)}, live ${kind(live)})`];
+  }
+
+  if (Array.isArray(mock)) {
+    if (!Array.isArray(live)) return [`${prefix} (mock array, live ${kind(live)})`];
+    if (mock.length === 0) return [];
+    if (live.length === 0) return [`${prefix}[0] (live array is empty)`];
+    return driftedPaths(mock[0], live[0], `${prefix}[0]`);
+  }
+
+  const liveRecord = live as Record<string, unknown> | null;
+  if (kind(live) !== "object" || liveRecord === null) {
+    return [`${prefix} (mock object, live ${kind(live)})`];
+  }
+
+  return Object.entries(mock as Record<string, unknown>).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (!(key in liveRecord)) return [`${path} (absent from the live object)`];
+    return driftedPaths(value, liveRecord[key], path);
+  });
+}
+
+/** Value at a dotted path, `[0]` segments included. `undefined` when absent. */
+function at(root: unknown, path: string): unknown {
+  return path
+    .split(".")
+    .flatMap((seg) => seg.split(/\[(\d+)\]/).filter(Boolean))
+    .reduce<unknown>((node, seg) => {
+      if (node === null || typeof node !== "object") return undefined;
+      return (node as Record<string, unknown>)[seg];
+    }, root);
+}
+
+describe.skipIf(!SECRET_KEY)("Stripe live contract", () => {
+  // Built in `beforeAll`, not here: `describe.skipIf` still evaluates this
+  // body, and the Stripe constructor throws on an empty key — which would turn
+  // the intended silent skip into a red file on every machine without the
+  // secret, i.e. all of them.
+  let stripe: Stripe;
+
+  let customer: Stripe.Customer;
+  let subscription: Stripe.Subscription;
+  let starterPriceId: string;
+  let proPriceId: string | null = null;
+
+  beforeAll(async () => {
+    stripe = new Stripe(SECRET_KEY!, { apiVersion: "2026-08-26.dahlia" });
+
+    // Prices come from the account rather than from env: `requirements.ts`
+    // force-overrides STRIPE_PRICE_ID_* for the mocked suite, so reading those
+    // here would send `price_starter_test` to the real API.
+    const prices = await stripe.prices.list({ type: "recurring", active: true, limit: 2 });
+    if (prices.data.length === 0) {
+      throw new Error(
+        "No active recurring price in the test account — this suite needs one to subscribe to.",
+      );
+    }
+    starterPriceId = prices.data[0]!.id;
+    proPriceId = prices.data[1]?.id ?? null;
+
+    customer = await stripe.customers.create({
+      email: "contract-suite@example.test",
+      metadata: { orgId: "00000000-0000-4000-a000-00000000c0de" },
+    });
+    const pm = await stripe.paymentMethods.attach("pm_card_visa", { customer: customer.id });
+    await stripe.customers.update(customer.id, {
+      invoice_settings: { default_payment_method: pm.id },
+    });
+    subscription = await stripe.subscriptions.create({
+      customer: customer.id,
+      items: [{ price: starterPriceId }],
+      metadata: { orgId: "00000000-0000-4000-a000-00000000c0de", planId: "starter" },
+    });
+  });
+
+  afterAll(async () => {
+    // Deleting the customer cancels its subscriptions, but cancel first so a
+    // failed delete still leaves nothing billable behind.
+    if (subscription) await stripe.subscriptions.cancel(subscription.id).catch(() => {});
+    if (customer) await stripe.customers.del(customer.id).catch(() => {});
+  });
+
+  // ─── 1. Shape: the mock may not invent fields ─────────────────
+
+  describe("mock fixtures match the live response shape", () => {
+    it("subscription", () => {
+      expect(driftedPaths(defaultSubscriptionResponse(subscription.id), subscription)).toEqual([]);
+    });
+
+    it("customer", () => {
+      expect(driftedPaths(defaultCustomerResponse(), customer)).toEqual([]);
+    });
+
+    it("checkout session", async () => {
+      const session = await stripe.checkout.sessions.create({
+        customer: customer.id,
+        mode: "subscription",
+        line_items: [{ price: starterPriceId, quantity: 1 }],
+        success_url: "https://example.test/org-settings/billing",
+        cancel_url: "https://example.test/org-settings/billing",
+      });
+      expect(driftedPaths(defaultCheckoutResponse(), session)).toEqual([]);
+    });
+
+    it("billing portal session", async () => {
+      const session = await stripe.billingPortal.sessions.create({
+        customer: customer.id,
+        return_url: "https://example.test/org-settings/billing",
+      });
+      expect(driftedPaths(defaultPortalResponse(), session)).toEqual([]);
+    });
+  });
+
+  // ─── 2. Shape: production's reads must land on both sides ─────
+
+  // Every path `packages/module-ee/src` dereferences on a retrieved
+  // subscription. Asserted against the LIVE object and the MOCK alike: a path
+  // that exists in only one of them is a test suite proving nothing.
+  const SUBSCRIPTION_READS = [
+    "id",
+    "status",
+    "customer",
+    "metadata",
+    "cancel_at_period_end",
+    "items.data[0].id",
+    "items.data[0].price.id",
+    "items.data[0].current_period_end",
+  ];
+
+  describe("the fields production reads exist", () => {
+    for (const path of SUBSCRIPTION_READS) {
+      it(`live subscription has ${path}`, () => {
+        expect(at(subscription, path)).toBeDefined();
+      });
+
+      it(`mock subscription has ${path}`, () => {
+        expect(at(defaultSubscriptionResponse("sub_shape"), path)).toBeDefined();
+      });
+    }
+  });
+
+  // ─── 3. Semantics: what only the real API can settle ──────────
+
+  it("current_period_end is a unix timestamp on the item", () => {
+    const ts = subscription.items.data[0]?.current_period_end;
+    expect(typeof ts).toBe("number");
+    // Sanity, not precision: a seconds/milliseconds mix-up is the failure mode
+    // that would otherwise sail through as a date in the year 58000.
+    expect(new Date((ts as number) * 1000).getUTCFullYear()).toBeLessThan(2100);
+  });
+
+  it("subscriptions.update REPLACES the priced item instead of adding one", async () => {
+    if (!proPriceId) {
+      throw new Error(
+        "The test account has only one active recurring price — a plan change cannot be exercised.",
+      );
+    }
+    const itemId = subscription.items.data[0]!.id;
+
+    const updated = await stripe.subscriptions.update(subscription.id, {
+      items: [{ id: itemId, price: proPriceId }],
+      proration_behavior: "create_prorations",
+    });
+
+    // The invariant `packages/module-ee/src/stripe/plan.ts` bets the business
+    // on: without the item id, this call ADDS a second priced item and every
+    // plan change starts billing twice.
+    expect(updated.items.data).toHaveLength(1);
+    expect(updated.items.data[0]!.price.id).toBe(proPriceId);
+  });
+
+  it("accepts a valid webhook signature and rejects a forged one", async () => {
+    const payload = JSON.stringify({
+      id: "evt_contract",
+      object: "event",
+      type: "customer.subscription.updated",
+      data: { object: { id: subscription.id, object: "subscription" } },
+    });
+    const secret = "whsec_contract_suite";
+
+    const header = await stripe.webhooks.generateTestHeaderStringAsync({ payload, secret });
+    const event = await stripe.webhooks.constructEventAsync(payload, header, secret);
+    expect(event.type).toBe("customer.subscription.updated");
+
+    // `apps`-side error handling keys off this exact class (module-ee/src/
+    // routes/billing.ts) to answer 400 rather than 500.
+    await expect(
+      stripe.webhooks.constructEventAsync(payload, "t=1,v1=deadbeef", secret),
+    ).rejects.toBeInstanceOf(Stripe.errors.StripeSignatureVerificationError);
+  });
+
+  it("raises StripeInvalidRequestError for an unknown subscription", async () => {
+    await expect(stripe.subscriptions.retrieve("sub_does_not_exist_xyz")).rejects.toBeInstanceOf(
+      Stripe.errors.StripeInvalidRequestError,
+    );
+  });
+});


### PR DESCRIPTION
## Why

The EE billing tests run against a hand-written Stripe mock (`packages/module-ee/test/helpers/stripe.ts`). That mock proves what the module **sends** — every request is recorded and the bodies are asserted. It can prove nothing about what Stripe **returns**, or how Stripe **interprets** what we sent, because we wrote those answers ourselves.

They had already drifted, in two places, silently:

- Stripe moved the billing-cycle end onto the subscription **item** in the 2025-03-31 API version. The fixture kept returning it at the top level, where the live API does not have it at all. `subscriptionPeriodEnd` (`src/stripe/webhooks.ts`) reads the item, so against the mock that read was `undefined` in every test, and the `subscription-confirmed` e-mail silently fell back to today's date.
- The fixture carried no `metadata` at all, though production calls `parseStripeMetadata` on it during budget allocation.

Neither failed anything. Neither could: the fixtures and the assertions were written from the same belief.

This is not a production bug — production reads the correct paths and the live API supplies them. It is a blind spot: a stretch of production code that no test actually executes, and no test would notice breaking.

## What this adds

`packages/module-ee/test/live/stripe-contract.test.ts` — runs against real Stripe in **test mode** and checks the two things a mock structurally cannot:

1. **Shape.** Every key path a fixture claims must exist on the live object, with the same type. Extra live fields are ignored (the fixtures are deliberately minimal); invented ones fail. This is the check that turns the next relocation into a red mock rather than a quiet production lie — and it is how both bugs above surfaced.
2. **Semantics.** `subscriptions.update` replaces the priced item instead of adding one — the double-charge invariant `src/stripe/plan.ts` rests on; `current_period_end` is a timestamp on the item; a forged webhook signature raises `StripeSignatureVerificationError` and an unknown id raises `StripeInvalidRequestError`, the two classes `src/routes/billing.ts` branches on.

Plus the fixture fix the suite demanded, and a README section on where the boundary between the two suites lies.

## Opt-in

Gated on `STRIPE_LIVE_SECRET_KEY`, following `scripts/conformance/probes.ts`: no secret, no run, no noise. Deliberately **not** `STRIPE_SECRET_KEY` — a developer `.env` holding a working key must never make `bun test` start creating objects in an account nobody aimed at. A key not starting with `sk_test_` is refused outright rather than skipped, since the suite mutates the account.

CI is `.github/workflows/stripe-live.yml`: weekly, on demand, and on any PR touching `packages/module-ee/**` — which covers a Dependabot bump of `stripe`. Without the secret the job runs green with the suite skipped, and says so in an annotation.

## What this deliberately does NOT change

An earlier revision of this PR also made the `Integration tests` job fire on a module-ee path change, not only on the `integration` label. `test.yml` has no `paths:` filter, so that needed a `changes` job of its own — a permanent extra job on every PR, a full-depth checkout to find the merge base, and a special case naming one module. It bought earlier feedback on some PRs and nothing else: the integration suite already runs post-merge on `main`, so nothing reaches production unverified, and the drift risk that motivated it is exactly what the workflow above now covers natively. Reverted; `test.yml` is untouched.

## Verification

| | |
|---|---|
| Live suite against real Stripe (test mode), locally and in CI | 24 pass, 0 fail |
| Same suite against the **pre-fix** fixtures | 3 fail — the drift, as intended |
| Suite with no secret | 26 skip, 0 fail |
| Mocked module-ee suites (unit + integration) | 431 pass, 0 fail |
| `bun run check` | 41/41 |

## Operator step

Done: the `STRIPE_LIVE_SECRET_KEY` repository secret is provisioned. The suite needs at least one active recurring price in that Stripe test account, and two to exercise the plan change.