### PR TITLE
Lint the GitHub Actions workflows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,15 +150,21 @@ Tier 0 (zero-install) requires only Bun.
 - **New API route**: route file in `routes/` + OpenAPI path file in `openapi/paths/` + wire in `index.ts`. Run `bun run verify:openapi`, then `bun run generate:api` to refresh the SPA's generated types (`verify:api-types` in `check` fails otherwise). Every 2xx JSON response must declare a schema (verify-openapi step 6).
 - **DB migration (core)**: edit the domain file under `packages/db/src/schema/<domain>.ts` (the barrel is `packages/db/src/schema/index.ts` — nothing is defined there) → `bun run db:generate` (needs `DATABASE_URL` for drizzle-kit). Applied automatically at boot (PGlite + PostgreSQL) — no manual `db:migrate`.
 - **Module tables**: there are none separately — a module's tables live in the core schema (`packages/db/src/schema/<domain>.ts`) and migrate with core. No per-module migration step. The one exception is `packages/module-ee`, which keeps a drizzle tree of its OWN and self-migrates its seven `ee_*` tables into the platform database at `init()`, under its own journal `drizzle.ee_migrations` — the platform's `drizzle.__drizzle_migrations` is untouched. That is the escape hatch of `apps/api/src/modules/README.md` § "Database ownership rules" (rule 4), for tables the Apache-2.0 core schema must not carry.
-- **Quality gate**: `bun run check` — 20 task names, not 2: `turbo typecheck lint format:check` plus
+- **Quality gate**: `bun run check` — 21 task names, not 2: `turbo typecheck lint format:check` plus
   `verify:openapi`, `verify:api-types`, `verify:type-coverage`, `verify:compose-defaults`,
-  `verify:release-version`, `verify:env-docs`, `detect:breaking`, `build:system-packages:check`,
-  `lint:manifest-casing`, `conformance:check`, `verify:module-isolation`,
-  `verify:module-sql-boundary`, `verify:license-boundary`, `typecheck:scripts`,
-  `verify:module-contract`, `verify:dead-code`, `verify:no-migration-dml`.
-  turbo fans those out to **41** actual tasks (`typecheck` alone runs in 22 workspaces) — count them
-  with `bunx turbo run <the 20 names> --dry=json`, never by reading this line.
+  `verify:release-version`, `verify:env-docs`, `verify:workflows`, `detect:breaking`,
+  `build:system-packages:check`, `lint:manifest-casing`, `conformance:check`,
+  `verify:module-isolation`, `verify:module-sql-boundary`, `verify:license-boundary`,
+  `typecheck:scripts`, `verify:module-contract`, `verify:dead-code`, `verify:no-migration-dml`.
+  turbo fans those out to **42** actual tasks (`typecheck` alone runs in 22 workspaces) — count them
+  with `bunx turbo run <the 21 names> --dry=json`, never by reading this line.
   There is no `turbo check` task — the root script drives turbo directly.
+  `verify:workflows` is the newest and the narrowest: `actionlint` over `.github/workflows`, the
+  one language in this repo the gate used to skip entirely. It downloads a version-pinned,
+  SHA-256-verified binary on first run and caches it under `node_modules/.cache` — the npm package
+  named `actionlint` is an unrelated abandoned wasm build, not the linter. Its `shellcheck` and
+  `pyflakes` integrations are switched OFF on purpose so the verdict cannot depend on what happens
+  to be installed on the host; `scripts/verify-workflows.ts` states the full reasoning.
   `verify:module-sql-boundary` is what enforces "a module never joins across the licence boundary"
   (`apps/api/src/modules/README.md` rule 4): `@appstrate/module-ee` keeps its tables in the PLATFORM
   database, so a `SELECT … FROM organizations` written there compiles and runs. The gate refuses any

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "conformance:check": "bun scripts/conformance/run.ts --tier gate",
     "verify:dead-code": "knip-bun",
     "test:system-packages": "bun scripts/conformance/run.ts",
-    "check": "turbo typecheck lint format:check verify:openapi verify:api-types verify:type-coverage verify:compose-defaults verify:release-version verify:env-docs detect:breaking build:system-packages:check lint:manifest-casing conformance:check verify:module-isolation verify:module-sql-boundary verify:license-boundary typecheck:scripts verify:module-contract verify:dead-code verify:no-migration-dml",
+    "check": "turbo typecheck lint format:check verify:openapi verify:api-types verify:type-coverage verify:compose-defaults verify:release-version verify:env-docs verify:workflows detect:breaking build:system-packages:check lint:manifest-casing conformance:check verify:module-isolation verify:module-sql-boundary verify:license-boundary typecheck:scripts verify:module-contract verify:dead-code verify:no-migration-dml",
     "verify:module-isolation": "bun scripts/verify-module-isolation.ts",
     "verify:module-sql-boundary": "bun scripts/verify-module-sql-boundary.ts",
     "verify:license-boundary": "bun scripts/verify-license-boundary.ts",
@@ -116,6 +116,7 @@
     "verify:compose-defaults": "bun scripts/verify-compose-defaults.ts",
     "verify:release-version": "bun scripts/verify-release-version.ts",
     "verify:env-docs": "bun scripts/verify-env-docs.ts",
+    "verify:workflows": "bun scripts/verify-workflows.ts",
     "openapi:baseline": "bun scripts/detect-breaking-changes.ts --update-baseline",
     "clean": "rm -rf node_modules/.cache .turbo .eslintcache apps/*/dist apps/web/.vite packages/*/dist coverage",
     "prepare": "husky"

--- a/scripts/verify-workflows.ts
+++ b/scripts/verify-workflows.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+/// <reference types="bun" />
+
+/**
+ * Gate — the GitHub Actions workflows must lint.
+ *
+ * `bun run check` covered every language in this repo except the one that
+ * decides whether the rest of the checks run at all. Eighteen workflow files,
+ * ~4k lines of YAML and embedded shell, were held to prettier's formatting and
+ * nothing else: a typo in a context path, a `needs` pointing at a job that no
+ * longer exists, a misspelt runner label, an unclosed `${{ }}` — none of it was
+ * caught before GitHub itself tried to run the file, and a workflow that fails
+ * to parse simply does not run. On a repo whose `main` ruleset requires no
+ * status checks (see #1230), a workflow that silently stops running is a gate
+ * that silently stops existing.
+ *
+ * This wraps `actionlint`, which is the linter for that language.
+ *
+ * ## Why a pinned download and not a dependency
+ *
+ * actionlint is a Go binary. Its author publishes GitHub releases and a Docker
+ * image, and nothing on npm. The npm package literally named `actionlint` is
+ * NOT it — an unrelated wasm build published by `hops-release`, no source
+ * repository declared, last touched in 2022. Depending on it would be handing
+ * a third party the right to run code in every developer's install.
+ *
+ * So the binary comes from the author's own release page, pinned to an exact
+ * version, and its SHA-256 is verified against {@link CHECKSUMS} BEFORE the
+ * file is ever marked executable. Those digests are transcribed from the
+ * signed `actionlint_<version>_checksums.txt` of that release. A mismatch
+ * aborts and leaves nothing on disk. Bumping the version means replacing every
+ * digest in the same commit — that is the point, not an inconvenience.
+ *
+ * ## Why shellcheck and pyflakes are switched off
+ *
+ * actionlint shells out to `shellcheck` for `run:` blocks when it finds one on
+ * PATH. Ubuntu runners ship shellcheck; a developer's Mac generally does not.
+ * Left on, this gate would report different findings depending on whose
+ * machine ran it — green locally, red in CI, for a diff that changed neither.
+ * A check whose verdict depends on the host is a check that lies, so both
+ * integrations are disabled explicitly rather than left to ambient discovery.
+ *
+ * What this costs, measured at the time of writing: three `SC2129` style
+ * suggestions ("consider using { cmd1; cmd2; } >> file") in `preview.yml` and
+ * `release.yml`. Nothing else. Adding shellcheck back is a separate decision
+ * that has to pin shellcheck the same way this pins actionlint.
+ *
+ * ## What this does and does not catch
+ *
+ * Verified against a deliberately broken workflow: undefined step ids,
+ * misspelt context properties, `needs` on a job that does not exist, unknown
+ * runner labels, malformed expressions, and `github.event.*` interpolated
+ * straight into a `run:` script (the script-injection rule).
+ *
+ * It does NOT flag a `steps.*.outputs.*` interpolated into a `run:` — that is
+ * outside actionlint's untrusted-input set, which covers attacker-controlled
+ * event fields only. The convention of routing step outputs through `env:`
+ * (see `conformance-monitor.yml`) remains a matter of review, not of this gate.
+ * It also does not verify that an action reference resolves: `uses:
+ * actions/checkout@v99999` passes, because resolving it needs the network.
+ */
+
+import { chmodSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+/** Pinned release. Bumping this means re-transcribing every digest below. */
+const VERSION = "1.7.12";
+
+/**
+ * SHA-256 of each release tarball, from
+ * `https://github.com/rhysd/actionlint/releases/download/v{VERSION}/actionlint_{VERSION}_checksums.txt`.
+ * Keyed by the `<os>_<arch>` slug that appears in the asset name.
+ */
+const CHECKSUMS: Readonly<Record<string, string>> = {
+  darwin_amd64: "5b44c3bc2255115c9b69e30efc0fecdf498fdb63c5d58e17084fd5f16324c644",
+  darwin_arm64: "aba9ced2dee8d27fecca3dc7feb1a7f9a52caefa1eb46f3271ea66b6e0e6953f",
+  linux_amd64: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8",
+  linux_arm64: "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6",
+};
+
+const ROOT = join(import.meta.dir, "..");
+const CACHE_DIR = join(ROOT, "node_modules/.cache/actionlint", VERSION);
+const BINARY = join(CACHE_DIR, "actionlint");
+
+/** Map Bun's platform/arch onto the slug used in the release asset names. */
+export function platformSlug(platform: string, arch: string): string {
+  const os = platform === "darwin" ? "darwin" : platform === "linux" ? "linux" : undefined;
+  const cpu = arch === "arm64" ? "arm64" : arch === "x64" ? "amd64" : undefined;
+  if (!os || !cpu) {
+    throw new Error(
+      `actionlint publishes no release for ${platform}/${arch}. ` +
+        `Supported here: darwin|linux × arm64|x64.`,
+    );
+  }
+  return `${os}_${cpu}`;
+}
+
+function assetUrl(slug: string): string {
+  return (
+    `https://github.com/rhysd/actionlint/releases/download/v${VERSION}/` +
+    `actionlint_${VERSION}_${slug}.tar.gz`
+  );
+}
+
+/**
+ * Fetch the tarball, refuse it unless its digest matches, then extract the
+ * single binary we want. Nothing is made executable before the digest check.
+ */
+async function download(slug: string): Promise<void> {
+  const url = assetUrl(slug);
+  const expected = CHECKSUMS[slug];
+  if (!expected) throw new Error(`No pinned checksum for ${slug} — add one before using it.`);
+
+  process.stdout.write(`[verify:workflows] fetching actionlint ${VERSION} (${slug})…\n`);
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(
+      `Could not download actionlint ${VERSION} (${slug}): HTTP ${res.status} from ${url}. ` +
+        `This gate needs network access on its first run; the binary is cached afterwards.`,
+    );
+  }
+  const bytes = new Uint8Array(await res.arrayBuffer());
+
+  const actual = new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch for actionlint ${VERSION} (${slug}).\n` +
+        `  expected ${expected}\n  actual   ${actual}\n` +
+        `Refusing to run it. Either the release was re-cut, or the download was tampered with.`,
+    );
+  }
+
+  // Extract only after the bytes are vouched for. A fresh directory each time
+  // so a half-extracted previous attempt cannot be mistaken for a good cache.
+  rmSync(CACHE_DIR, { recursive: true, force: true });
+  mkdirSync(CACHE_DIR, { recursive: true });
+  const tarball = join(CACHE_DIR, "actionlint.tar.gz");
+  await Bun.write(tarball, bytes);
+
+  const tar = Bun.spawnSync(["tar", "xzf", tarball, "-C", CACHE_DIR, "actionlint"], {
+    stderr: "pipe",
+  });
+  if (tar.exitCode !== 0) {
+    throw new Error(`Extracting actionlint failed: ${tar.stderr.toString().trim()}`);
+  }
+  rmSync(tarball, { force: true });
+  chmodSync(BINARY, 0o755);
+}
+
+async function main(): Promise<number> {
+  if (!existsSync(BINARY)) {
+    await download(platformSlug(process.platform, process.arch));
+  }
+
+  const run = Bun.spawnSync(
+    [
+      BINARY,
+      "-no-color",
+      "-oneline",
+      // Both integrations off on purpose — see the header.
+      "-shellcheck=",
+      "-pyflakes=",
+    ],
+    { cwd: ROOT, stdout: "pipe", stderr: "pipe" },
+  );
+
+  const out = `${run.stdout.toString()}${run.stderr.toString()}`.trim();
+  if (run.exitCode === 0) {
+    process.stdout.write("[verify:workflows] OK — actionlint reports no findings.\n");
+    return 0;
+  }
+  process.stdout.write(`${out}\n`);
+  process.stdout.write(
+    "\n[verify:workflows] actionlint reported the findings above. " +
+      "Rule reference: https://github.com/rhysd/actionlint/blob/main/docs/checks.md\n",
+  );
+  return 1;
+}
+
+if (import.meta.main) {
+  process.exit(await main());
+}

--- a/turbo.json
+++ b/turbo.json
@@ -429,6 +429,12 @@
         "package.json"
       ]
     },
+    // `cache: false`, like most siblings: the run is a spawn of a cached
+    // binary against 18 files and finishes in milliseconds, so a cache entry
+    // would buy nothing and could only ever hide a finding.
+    "//#verify:workflows": {
+      "cache": false
+    },
     "//#detect:breaking": {
       "cache": false
     },


### PR DESCRIPTION
Follow-up to #1304, which surfaced this: `bun run check` covered every language in this repo except the one that decides whether the rest of the checks run at all.

Eighteen workflow files, roughly 4k lines of YAML and embedded shell, held to prettier's formatting and nothing else. A typo in a context path, a `needs` pointing at a job that no longer exists, a misspelt runner label, an unclosed `${{ }}` — none of it was caught before GitHub itself tried to run the file, and a workflow that fails to parse simply does not run.

That gap has teeth here specifically. `main` requires no status checks (#1230), so a workflow that silently stops running is a gate that silently stops existing. #1206 was the demonstration: a monitor whose reporting half worked while its failing half did not, sitting green for weeks.

## What it catches, verified

Run against a deliberately broken workflow before wiring it in:

| what | rule |
|---|---|
| `runs-on: ubunut-latest` | `runner-label` |
| `needs: [typo-job]` on a job that does not exist | `job-needs` |
| `${{ steps.nope.outputs.thing }}` — undefined step id | `expression` |
| `${{ github.evnt.repository.name }}` — misspelt context property | `expression` |
| `if: ${{ a == 'b' && }}` — malformed expression | `expression` |
| `${{ github.event.issue.title }}` straight into `run:` | `expression` (script injection) |

**Two things it does not do**, stated so nobody assumes otherwise:

- It does **not** flag a `steps.*.outputs.*` interpolated into a `run:`. I tested this by undoing #1230's hand-written hardening in `conformance-monitor.yml` — actionlint passes it. Its untrusted-input set covers attacker-controlled event fields only. The convention of routing step outputs through `env:` stays a matter of review, not of this gate.
- It does **not** resolve action references. `uses: actions/checkout@v99999` passes, because resolving it needs the network.

## The binary, and why it is not a dependency

actionlint is a Go binary with no npm distribution. **The npm package literally named `actionlint` is not it** — an unrelated wasm build published by `hops-release`, no source repository declared, untouched since 2022. Depending on it would hand a third party the right to run code in every developer's install.

So it comes from the author's release page, pinned to `v1.7.12`, with the SHA-256 of each supported platform tarball transcribed from that release's checksums file and verified **before the file is ever made executable**. Negative control: flipping one digest makes the run refuse and leaves the cache directory empty.

```
Checksum mismatch for actionlint 1.7.12 (darwin_arm64).
  expected 0000…
  actual   aba9ced2…
Refusing to run it.
```

Bumping the version means replacing every digest in the same commit. That is the point, not the friction.

## shellcheck and pyflakes are switched off

actionlint shells out to shellcheck for `run:` blocks when it finds one on PATH. Ubuntu runners ship it; a developer's Mac generally does not. Left on, this gate reports different findings depending on whose machine ran it — green locally, red in CI, for a diff that changed neither. A check whose verdict depends on the host is a check that lies, so both integrations are disabled explicitly rather than left to ambient discovery.

Measured cost of that call: three `SC2129` style suggestions ("consider using `{ cmd1; cmd2; } >> file`") in `preview.yml` and `release.yml`. Nothing else. Adding shellcheck back is a separate decision that has to pin shellcheck the same way this pins actionlint — I did not smuggle it in here.

## Verification

- `bun run check` — 42/42 green (was 41; `CLAUDE.md`'s enumerated list and both counts updated)
- Negative control: a workflow with a bad runner label and two bad expressions makes `verify:workflows` exit 1 with the findings; removing it returns to green without refetching the binary
- Negative control on the checksum guard, as above

The repo is clean under this gate today, and it goes red on a broken workflow — checked both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
