### PR TITLE
test(runtime-pi): gate one inference turn through the built pi + sidecar pair

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -313,11 +313,23 @@ jobs:
 
   runtime-e2e:
     name: Runtime container e2e
-    # The runtime-pi file-provisioning spin only reproduces in the BUNDLED
-    # image, so `runtime-pi/test/provision-container.e2e.test.ts` needs the real
-    # `appstrate-pi` image built — which the fast `unit` job does not do (it
-    # would blow the 5-min budget), so that test SKIPS there. This job builds
-    # the image and runs it, giving the regression an actual gate. Same
+    # The only pre-merge job that runs the REAL runtime images, and it gates two
+    # regressions that live exclusively there:
+    #
+    #   1. The runtime-pi file-provisioning spin only reproduces in the BUNDLED
+    #      image (#882), so `provision-container.e2e.test.ts` needs a real
+    #      `appstrate-pi` built — which the fast `unit` job does not do (it would
+    #      blow the 5-min budget), so that test SKIPS there.
+    #   2. One inference turn driven through the built pi + sidecar PAIR against
+    #      a stub upstream (`inference-container.e2e.test.ts`), asserting the
+    #      Codex request shape and the zstd body's byte integrity (#1197). That
+    #      is the #1195 class: a MISMATCHED IMAGE PAIR, where each half is
+    #      correct on its own and only their combination fails — invisible to
+    #      every in-process test, because those wire the two halves together
+    #      from one source tree, the configuration that never breaks.
+    #
+    # Hence both images are built here, from the same checkout: a pair is only
+    # comparable when both halves come from the code under test. Same
     # label-OR-main policy as the other heavy jobs (opt-in pre-merge via the
     # `e2e` label, always post-merge on main).
     if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.ref == 'refs/heads/main'
@@ -349,14 +361,20 @@ jobs:
       - name: Build appstrate-pi image
         run: docker build -t appstrate-pi:latest -f runtime-pi/Dockerfile .
 
+      # The pair's other half. Same tag family, and `appstrate-sidecar:latest` is
+      # the inference e2e's default `SIDECAR_IMAGE`; without it that suite gates
+      # nothing, it skips.
+      - name: Build appstrate-sidecar image
+        run: docker build -t appstrate-sidecar:latest -f runtime-pi/sidecar/Dockerfile .
+
       # The root bunfig preload boots the test docker-compose stack
       # unconditionally; start it so the preload is satisfied (the e2e itself
       # uses only its own in-process mock sink, not the DB).
       - name: Start test infrastructure
         run: docker compose -f test/setup/docker-compose.test.yml up -d --wait
 
-      - name: Run runtime container e2e
-        run: bun test runtime-pi/test/provision-container.e2e.test.ts
+      - name: Run runtime container e2e suites
+        run: bun test runtime-pi/test/provision-container.e2e.test.ts runtime-pi/test/inference-container.e2e.test.ts
 
   e2e:
     name: E2E tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,6 +536,20 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
   per cluster to per process for its length rather than removing it or refusing
   the call. A rejection that still reaches a caller means both backends failed.
 
+- **The runtime container e2e now runs one inference turn through the BUILT
+  pi + sidecar pair (#1197).** `runtime-pi/test/inference-container.e2e.test.ts`
+  launches both images on a private Docker network — the agent reaching the
+  sidecar on its `sidecar` DNS alias, exactly as the platform wires them — and
+  drives a single Codex OAuth turn against a stub upstream on the host. It
+  asserts what actually arrives there: one `POST /codex/responses`, the real
+  subscription bearer swapped in and the container's placeholder JWT present in
+  no header, Pi's own `chatgpt-account-id` / `originator` / `OpenAI-Beta`
+  fingerprint forwarded verbatim, the two container→sidecar-only headers
+  stripped, and the `content-encoding: zstd` body decompressing and parsing —
+  which is the byte-identity witness a mismatched pair cannot produce (#1195
+  was an older sidecar text-decoding that frame; both halves were individually
+  correct and every in-process test stayed green).
+
 ### Fixed
 
 - **The hosted connect portal names the missing OAuth client instead of a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,21 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
   in no schema and in no example file — which `docs/ENV.md`'s own header now
   says out loud.
 
+- **The runtime container e2e now runs one inference turn through the BUILT
+  pi + sidecar pair (#1197).** `runtime-pi/test/inference-container.e2e.test.ts`
+  launches both images on a private Docker network — the agent reaching the
+  sidecar on its `sidecar` DNS alias, exactly as the platform wires them — and
+  drives a single Codex OAuth turn against a stub upstream on the host. It
+  asserts what actually arrives there: one `POST /codex/responses`, the real
+  subscription bearer swapped in and the container's placeholder JWT present in
+  no header, Pi's own `chatgpt-account-id` / `originator` / `OpenAI-Beta` /
+  `User-Agent` fingerprint forwarded verbatim, the container→sidecar-only
+  `x-appstrate-sidecar-auth` header stripped, and the `content-encoding: zstd`
+  body decompressing and parsing — which is the byte-identity witness a
+  mismatched pair cannot produce (#1195 was an older sidecar text-decoding that
+  frame; both halves were individually correct and every in-process test stayed
+  green).
+
 ### Changed
 
 - **The commercial module stores its tables in the platform database.**
@@ -535,20 +550,6 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
   insurance budget answers instead, so a Redis outage degrades each limit from
   per cluster to per process for its length rather than removing it or refusing
   the call. A rejection that still reaches a caller means both backends failed.
-
-- **The runtime container e2e now runs one inference turn through the BUILT
-  pi + sidecar pair (#1197).** `runtime-pi/test/inference-container.e2e.test.ts`
-  launches both images on a private Docker network — the agent reaching the
-  sidecar on its `sidecar` DNS alias, exactly as the platform wires them — and
-  drives a single Codex OAuth turn against a stub upstream on the host. It
-  asserts what actually arrives there: one `POST /codex/responses`, the real
-  subscription bearer swapped in and the container's placeholder JWT present in
-  no header, Pi's own `chatgpt-account-id` / `originator` / `OpenAI-Beta`
-  fingerprint forwarded verbatim, the two container→sidecar-only headers
-  stripped, and the `content-encoding: zstd` body decompressing and parsing —
-  which is the byte-identity witness a mismatched pair cannot produce (#1195
-  was an older sidecar text-decoding that frame; both halves were individually
-  correct and every in-process test stayed green).
 
 ### Fixed
 

--- a/runtime-pi/test/helpers/container-e2e.ts
+++ b/runtime-pi/test/helpers/container-e2e.ts
@@ -85,11 +85,14 @@ export function resolveContainerE2eGate(label: string, images: string[]): Contai
   const platforms = images.map((image) => ({ image, platform: imagePlatform(image) }));
   const run = daemon !== null && platforms.every(({ platform }) => platform === daemon);
   if (dockerEnabled && !run) {
-    const mismatched = daemon !== null && platforms.some(({ platform }) => platform !== null);
-    const hint = mismatched
-      ? " — rebuild natively: bun run docker:build:runtime (or, for one image," +
-        ` docker build --platform ${daemon} -t <tag> -f <dockerfile> .)`
-      : "";
+    // Same remedy whether an image is absent or built for another platform:
+    // build it natively. `docker:build:runtime` is the only command that builds
+    // the pi + sidecar pair with one revision stamp.
+    const hint =
+      daemon !== null
+        ? " — build natively: bun run docker:build:runtime (or, for one image," +
+          ` docker build --platform ${daemon} -t <tag> -f <dockerfile> .)`
+        : "";
     const seen = platforms
       .map(({ image, platform }) => `${image}=${platform ?? "absent"}`)
       .join(" ");

--- a/runtime-pi/test/helpers/container-e2e.ts
+++ b/runtime-pi/test/helpers/container-e2e.ts
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared plumbing for the `runtime-pi` container e2e tests — the layer that
+ * runs the BUILT images under the local Docker engine.
+ *
+ * Every such test needs the same three things, and getting any of them subtly
+ * different is how a container e2e silently stops running: the opt-in gate
+ * (docker present, images present, image platform == daemon platform, #882),
+ * a valid agent `.afps-bundle` to serve from the mock `/workspace` route, and
+ * the container-log dump that makes a deadline failure diagnosable. They live
+ * here so both suites share one definition.
+ */
+
+import { spawnSync } from "node:child_process";
+import { zipArtifact } from "@appstrate/core/zip";
+import {
+  extractRootFromAfps,
+  buildBundleFromCatalog,
+  writeBundleToBuffer,
+  emptyPackageCatalog,
+} from "@appstrate/afps-runtime/bundle";
+
+/**
+ * Opt-in gate: `TEST_DOCKER=1` locally, `CI=true` on GitHub Actions (set
+ * automatically). Mirrors the rule in `apps/api/test/helpers/tier.ts`.
+ */
+const dockerEnabled = process.env.TEST_DOCKER === "1" || process.env.CI === "true";
+
+function hasDocker(): boolean {
+  try {
+    return spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * `os/arch` from a docker `--format` template (e.g. "linux/arm64"), or null
+ * when the command fails (daemon down, image absent) or prints something
+ * unexpected. Both templates below emit Go's GOOS/GOARCH vocabulary, so the
+ * two results are directly comparable.
+ */
+function dockerPlatform(args: string[]): string | null {
+  try {
+    const out = spawnSync("docker", args, { encoding: "utf8" });
+    if (out.status !== 0) return null;
+    const platform = out.stdout.trim();
+    return /^[a-z0-9]+\/[a-z0-9]+$/.test(platform) ? platform : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Platform the Docker engine runs containers on natively. */
+function daemonPlatform(): string | null {
+  return dockerPlatform(["version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"]);
+}
+
+/** Platform a local image was built for, or null when the image is absent. */
+function imagePlatform(image: string): string | null {
+  return dockerPlatform(["image", "inspect", image, "--format", "{{.Os}}/{{.Architecture}}"]);
+}
+
+interface ContainerE2eGate {
+  /** Whether the suite may run: docker up, every image present and native. */
+  run: boolean;
+  /** The engine's native platform, non-null whenever {@link run} is true. */
+  daemon: string | null;
+}
+
+/**
+ * Decide whether a container e2e that needs `images` can run, and warn (once,
+ * at import time) with an actionable hint when it cannot.
+ *
+ * The `docker run` calls in these suites use the engine's native platform, so
+ * the gate must check more than image presence: a bare `docker image inspect`
+ * is architecture-blind, and an image built for another platform (e.g. an
+ * amd64 build left over on an Apple Silicon host) would pass it and then fail
+ * inside `docker run` with a misleading "pull access denied" (#882). Require
+ * every image's platform to match the daemon's and skip honestly otherwise.
+ */
+export function resolveContainerE2eGate(label: string, images: string[]): ContainerE2eGate {
+  const daemon = dockerEnabled && hasDocker() ? daemonPlatform() : null;
+  const platforms = images.map((image) => ({ image, platform: imagePlatform(image) }));
+  const run = daemon !== null && platforms.every(({ platform }) => platform === daemon);
+  if (dockerEnabled && !run) {
+    const mismatched = daemon !== null && platforms.some(({ platform }) => platform !== null);
+    const hint = mismatched
+      ? " — rebuild natively: bun run docker:build:runtime (or, for one image," +
+        ` docker build --platform ${daemon} -t <tag> -f <dockerfile> .)`
+      : "";
+    const seen = platforms
+      .map(({ image, platform }) => `${image}=${platform ?? "absent"}`)
+      .join(" ");
+    console.warn(
+      `[${label}] skipped — docker=${hasDocker()} ${seen} daemon=${daemon ?? "unknown"}${hint}`,
+    );
+  }
+  return { run, daemon };
+}
+
+/**
+ * Minimal valid agent `.afps-bundle` (the multi-package archive with
+ * `bundle.json` that the platform's `/workspace` route serves and the runtime
+ * reads via `readBundleFromFile`). A raw single-package `.afps` is rejected
+ * with `BUNDLE_JSON_MISSING`.
+ */
+export async function buildAgentBundle(name = "@e2e/provision-probe"): Promise<Uint8Array> {
+  const manifest = {
+    name,
+    version: "1.0.0",
+    type: "agent",
+    schema_version: "0.2",
+    display_name: "Provision Probe",
+    author: "e2e",
+  };
+  const afps = zipArtifact({
+    "manifest.json": new TextEncoder().encode(JSON.stringify(manifest)),
+    "prompt.md": new TextEncoder().encode("# probe\n\nStop immediately.\n"),
+  });
+  const root = extractRootFromAfps(afps);
+  const bundle = await buildBundleFromCatalog(root, emptyPackageCatalog, { depTypes: ["skills"] });
+  return writeBundleToBuffer(bundle);
+}
+
+/** `docker logs` (stdout+stderr merged) for a container, for failure messages. */
+export function dumpContainerLogs(containerName: string): string {
+  const logs = spawnSync("docker", ["logs", containerName], { encoding: "utf8" });
+  return (logs.stdout ?? "") + (logs.stderr ?? "");
+}
+
+/**
+ * The `MODEL_API_KEY` a codex OAuth run carries inside the container: an
+ * unsigned JWT whose only job is to let pi-ai read `chatgpt_account_id` off
+ * the auth claim and stamp it on the request. The real bearer never enters the
+ * container — the sidecar swaps it in. Same shape as
+ * `packages/module-codex/src/index.ts`, hand-rolled because `@appstrate/module-codex`
+ * is not a dependency of `runtime-pi`.
+ */
+export function codexPlaceholderJwt(accountId: string): string {
+  const segment = (value: unknown): string =>
+    btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+  return [
+    segment({ alg: "none", typ: "JWT" }),
+    segment({ "https://api.openai.com/auth": { chatgpt_account_id: accountId } }),
+    "placeholder",
+  ].join(".");
+}

--- a/runtime-pi/test/helpers/container-e2e.ts
+++ b/runtime-pi/test/helpers/container-e2e.ts
@@ -4,15 +4,16 @@
  * Shared plumbing for the `runtime-pi` container e2e tests — the layer that
  * runs the BUILT images under the local Docker engine.
  *
- * Every such test needs the same three things, and getting any of them subtly
+ * Every such test needs the same five things, and getting any of them subtly
  * different is how a container e2e silently stops running: the opt-in gate
  * (docker present, images present, image platform == daemon platform, #882),
- * a valid agent `.afps-bundle` to serve from the mock `/workspace` route, and
- * the container-log dump that makes a deadline failure diagnosable. They live
- * here so both suites share one definition.
+ * the `docker run` argv both suites launch containers with, a valid agent
+ * `.afps-bundle` to serve from the mock `/workspace` route, the container-log
+ * dump that makes a failure diagnosable, and the placeholder codex JWT a
+ * subscription run carries. They live here so both suites share one definition.
  */
 
-import { spawnSync } from "node:child_process";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { zipArtifact } from "@appstrate/core/zip";
 import {
   extractRootFromAfps,
@@ -81,8 +82,15 @@ interface ContainerE2eGate {
  * every image's platform to match the daemon's and skip honestly otherwise.
  */
 export function resolveContainerE2eGate(label: string, images: string[]): ContainerE2eGate {
-  const daemon = dockerEnabled && hasDocker() ? daemonPlatform() : null;
-  const platforms = images.map((image) => ({ image, platform: imagePlatform(image) }));
+  const dockerPresent = dockerEnabled && hasDocker();
+  const daemon = dockerPresent ? daemonPlatform() : null;
+  // One `docker` process per image, so only probe when there is a daemon to
+  // answer: with none, every inspect fails identically and the images are
+  // unreachable by definition. Keeps a skipped suite at zero docker spawns.
+  const platforms: { image: string; platform: string | null }[] =
+    daemon === null
+      ? images.map((image) => ({ image, platform: null }))
+      : images.map((image) => ({ image, platform: imagePlatform(image) }));
   const run = daemon !== null && platforms.every(({ platform }) => platform === daemon);
   if (dockerEnabled && !run) {
     // Same remedy whether an image is absent or built for another platform:
@@ -97,10 +105,64 @@ export function resolveContainerE2eGate(label: string, images: string[]): Contai
       .map(({ image, platform }) => `${image}=${platform ?? "absent"}`)
       .join(" ");
     console.warn(
-      `[${label}] skipped — docker=${hasDocker()} ${seen} daemon=${daemon ?? "unknown"}${hint}`,
+      `[${label}] skipped — docker=${dockerPresent} ${seen} daemon=${daemon ?? "unknown"}${hint}`,
     );
   }
   return { run, daemon };
+}
+
+/** `docker` with string output. Every docker call in these suites goes here. */
+export function docker(args: string[]): SpawnSyncReturns<string> {
+  return spawnSync("docker", args, { encoding: "utf8" });
+}
+
+export interface DockerRunOptions {
+  /** `--name`, so `docker logs` and `docker rm -f` can reach the container. */
+  name: string;
+  image: string;
+  /**
+   * `--platform`. Explicit rather than omitted: a `DOCKER_DEFAULT_PLATFORM`
+   * override would otherwise re-route the run to a foreign platform behind the
+   * gate's back (#882). Null only when there is no daemon platform to pin,
+   * which the gate makes unreachable from a running suite.
+   */
+  platform: string | null;
+  /** `-e KEY=VALUE`, in insertion order. */
+  env: Record<string, string>;
+  /** `--network`, when the container shares a private network with a peer. */
+  network?: string;
+  /** `--network-alias`, the DNS name peers on {@link network} reach it by. */
+  networkAlias?: string;
+}
+
+/**
+ * `docker run -d` as both container e2e suites need it: detached, so no
+ * long-lived child keeps Bun alive — each suite polls its own mock sink and
+ * then `rm -f`s — and always with `--add-host
+ * host.docker.internal:host-gateway`, which Docker Desktop adds by itself but a
+ * Linux engine (CI) needs spelled out.
+ */
+export function dockerRun({
+  name,
+  image,
+  platform,
+  env,
+  network,
+  networkAlias,
+}: DockerRunOptions): SpawnSyncReturns<string> {
+  return docker([
+    "run",
+    "-d",
+    "--name",
+    name,
+    ...(platform !== null ? ["--platform", platform] : []),
+    ...(network !== undefined ? ["--network", network] : []),
+    ...(networkAlias !== undefined ? ["--network-alias", networkAlias] : []),
+    "--add-host",
+    "host.docker.internal:host-gateway",
+    ...Object.entries(env).flatMap(([key, value]) => ["-e", `${key}=${value}`]),
+    image,
+  ]);
 }
 
 /**
@@ -129,7 +191,7 @@ export async function buildAgentBundle(name = "@e2e/provision-probe"): Promise<U
 
 /** `docker logs` (stdout+stderr merged) for a container, for failure messages. */
 export function dumpContainerLogs(containerName: string): string {
-  const logs = spawnSync("docker", ["logs", containerName], { encoding: "utf8" });
+  const logs = docker(["logs", containerName]);
   return (logs.stdout ?? "") + (logs.stderr ?? "");
 }
 

--- a/runtime-pi/test/inference-container.e2e.test.ts
+++ b/runtime-pi/test/inference-container.e2e.test.ts
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Container e2e — one inference turn through the BUILT pi + sidecar pair.
+ *
+ * #1195 was not a code regression: it was a MISMATCHED IMAGE PAIR. pi-ai
+ * compresses the Codex request body with zstd on the SSE path
+ * (`content-encoding: zstd`), and a sidecar predating #1166 text-decoded that
+ * body while buffering it, corrupting every byte above U+007F. Both halves
+ * were individually correct; only their combination failed.
+ *
+ * No in-process test can see that. `sidecar/test/oauth-llm.test.ts` proves the
+ * sidecar forwards bytes verbatim, and `pi-runner-transport.test.ts` proves the
+ * runner reaches `/llm/codex/responses` over SSE — but both wire the two halves
+ * together from ONE source tree, which is exactly the configuration that never
+ * breaks. The version gap only exists between two built images, container to
+ * container, so that is where this test lives.
+ *
+ * Shape: a stub platform on the host serves the run's sink + workspace routes,
+ * the sidecar's `/internal/oauth-token/:id` read, and a stub Codex upstream
+ * that records the request and answers a canned `response.completed`. The
+ * agent container runs one turn against it and finalizes; we then assert what
+ * arrived at the upstream — the request Pi signed, carried verbatim across the
+ * container boundary with only the bearer swapped.
+ *
+ * Both containers reach the stub via `host.docker.internal`. In production the
+ * agent's sink traffic rides the sidecar's forward proxy instead; that leg has
+ * its own coverage and is deliberately not under test here.
+ *
+ * Gated exactly like `provision-container.e2e.test.ts`: `TEST_DOCKER=1`
+ * locally, `CI=true` on GitHub Actions, and skipped unless BOTH images are
+ * present and native. Build them with `bun run docker:build:runtime`, which is
+ * the only command that stamps the pair with one revision.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { zstdDecompressSync } from "node:zlib";
+import { SIDECAR_AUTH_HEADER } from "@appstrate/core/sidecar-types";
+import { PI_SDK_VERSION_HEADER } from "@appstrate/runner-pi/provider-map";
+import {
+  buildAgentBundle,
+  codexPlaceholderJwt,
+  dumpContainerLogs,
+  resolveContainerE2eGate,
+} from "./helpers/container-e2e.ts";
+
+const PI_IMAGE = process.env.PI_IMAGE ?? "appstrate-pi:latest";
+const SIDECAR_IMAGE = process.env.SIDECAR_IMAGE ?? "appstrate-sidecar:latest";
+const DEADLINE_MS = 120_000;
+
+const { run: RUN, daemon } = resolveContainerE2eGate("inference-container.e2e", [
+  PI_IMAGE,
+  SIDECAR_IMAGE,
+]);
+
+const RID = "run_inference_e2e";
+const MODEL_ID = "gpt-5-codex";
+const ACCOUNT_ID = "acct_inference_e2e";
+const CREDENTIAL_ID = "cred_inference_e2e";
+const SINK_SECRET = "inference-e2e-secret-0123456789";
+const SIDECAR_AUTH_TOKEN = "inference-e2e-sidecar-token";
+const RUN_TOKEN = "inference-e2e-run-token";
+/** What the sidecar must swap ONTO the request. Never enters the agent container. */
+const REAL_ACCESS_TOKEN = "inference-e2e-real-subscription-bearer";
+/** What the agent container carries as `MODEL_API_KEY`. Must never reach upstream. */
+const PLACEHOLDER_JWT = codexPlaceholderJwt(ACCOUNT_ID);
+
+interface CapturedRequest {
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  bodyBytes: Uint8Array;
+}
+
+/**
+ * The canned Codex SSE completion — enough for the Pi run loop to finish its
+ * one turn and finalize `success`. Same frame as `pi-runner-transport.test.ts`.
+ */
+function completedSseBody(): string {
+  return `data: ${JSON.stringify({
+    type: "response.completed",
+    response: {
+      id: "resp_test",
+      status: "completed",
+      output: [],
+      usage: {
+        input_tokens: 1,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    },
+  })}\n\n`;
+}
+
+function docker(args: string[]): ReturnType<typeof spawnSync> {
+  return spawnSync("docker", args, { encoding: "utf8" });
+}
+
+describe.skipIf(!RUN)("runtime-pi + sidecar images carry one inference turn verbatim", () => {
+  let server: ReturnType<typeof Bun.serve> | undefined;
+  const networkName = `appstrate-e2e-inference-net-${Date.now()}`;
+  const sidecarName = `appstrate-e2e-inference-sidecar-${Date.now()}`;
+  const piName = `appstrate-e2e-inference-pi-${Date.now()}`;
+
+  const upstreamRequests: CapturedRequest[] = [];
+  /** Anything the stub did not expect, so a surprising call shows up in the failure. */
+  const unmatchedRequests: string[] = [];
+  const finalizeBodies: string[] = [];
+  let tokenReadAuthorization: string | undefined;
+
+  beforeAll(async () => {
+    const bundle = await buildAgentBundle("@e2e/inference-probe");
+    server = Bun.serve({
+      port: 0,
+      // Bind all interfaces: on Linux the containers reach the stub via the
+      // `host.docker.internal:host-gateway` IP, which a loopback-only bind
+      // would not answer (Docker Desktop hides this on macOS; CI is Linux).
+      hostname: "0.0.0.0",
+      async fetch(req) {
+        const path = new URL(req.url).pathname;
+
+        // ─ Stub Codex upstream (what the sidecar re-originates against) ─
+        if (path.startsWith("/upstream/")) {
+          upstreamRequests.push({
+            method: req.method,
+            path,
+            headers: Object.fromEntries(
+              [...req.headers.entries()].map(([k, v]) => [k.toLowerCase(), v]),
+            ),
+            bodyBytes: new Uint8Array(await req.arrayBuffer()),
+          });
+          return new Response(completedSseBody(), {
+            headers: { "content-type": "text/event-stream" },
+          });
+        }
+
+        // ─ Platform-internal: the sidecar resolves the real subscription bearer ─
+        if (path.startsWith("/internal/oauth-token/")) {
+          tokenReadAuthorization = req.headers.get("authorization") ?? undefined;
+          return Response.json({
+            accessToken: REAL_ACCESS_TOKEN,
+            expiresAt: Date.now() + 3_600_000,
+          });
+        }
+
+        // ─ Run sink + workspace, as the agent container expects them ─
+        if (path.endsWith("/workspace")) {
+          return new Response(bundle, { headers: { "content-type": "application/octet-stream" } });
+        }
+        if (path.endsWith("/files")) {
+          return new Response(null, { status: 404 });
+        }
+        if (path.endsWith("/events/finalize")) {
+          finalizeBodies.push(await req.text());
+          return new Response(null, { status: 204 });
+        }
+        if (path.endsWith("/events") || path.endsWith("/events/heartbeat")) {
+          return new Response(null, { status: 204 });
+        }
+
+        unmatchedRequests.push(`${req.method} ${path}`);
+        return new Response(null, { status: 404 });
+      },
+    });
+  });
+
+  afterAll(() => {
+    server?.stop(true);
+    docker(["rm", "-f", sidecarName, piName]);
+    docker(["network", "rm", networkName]);
+  });
+
+  it(
+    "delivers the signed Codex request to the upstream with the bearer swapped and the zstd body intact",
+    async () => {
+      const port = server!.port;
+      const platformUrl = `http://host.docker.internal:${port}`;
+      const sinkBase = `${platformUrl}/api/runs/${RID}`;
+      // `daemon` is non-null whenever RUN is true. Pin it explicitly so a
+      // DOCKER_DEFAULT_PLATFORM override cannot re-route the run to a foreign
+      // platform behind the gate's back (#882).
+      const platformArgs = daemon !== null ? ["--platform", daemon] : [];
+
+      const network = docker(["network", "create", networkName]);
+      expect(network.status, `docker network create failed: ${network.stderr}`).toBe(0);
+
+      try {
+        // The sidecar answers the agent on the DNS alias `sidecar`, exactly as
+        // the platform's Docker orchestrator wires it in production.
+        const sidecar = docker([
+          "run",
+          "-d",
+          "--name",
+          sidecarName,
+          ...platformArgs,
+          "--network",
+          networkName,
+          "--network-alias",
+          "sidecar",
+          "--add-host",
+          "host.docker.internal:host-gateway",
+          "-e",
+          "PORT=8080",
+          "-e",
+          `RUN_ID=${RID}`,
+          "-e",
+          `RUN_TOKEN=${RUN_TOKEN}`,
+          "-e",
+          `PLATFORM_API_URL=${platformUrl}`,
+          "-e",
+          `SIDECAR_AUTH_TOKEN=${SIDECAR_AUTH_TOKEN}`,
+          "-e",
+          `PI_LLM_OAUTH_CONFIG_JSON=${JSON.stringify({
+            authMode: "oauth",
+            baseUrl: `${platformUrl}/upstream`,
+            credentialId: CREDENTIAL_ID,
+          })}`,
+          // Mandatory: `host.docker.internal` resolves into a private range, so
+          // without this operator allowlist the sidecar's SSRF gate answers 403
+          // "Resolved OAuth base URL targets a blocked network range" before
+          // any request leaves. The platform forwards the same var in prod.
+          "-e",
+          "EGRESS_ALLOW_INTERNAL_HOSTS=host.docker.internal",
+          SIDECAR_IMAGE,
+        ]);
+        expect(sidecar.status, `docker run sidecar failed: ${sidecar.stderr}`).toBe(0);
+
+        const pi = docker([
+          "run",
+          "-d",
+          "--name",
+          piName,
+          ...platformArgs,
+          "--network",
+          networkName,
+          "--add-host",
+          "host.docker.internal:host-gateway",
+          "-e",
+          `AGENT_RUN_ID=${RID}`,
+          "-e",
+          `APPSTRATE_SINK_URL=${sinkBase}/events`,
+          "-e",
+          `APPSTRATE_SINK_FINALIZE_URL=${sinkBase}/events/finalize`,
+          "-e",
+          `APPSTRATE_SINK_SECRET=${SINK_SECRET}`,
+          "-e",
+          "MODEL_API=openai-codex-responses",
+          "-e",
+          `MODEL_ID=${MODEL_ID}`,
+          "-e",
+          "MODEL_PROVIDER=codex",
+          "-e",
+          "MODEL_BASE_URL=http://sidecar:8080/llm",
+          "-e",
+          `MODEL_API_KEY=${PLACEHOLDER_JWT}`,
+          "-e",
+          "SIDECAR_URL=http://sidecar:8080",
+          "-e",
+          `SIDECAR_AUTH_TOKEN=${SIDECAR_AUTH_TOKEN}`,
+          // Both the system prompt and the run's single user turn — no
+          // `startMessage`, so the run is exactly one inference call.
+          "-e",
+          "AGENT_PROMPT=Stop immediately.",
+          PI_IMAGE,
+        ]);
+        expect(pi.status, `docker run pi failed: ${pi.stderr}`).toBe(0);
+
+        const start = Date.now();
+        for (;;) {
+          if (finalizeBodies.length > 0) break;
+          if (Date.now() - start > DEADLINE_MS) {
+            throw new Error(
+              `run did not finalize within ${DEADLINE_MS}ms.\n` +
+                `upstream=${JSON.stringify(upstreamRequests.map((r) => `${r.method} ${r.path}`))}\n` +
+                `unmatched=${JSON.stringify(unmatchedRequests)}\n` +
+                `sidecar logs:\n${dumpContainerLogs(sidecarName).slice(-3000)}\n` +
+                `pi logs:\n${dumpContainerLogs(piName).slice(-3000)}`,
+            );
+          }
+          await new Promise((r) => setTimeout(r, 500));
+        }
+
+        expect(unmatchedRequests).toEqual([]);
+        expect(tokenReadAuthorization).toBe(`Bearer ${RUN_TOKEN}`);
+        expect(upstreamRequests).toHaveLength(1);
+
+        const request = upstreamRequests[0]!;
+        expect(request.method).toBe("POST");
+        // `resolveCodexUrl` appends `/codex/responses`; the sidecar maps
+        // `/llm/codex/responses` onto `${llm.baseUrl}/codex/responses`.
+        expect(request.path).toBe("/upstream/codex/responses");
+
+        // The bearer swap: the real subscription token arrives, and the
+        // placeholder the container carried appears in NO header at all.
+        expect(request.headers.authorization).toBe(`Bearer ${REAL_ACCESS_TOKEN}`);
+        expect(Object.values(request.headers).some((v) => v.includes(PLACEHOLDER_JWT))).toBe(false);
+
+        // Pi's own Codex fingerprint, forwarded verbatim — the sidecar forges
+        // none of it, it only passes it through.
+        expect(request.headers["chatgpt-account-id"]).toBe(ACCOUNT_ID);
+        expect(request.headers.originator).toBe("pi");
+        expect(request.headers["openai-beta"]).toBe("responses=experimental");
+        expect(request.headers.accept).toBe("text/event-stream");
+        expect(request.headers["content-type"]).toStartWith("application/json");
+        expect(request.headers["user-agent"]).toBeTruthy();
+
+        // Container→sidecar-only headers must stop at the sidecar: the agent's
+        // own auth token has no business reaching the model provider.
+        expect(request.headers[SIDECAR_AUTH_HEADER]).toBeUndefined();
+        expect(request.headers[PI_SDK_VERSION_HEADER]).toBeUndefined();
+
+        // Pinned deliberately. zstd on the SSE path is the one thing the
+        // subscription path does that nothing else does, and it is what #1195
+        // corrupted. If a Pi bump stops compressing, this gate must go red so
+        // the leg is re-examined consciously rather than quietly losing the
+        // only coverage of it.
+        expect(request.headers["content-encoding"]).toBe("zstd");
+
+        // A successful decode + parse IS the byte-identity witness: zstd is a
+        // checksummed binary frame, so a sidecar that text-decodes it (#1195)
+        // cannot produce anything that survives this line.
+        const body = JSON.parse(zstdDecompressSync(request.bodyBytes).toString("utf8"));
+        expect(body.model).toBe(MODEL_ID);
+        expect(body.store).toBe(false);
+        expect(body.stream).toBe(true);
+        expect(typeof body.instructions).toBe("string");
+        expect(body.instructions.length).toBeGreaterThan(0);
+        expect(Array.isArray(body.input)).toBe(true);
+        expect(body.input.length).toBeGreaterThan(0);
+        expect(Array.isArray(body.tools)).toBe(true);
+
+        // The turn actually completed — the canned SSE frame was parsed by the
+        // real runner, not just accepted at the socket.
+        const finalize = JSON.parse(finalizeBodies[0]!);
+        expect(finalize.status).toBe("success");
+      } finally {
+        docker(["rm", "-f", sidecarName, piName]);
+        docker(["network", "rm", networkName]);
+      }
+    },
+    DEADLINE_MS + 30_000,
+  );
+});

--- a/runtime-pi/test/inference-container.e2e.test.ts
+++ b/runtime-pi/test/inference-container.e2e.test.ts
@@ -34,13 +34,13 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { spawnSync } from "node:child_process";
 import { zstdDecompressSync } from "node:zlib";
 import { SIDECAR_AUTH_HEADER } from "@appstrate/core/sidecar-types";
-import { PI_SDK_VERSION_HEADER } from "@appstrate/runner-pi/provider-map";
 import {
   buildAgentBundle,
   codexPlaceholderJwt,
+  docker,
+  dockerRun,
   dumpContainerLogs,
   resolveContainerE2eGate,
 } from "./helpers/container-e2e.ts";
@@ -76,6 +76,13 @@ interface CapturedRequest {
 /**
  * The canned Codex SSE completion — enough for the Pi run loop to finish its
  * one turn and finalize `success`. Same frame as `pi-runner-transport.test.ts`.
+ *
+ * `output: []` is load-bearing, not just brevity: the sidecar advertises
+ * `run_history` and `recall_memory` to the model (`runtime-pi/sidecar/mcp.ts`),
+ * so a frame carrying a tool call would send the agent to
+ * `GET /internal/run-history` or `/internal/memories`, which the stub below
+ * deliberately does not serve — a surprise call must stay a failure, and it
+ * shows up as the offending path in `unmatchedRequests`.
  */
 function completedSseBody(): string {
   return `data: ${JSON.stringify({
@@ -94,15 +101,12 @@ function completedSseBody(): string {
   })}\n\n`;
 }
 
-function docker(args: string[]): ReturnType<typeof spawnSync> {
-  return spawnSync("docker", args, { encoding: "utf8" });
-}
-
 describe.skipIf(!RUN)("runtime-pi + sidecar images carry one inference turn verbatim", () => {
   let server: ReturnType<typeof Bun.serve> | undefined;
-  const networkName = `appstrate-e2e-inference-net-${Date.now()}`;
-  const sidecarName = `appstrate-e2e-inference-sidecar-${Date.now()}`;
-  const piName = `appstrate-e2e-inference-pi-${Date.now()}`;
+  const stamp = Date.now();
+  const networkName = `appstrate-e2e-inference-net-${stamp}`;
+  const sidecarName = `appstrate-e2e-inference-sidecar-${stamp}`;
+  const piName = `appstrate-e2e-inference-pi-${stamp}`;
 
   const upstreamRequests: CapturedRequest[] = [];
   /** Anything the stub did not expect, so a surprising call shows up in the failure. */
@@ -178,105 +182,75 @@ describe.skipIf(!RUN)("runtime-pi + sidecar images carry one inference turn verb
       const port = server!.port;
       const platformUrl = `http://host.docker.internal:${port}`;
       const sinkBase = `${platformUrl}/api/runs/${RID}`;
-      // `daemon` is non-null whenever RUN is true. Pin it explicitly so a
-      // DOCKER_DEFAULT_PLATFORM override cannot re-route the run to a foreign
-      // platform behind the gate's back (#882).
-      const platformArgs = daemon !== null ? ["--platform", daemon] : [];
 
       const network = docker(["network", "create", networkName]);
       expect(network.status, `docker network create failed: ${network.stderr}`).toBe(0);
 
       try {
-        // The sidecar answers the agent on the DNS alias `sidecar`, exactly as
-        // the platform's Docker orchestrator wires it in production.
-        const sidecar = docker([
-          "run",
-          "-d",
-          "--name",
-          sidecarName,
-          ...platformArgs,
-          "--network",
-          networkName,
-          "--network-alias",
-          "sidecar",
-          "--add-host",
-          "host.docker.internal:host-gateway",
-          "-e",
-          "PORT=8080",
-          "-e",
-          `RUN_ID=${RID}`,
-          "-e",
-          `RUN_TOKEN=${RUN_TOKEN}`,
-          "-e",
-          `PLATFORM_API_URL=${platformUrl}`,
-          "-e",
-          `SIDECAR_AUTH_TOKEN=${SIDECAR_AUTH_TOKEN}`,
-          "-e",
-          `PI_LLM_OAUTH_CONFIG_JSON=${JSON.stringify({
-            authMode: "oauth",
-            baseUrl: `${platformUrl}/upstream`,
-            credentialId: CREDENTIAL_ID,
-          })}`,
-          // Mandatory: `host.docker.internal` resolves into a private range, so
-          // without this operator allowlist the sidecar's SSRF gate answers 403
-          // "Resolved OAuth base URL targets a blocked network range" before
-          // any request leaves. The platform forwards the same var in prod.
-          "-e",
-          "EGRESS_ALLOW_INTERNAL_HOSTS=host.docker.internal",
-          SIDECAR_IMAGE,
-        ]);
+        const sidecar = dockerRun({
+          name: sidecarName,
+          image: SIDECAR_IMAGE,
+          // Non-null whenever RUN is true; `dockerRun` pins it on the argv.
+          platform: daemon,
+          network: networkName,
+          // The sidecar answers the agent on the DNS alias `sidecar`, exactly
+          // as the platform's Docker orchestrator wires it in production.
+          networkAlias: "sidecar",
+          env: {
+            PORT: "8080",
+            RUN_ID: RID,
+            RUN_TOKEN,
+            PLATFORM_API_URL: platformUrl,
+            SIDECAR_AUTH_TOKEN,
+            PI_LLM_OAUTH_CONFIG_JSON: JSON.stringify({
+              authMode: "oauth",
+              baseUrl: `${platformUrl}/upstream`,
+              credentialId: CREDENTIAL_ID,
+            }),
+            // Mandatory: `host.docker.internal` resolves into a private range,
+            // so without this operator allowlist the sidecar's SSRF gate
+            // answers 403 "Resolved OAuth base URL targets a blocked network
+            // range" before any request leaves. The platform forwards the same
+            // var in prod.
+            EGRESS_ALLOW_INTERNAL_HOSTS: "host.docker.internal",
+          },
+        });
         expect(sidecar.status, `docker run sidecar failed: ${sidecar.stderr}`).toBe(0);
 
-        const pi = docker([
-          "run",
-          "-d",
-          "--name",
-          piName,
-          ...platformArgs,
-          "--network",
-          networkName,
-          "--add-host",
-          "host.docker.internal:host-gateway",
-          "-e",
-          `AGENT_RUN_ID=${RID}`,
-          "-e",
-          `APPSTRATE_SINK_URL=${sinkBase}/events`,
-          "-e",
-          `APPSTRATE_SINK_FINALIZE_URL=${sinkBase}/events/finalize`,
-          "-e",
-          `APPSTRATE_SINK_SECRET=${SINK_SECRET}`,
-          "-e",
-          "MODEL_API=openai-codex-responses",
-          "-e",
-          `MODEL_ID=${MODEL_ID}`,
-          "-e",
-          "MODEL_PROVIDER=codex",
-          "-e",
-          "MODEL_BASE_URL=http://sidecar:8080/llm",
-          "-e",
-          `MODEL_API_KEY=${PLACEHOLDER_JWT}`,
-          "-e",
-          "SIDECAR_URL=http://sidecar:8080",
-          "-e",
-          `SIDECAR_AUTH_TOKEN=${SIDECAR_AUTH_TOKEN}`,
-          // Both the system prompt and the run's single user turn — no
-          // `startMessage`, so the run is exactly one inference call.
-          "-e",
-          "AGENT_PROMPT=Stop immediately.",
-          PI_IMAGE,
-        ]);
+        const pi = dockerRun({
+          name: piName,
+          image: PI_IMAGE,
+          platform: daemon,
+          network: networkName,
+          env: {
+            AGENT_RUN_ID: RID,
+            APPSTRATE_SINK_URL: `${sinkBase}/events`,
+            APPSTRATE_SINK_FINALIZE_URL: `${sinkBase}/events/finalize`,
+            APPSTRATE_SINK_SECRET: SINK_SECRET,
+            MODEL_API: "openai-codex-responses",
+            MODEL_ID,
+            MODEL_PROVIDER: "codex",
+            MODEL_BASE_URL: "http://sidecar:8080/llm",
+            MODEL_API_KEY: PLACEHOLDER_JWT,
+            SIDECAR_URL: "http://sidecar:8080",
+            SIDECAR_AUTH_TOKEN,
+            // Both the system prompt and the run's single user turn — no
+            // `startMessage`, so the run is exactly one inference call.
+            AGENT_PROMPT: "Stop immediately.",
+          },
+        });
         expect(pi.status, `docker run pi failed: ${pi.stderr}`).toBe(0);
 
         const start = Date.now();
         for (;;) {
           if (finalizeBodies.length > 0) break;
           if (Date.now() - start > DEADLINE_MS) {
+            // Both containers' logs are appended by the `catch` below, which
+            // covers every failure in here, not just this one.
             throw new Error(
-              `run did not finalize within ${DEADLINE_MS}ms.\n` +
+              `run did not finalize within ${DEADLINE_MS}ms\n` +
                 `upstream=${JSON.stringify(upstreamRequests.map((r) => `${r.method} ${r.path}`))}\n` +
-                `unmatched=${JSON.stringify(unmatchedRequests)}\n` +
-                `sidecar logs:\n${dumpContainerLogs(sidecarName).slice(-3000)}\n` +
-                `pi logs:\n${dumpContainerLogs(piName).slice(-3000)}`,
+                `unmatched=${JSON.stringify(unmatchedRequests)}`,
             );
           }
           await new Promise((r) => setTimeout(r, 500));
@@ -304,12 +278,17 @@ describe.skipIf(!RUN)("runtime-pi + sidecar images carry one inference turn verb
         expect(request.headers["openai-beta"]).toBe("responses=experimental");
         expect(request.headers.accept).toBe("text/event-stream");
         expect(request.headers["content-type"]).toStartWith("application/json");
-        expect(request.headers["user-agent"]).toBeTruthy();
+        // Pi's own UA, `getPiUserAgent()`: `pi (<platform> <release>; <arch>)`,
+        // or `pi (browser)` off Node. Assert the prefix rather than mere
+        // presence — Bun's fetch supplies a `Bun/<version>` UA when a request
+        // carries none, so `toBeTruthy()` would hold even had the header never
+        // crossed the container boundary.
+        expect(request.headers["user-agent"]).toStartWith("pi (");
 
-        // Container→sidecar-only headers must stop at the sidecar: the agent's
-        // own auth token has no business reaching the model provider.
+        // The container→sidecar-only header must stop at the sidecar: the
+        // agent's own auth token has no business reaching the model provider.
+        // (Verified: a beta.51 sidecar really did leak it upstream.)
         expect(request.headers[SIDECAR_AUTH_HEADER]).toBeUndefined();
-        expect(request.headers[PI_SDK_VERSION_HEADER]).toBeUndefined();
 
         // Pinned deliberately. zstd on the SSE path is the one thing the
         // subscription path does that nothing else does, and it is what #1195
@@ -319,8 +298,11 @@ describe.skipIf(!RUN)("runtime-pi + sidecar images carry one inference turn verb
         expect(request.headers["content-encoding"]).toBe("zstd");
 
         // A successful decode + parse IS the byte-identity witness: zstd is a
-        // checksummed binary frame, so a sidecar that text-decodes it (#1195)
-        // cannot produce anything that survives this line.
+        // framed binary format — magic number, frame descriptor, block headers —
+        // and a text round-trip replaces every byte above U+007F, so a sidecar
+        // that decodes the body as text (#1195) cannot produce anything
+        // `zstdDecompressSync` accepts, let alone anything `JSON.parse` and the
+        // field assertions behind it survive.
         const body = JSON.parse(zstdDecompressSync(request.bodyBytes).toString("utf8"));
         expect(body.model).toBe(MODEL_ID);
         expect(body.store).toBe(false);
@@ -329,12 +311,22 @@ describe.skipIf(!RUN)("runtime-pi + sidecar images carry one inference turn verb
         expect(body.instructions.length).toBeGreaterThan(0);
         expect(Array.isArray(body.input)).toBe(true);
         expect(body.input.length).toBeGreaterThan(0);
-        expect(Array.isArray(body.tools)).toBe(true);
 
         // The turn actually completed — the canned SSE frame was parsed by the
         // real runner, not just accepted at the socket.
         const finalize = JSON.parse(finalizeBodies[0]!);
         expect(finalize.status).toBe("success");
+      } catch (err) {
+        // Every failure in here — a missed assertion as much as the deadline —
+        // is a statement about what the two containers did, and the `finally`
+        // below is about to delete them, so this is the last chance to read
+        // their logs. Capped, because a boot loop can print megabytes.
+        if (err instanceof Error) {
+          err.message +=
+            `\n\nsidecar logs:\n${dumpContainerLogs(sidecarName).slice(-3000)}` +
+            `\n\npi logs:\n${dumpContainerLogs(piName).slice(-3000)}`;
+        }
+        throw err;
       } finally {
         docker(["rm", "-f", sidecarName, piName]);
         docker(["network", "rm", networkName]);

--- a/runtime-pi/test/pi-runner-transport.test.ts
+++ b/runtime-pi/test/pi-runner-transport.test.ts
@@ -8,6 +8,7 @@ import type { PiModelConfig } from "@appstrate/runner-pi";
 import { SIDECAR_AUTH_HEADER } from "@appstrate/core/sidecar-types";
 import { createApp, type AppDeps } from "../sidecar/app.ts";
 import { createRuntimePiRunner } from "../pi-runner.ts";
+import { codexPlaceholderJwt } from "./helpers/container-e2e.ts";
 import {
   createCaptureSink,
   makeBundlePackage,
@@ -20,21 +21,11 @@ interface ObservedRequest {
   path: string;
 }
 
-const TEST_JWT = [
-  encodeJwtSegment({ alg: "none", typ: "JWT" }),
-  encodeJwtSegment({
-    "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" },
-  }),
-  "placeholder",
-].join(".");
+const TEST_JWT = codexPlaceholderJwt("acct_test");
 
 const TEST_BUNDLE = makeTestBundle(
   makeBundlePackage("@test/runtime-sidecar-transport", "0.0.0", "agent", {}),
 );
-
-function encodeJwtSegment(value: unknown): string {
-  return btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
-}
 
 function completedResponse(): Response {
   return new Response(

--- a/runtime-pi/test/provision-container.e2e.test.ts
+++ b/runtime-pi/test/provision-container.e2e.test.ts
@@ -23,9 +23,10 @@
  */
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { spawnSync } from "node:child_process";
 import {
   buildAgentBundle,
+  docker,
+  dockerRun,
   dumpContainerLogs,
   resolveContainerE2eGate,
 } from "./helpers/container-e2e.ts";
@@ -83,7 +84,7 @@ describe.skipIf(!RUN)("runtime-pi container provisions files without spinning", 
 
   afterAll(() => {
     server?.stop(true);
-    if (containerName) spawnSync("docker", ["rm", "-f", containerName], { stdio: "ignore" });
+    if (containerName) docker(["rm", "-f", containerName]);
   });
 
   it(
@@ -92,48 +93,26 @@ describe.skipIf(!RUN)("runtime-pi container provisions files without spinning", 
       const port = server!.port;
       const host = `http://host.docker.internal:${port}/api/runs/${RID}`;
       containerName = `appstrate-e2e-provision-${Date.now()}`;
-      // Detached: the container runs independently of this test process, so no
-      // long-lived child keeps Bun alive. We poll the sink, then `rm -f`.
-      const run = spawnSync(
-        "docker",
-        [
-          "run",
-          "-d",
-          "--name",
-          containerName,
-          // Pin to the engine's native platform (which the gate above
-          // guarantees the local image matches, mirroring how the platform's
-          // Docker orchestrator launches this image in production). Explicit
-          // rather than omitted: a DOCKER_DEFAULT_PLATFORM env override would
-          // otherwise re-route the run to a foreign platform behind the
-          // gate's back (#882). `daemon` is non-null whenever RUN is true.
-          ...(daemon !== null ? ["--platform", daemon] : []),
-          // Linux portability — Docker Desktop adds this automatically, but CI
-          // engines need it explicit.
-          "--add-host",
-          "host.docker.internal:host-gateway",
-          "-e",
-          `AGENT_RUN_ID=${RID}`,
-          "-e",
-          `APPSTRATE_SINK_URL=${host}/events`,
-          "-e",
-          `APPSTRATE_SINK_FINALIZE_URL=${host}/events/finalize`,
-          "-e",
-          `APPSTRATE_SINK_SECRET=${SECRET}`,
-          "-e",
-          "MODEL_API=anthropic-messages",
-          "-e",
-          "MODEL_ID=claude-sonnet-4-6",
-          "-e",
-          `MODEL_BASE_URL=http://host.docker.internal:${port}/llm`,
-          "-e",
-          "MODEL_API_KEY=test",
-          "-e",
-          "AGENT_PROMPT=Stop immediately.",
-          IMAGE,
-        ],
-        { encoding: "utf8" },
-      );
+      const run = dockerRun({
+        name: containerName,
+        image: IMAGE,
+        // The engine's native platform, which the gate above guarantees the
+        // local image matches — mirroring how the platform's Docker
+        // orchestrator launches this image in production. `daemon` is non-null
+        // whenever RUN is true.
+        platform: daemon,
+        env: {
+          AGENT_RUN_ID: RID,
+          APPSTRATE_SINK_URL: `${host}/events`,
+          APPSTRATE_SINK_FINALIZE_URL: `${host}/events/finalize`,
+          APPSTRATE_SINK_SECRET: SECRET,
+          MODEL_API: "anthropic-messages",
+          MODEL_ID: "claude-sonnet-4-6",
+          MODEL_BASE_URL: `http://host.docker.internal:${port}/llm`,
+          MODEL_API_KEY: "test",
+          AGENT_PROMPT: "Stop immediately.",
+        },
+      });
       expect(run.status, `docker run failed: ${run.stderr}`).toBe(0);
 
       try {
@@ -154,7 +133,7 @@ describe.skipIf(!RUN)("runtime-pi container provisions files without spinning", 
         }
         expect(events.some((e) => e.includes("workspace initialized"))).toBe(true);
       } finally {
-        spawnSync("docker", ["rm", "-f", containerName], { stdio: "ignore" });
+        docker(["rm", "-f", containerName]);
       }
     },
     DEADLINE_MS + 15_000,

--- a/runtime-pi/test/provision-container.e2e.test.ts
+++ b/runtime-pi/test/provision-container.e2e.test.ts
@@ -24,95 +24,16 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { zipArtifact } from "@appstrate/core/zip";
 import {
-  extractRootFromAfps,
-  buildBundleFromCatalog,
-  writeBundleToBuffer,
-  emptyPackageCatalog,
-} from "@appstrate/afps-runtime/bundle";
+  buildAgentBundle,
+  dumpContainerLogs,
+  resolveContainerE2eGate,
+} from "./helpers/container-e2e.ts";
 
 const IMAGE = process.env.PI_IMAGE ?? "appstrate-pi:latest";
 const DEADLINE_MS = 60_000;
 
-function hasDocker(): boolean {
-  try {
-    return spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
-  } catch {
-    return false;
-  }
-}
-/**
- * `os/arch` from a docker `--format` template (e.g. "linux/arm64"), or null
- * when the command fails (daemon down, image absent) or prints something
- * unexpected. Both templates below emit Go's GOOS/GOARCH vocabulary, so the
- * two results are directly comparable.
- */
-function dockerPlatform(args: string[]): string | null {
-  try {
-    const out = spawnSync("docker", args, { encoding: "utf8" });
-    if (out.status !== 0) return null;
-    const platform = out.stdout.trim();
-    return /^[a-z0-9]+\/[a-z0-9]+$/.test(platform) ? platform : null;
-  } catch {
-    return null;
-  }
-}
-/** Platform the Docker engine runs containers on natively. */
-function daemonPlatform(): string | null {
-  return dockerPlatform(["version", "--format", "{{.Server.Os}}/{{.Server.Arch}}"]);
-}
-/** Platform the local image was built for, or null when the image is absent. */
-function imagePlatform(): string | null {
-  return dockerPlatform(["image", "inspect", IMAGE, "--format", "{{.Os}}/{{.Architecture}}"]);
-}
-
-// Opt-in gate: TEST_DOCKER=1 locally, CI=true on GitHub Actions (set
-// automatically). Mirrors the rule in apps/api/test/helpers/tier.ts.
-const dockerEnabled = process.env.TEST_DOCKER === "1" || process.env.CI === "true";
-
-// The `docker run` below uses the engine's native platform, so the gate must
-// check more than image presence: a bare `docker image inspect` is
-// architecture-blind, and an image built for another platform (e.g. an amd64
-// build left over on an Apple Silicon host) would pass it and then fail inside
-// `docker run` with a misleading "pull access denied" (#882). Require the
-// image's platform to match the daemon's and skip honestly otherwise.
-const daemon = dockerEnabled && hasDocker() ? daemonPlatform() : null;
-const image = daemon !== null ? imagePlatform() : null;
-const RUN = daemon !== null && image === daemon;
-if (dockerEnabled && !RUN) {
-  const hint =
-    image !== null && daemon !== null && image !== daemon
-      ? ` — rebuild natively: docker build --platform ${daemon} -t ${IMAGE} -f runtime-pi/Dockerfile .`
-      : "";
-  console.warn(
-    `[provision-container.e2e] skipped — docker=${hasDocker()} image(${IMAGE})=${image ?? "absent"} daemon=${daemon ?? "unknown"}${hint}`,
-  );
-}
-
-/**
- * Minimal valid agent `.afps-bundle` (the multi-package archive with
- * `bundle.json` that the platform's `/workspace` route serves and the runtime
- * reads via `readBundleFromFile`). A raw single-package `.afps` is rejected
- * with `BUNDLE_JSON_MISSING`.
- */
-async function buildAgentBundle(): Promise<Uint8Array> {
-  const manifest = {
-    name: "@e2e/provision-probe",
-    version: "1.0.0",
-    type: "agent",
-    schema_version: "0.2",
-    display_name: "Provision Probe",
-    author: "e2e",
-  };
-  const afps = zipArtifact({
-    "manifest.json": new TextEncoder().encode(JSON.stringify(manifest)),
-    "prompt.md": new TextEncoder().encode("# probe\n\nStop immediately.\n"),
-  });
-  const root = extractRootFromAfps(afps);
-  const bundle = await buildBundleFromCatalog(root, emptyPackageCatalog, { depTypes: ["skills"] });
-  return writeBundleToBuffer(bundle);
-}
+const { run: RUN, daemon } = resolveContainerE2eGate("provision-container.e2e", [IMAGE]);
 
 describe.skipIf(!RUN)("runtime-pi container provisions files without spinning", () => {
   let server: ReturnType<typeof Bun.serve> | undefined;
@@ -222,9 +143,8 @@ describe.skipIf(!RUN)("runtime-pi container provisions files without spinning", 
         for (;;) {
           if (events.some((e) => e.includes("workspace initialized"))) break;
           if (Date.now() - start > DEADLINE_MS) {
-            const logs = spawnSync("docker", ["logs", containerName], { encoding: "utf8" });
             throw new Error(
-              `no post-provisioning event within ${DEADLINE_MS}ms — runtime likely spun in provisionFiles.\nevents=${JSON.stringify(events).slice(0, 500)}\ncontainer logs:\n${(logs.stdout ?? "") + (logs.stderr ?? "")}`.slice(
+              `no post-provisioning event within ${DEADLINE_MS}ms — runtime likely spun in provisionFiles.\nevents=${JSON.stringify(events).slice(0, 500)}\ncontainer logs:\n${dumpContainerLogs(containerName)}`.slice(
                 0,
                 1500,
               ),


### PR DESCRIPTION
Closes #1197.

## Why

No CI job exercised **inference** through the built runtime images. `Runtime container e2e` — the only job that builds the real `appstrate-pi` — ran `provision-container.e2e.test.ts` alone: workspace provisioning, no model request, and no sidecar image at all.

#1195 showed what that leaves open. It was not a code regression: pi-ai compresses the Codex request body with zstd on the SSE path (`content-encoding: zstd`), and a sidecar predating #1166 text-decoded that body while buffering it. Each half was correct against its own source tree; only the **pair** failed. Every in-process test stayed green, because every in-process test wires the two halves together from one checkout — the configuration that never breaks.

The recadrage on the issue is the spec: no subscription credential is needed. Build both images from the same commit, drive one model call through the sidecar to a fake upstream, and assert that the body arrives byte-identical — zstd included.

## What this adds

**`runtime-pi/test/inference-container.e2e.test.ts`** — launches the built `appstrate-pi` + `appstrate-sidecar` on a private Docker network (the agent reaches the sidecar on its `sidecar` DNS alias, as the platform's Docker orchestrator wires it), serves a stub platform on the host (sink + workspace routes, `/internal/oauth-token/:id`, and a stub Codex upstream that records every request), and drives one Codex OAuth turn with the placeholder JWT the platform would put in `MODEL_API_KEY`. It then asserts what reached the upstream:

- exactly one `POST /codex/responses`, over SSE (`accept: text/event-stream`);
- the real subscription bearer swapped in, and the container's placeholder JWT present in **no** header;
- Pi's own fingerprint forwarded verbatim — `chatgpt-account-id`, `originator: pi`, `OpenAI-Beta: responses=experimental`, a `pi (…)` User-Agent;
- `x-appstrate-sidecar-auth` stripped (the agent↔sidecar secret must stop at the sidecar);
- `content-encoding: zstd`, **pinned deliberately** — if a Pi bump stops compressing, the gate goes red so the leg is re-examined consciously instead of quietly losing its only coverage;
- the body decompresses and parses, with `model` / `store: false` / `stream: true` / `instructions` / `input` as pi-ai builds them. A successful decode is the byte-identity witness: a sidecar that text-decodes the frame (#1195) cannot produce one;
- the run finalizes `success` — the canned SSE frame was parsed by the real runner, not merely accepted at the socket.

**`runtime-pi/test/helpers/container-e2e.ts`** — the gate (`TEST_DOCKER`/`CI`, docker up, every image present and native, #882), the `docker run` argv, the agent `.afps-bundle`, the log dump and the placeholder JWT, lifted out of `provision-container.e2e.test.ts` and `pi-runner-transport.test.ts` so both container suites share one definition. A copied gate is a gate that drifts.

**`.github/workflows/test.yml`** — `Runtime container e2e` now builds the sidecar image too and runs both suites. Same label-OR-main policy (`e2e` label pre-merge, always on `main`); the pi build alone takes ~40 s on the runner, the sidecar build is comparable, so the 20-minute budget stands.

## Negative control

Run against `ghcr.io/appstrate/appstrate-sidecar:1.0.0-beta.51` — built the day before #1166 landed — the gate fails on two real defects: the zstd body arrives with `content-encoding: zstd` but does not decode (`Unknown frame descriptor`, the #1195 signature), and that sidecar also leaked `x-appstrate-sidecar-auth` to the provider. Against today's pair: green.

Two assertions the first revision carried were found to be tautologies in review and removed: `x-appstrate-pi-sdk` is only ever attached on the alias provider path, and `user-agent: toBeTruthy()` is satisfied by Bun's own default UA. Both would have been green whatever the images did — exactly the kind of gate this PR exists to replace.

## Not in scope

- A semantic refusal by the real upstream (a field ChatGPT stops accepting). Only a real credential would see it; excluded by `docs/architecture/SUBSCRIPTION_COMPLIANCE.md`.
- `module-claude-code`'s request shape. Same mechanism, different prelude; a follow-up once this gate has run on `main`.
- The agent's sink traffic rides `host.docker.internal` here rather than the sidecar's forward proxy; that leg has its own coverage and is not what the pair gate is for.

## Verification

| | |
|---|---|
| `inference-container.e2e` + `provision-container.e2e`, local pair (arm64) | 2 pass, 0 fail |
| Same, without `TEST_DOCKER` | 6 skip, 0 docker spawns |
| Same, against sidecar `1.0.0-beta.51` (pre-#1166) | fails on `x-appstrate-sidecar-auth` leaked; zstd body `Unknown frame descriptor` |
| `runtime-pi/test/` full | 171 pass |
| `pi-runner-transport.test.ts` after the helper extraction | 1 pass |
| `bun run lint`, `tsc --noEmit` (runtime-pi), `verify:dead-code`, `actionlint`, prettier | clean |

Carries the `e2e` label so the job runs on this PR rather than first on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
