### PR TITLE
fix(roles): bound and deduplicate a custom role's permission array

### DIFF
--- a/apps/api/src/services/space-roles.ts
+++ b/apps/api/src/services/space-roles.ts
@@ -110,23 +110,46 @@ export async function listSpaceRoles(orgId: string): Promise<SpaceRoleWire[]> {
 }
 
 /**
+ * What a write actually stores: every entry known, each one once.
+ *
  * An unknown permission is a REFUSAL, never a silent drop: a role created with
  * a typo would 403 on the thing its author asked for and say nothing about why.
  * Naming the first offender is enough — the array is authored in a picker.
+ *
+ * The vocabulary is also the array's ceiling, in both directions. Duplicates
+ * are what let a body name three permissions in twenty thousand entries, and
+ * the stored array is re-walked on every request of every holder
+ * (`spacePermissions`, and once per space in `GET /api/spaces`), so they are
+ * collapsed here rather than carried forever; a body longer than the whole
+ * vocabulary can hold nothing but duplicates and is refused before it is
+ * walked. Deriving the bound from `known` rather than picking a number keeps it
+ * exact under any set of loaded modules.
  */
-function assertKnownPermissions(permissions: string[]): void {
-  if (permissions.length === 0) {
-    throw invalidRequest("A role must grant at least one permission", "permissions");
-  }
+function normalizePermissions(permissions: string[]): string[] {
   const known = knownSpaceLevelPermissions();
-  const unknown = permissions.find((p) => !known.has(p));
-  if (unknown !== undefined) {
+  if (permissions.length > known.size) {
     throw invalidRequest(
-      `Unknown space-level permission '${unknown}'. ` +
+      `A role can hold at most ${known.size} permissions — the whole vocabulary — ` +
+        `and this list has ${permissions.length}. ` +
         `See GET /api/roles/vocabulary for the permissions a role can hold.`,
       "permissions",
     );
   }
+  const granted = new Set<string>();
+  for (const permission of permissions) {
+    if (!known.has(permission)) {
+      throw invalidRequest(
+        `Unknown space-level permission '${permission}'. ` +
+          `See GET /api/roles/vocabulary for the permissions a role can hold.`,
+        "permissions",
+      );
+    }
+    granted.add(permission);
+  }
+  if (granted.size === 0) {
+    throw invalidRequest("A role must grant at least one permission", "permissions");
+  }
+  return [...granted];
 }
 
 /** The DB CHECK backs this; a constraint violation would be a 500 naming nothing readable. */
@@ -167,7 +190,7 @@ export async function createSpaceRole(params: {
 }): Promise<SpaceRoleWire> {
   const { orgId, createdBy, input } = params;
   assertNotPresetKey(input.key);
-  assertKnownPermissions(input.permissions);
+  const permissions = normalizePermissions(input.permissions);
   await assertKeyFree(orgId, input.key);
 
   const [row] = await db
@@ -178,7 +201,7 @@ export async function createSpaceRole(params: {
       key: input.key,
       name: input.name,
       description: input.description ?? null,
-      permissions: input.permissions,
+      permissions,
       createdBy,
     })
     .returning()
@@ -197,7 +220,8 @@ export async function updateSpaceRole(params: {
     assertNotPresetKey(patch.key);
     await assertKeyFree(orgId, patch.key, id);
   }
-  if (patch.permissions !== undefined) assertKnownPermissions(patch.permissions);
+  const permissions =
+    patch.permissions !== undefined ? normalizePermissions(patch.permissions) : undefined;
 
   const [row] = await db
     .update(spaceRoles)
@@ -205,7 +229,7 @@ export async function updateSpaceRole(params: {
       ...(patch.key !== undefined ? { key: patch.key } : {}),
       ...(patch.name !== undefined ? { name: patch.name } : {}),
       ...(patch.description !== undefined ? { description: patch.description } : {}),
-      ...(patch.permissions !== undefined ? { permissions: patch.permissions } : {}),
+      ...(permissions !== undefined ? { permissions } : {}),
       updatedAt: new Date(),
     })
     .where(and(eq(spaceRoles.id, id), eq(spaceRoles.orgId, orgId)))

--- a/apps/api/test/integration/routes/roles.test.ts
+++ b/apps/api/test/integration/routes/roles.test.ts
@@ -209,6 +209,30 @@ describe("custom space roles", () => {
       });
     });
 
+    it("stores each permission once, and refuses a list longer than the vocabulary", async () => {
+      // Duplicates are what let a body name one permission in an unbounded
+      // number of entries, and the stored array is re-walked on every request
+      // of every holder — so the ceiling is the vocabulary, and it is the
+      // vocabulary the route reports, not a number this test restates.
+      const { data } = (await (await req("GET", "/api/roles/vocabulary")).json()) as {
+        data: { permissions: { permission: string }[] }[];
+      };
+      const size = data.flatMap((g) => g.permissions).length;
+
+      const atCeiling = Array.from({ length: size }, () => "agents:read");
+      const created = await post(validBody({ key: "at-ceiling", permissions: atCeiling }));
+      expect(created.status).toBe(201);
+      expect(((await created.json()) as RoleWire).permissions).toEqual(["agents:read"]);
+
+      // One entry more than the whole vocabulary can only be duplicates.
+      const over = await post(
+        validBody({ key: "over-ceiling", permissions: [...atCeiling, "agents:read"] }),
+      );
+      expect((await expectProblem(over, 400, { param: "permissions" })).detail).toContain(
+        String(size),
+      );
+    });
+
     it("refuses every preset key and accepts a free one", async () => {
       // Reserved by the code guard AND by `space_roles_key_not_preset`; a
       // preset the constraint does not list would answer 201 here and shadow


### PR DESCRIPTION
Closes #1342

## Root cause

`space_roles.permissions` was validated as `z.array(z.string().min(1))` with no length bound (`apps/api/src/routes/roles.ts:43`, `:52`) and stored verbatim by `createSpaceRole`/`updateSpaceRole` (`apps/api/src/services/space-roles.ts`). `assertKnownPermissions` already refused an *unknown* string, but nothing refused the same *known* string repeated: `{ permissions: [ …20 000 × "agents:read"… ] }` was a 201, and the stored array is then re-walked on every request of every holder — `spacePermissions()` (`apps/api/src/lib/space-role.ts:68`) and once per space in `loadSpaceMemberships()` for `GET /api/spaces`.

## Fix

`assertKnownPermissions` becomes `normalizePermissions(permissions): string[]`, the single write-time normaliser both `createSpaceRole` and `updateSpaceRole` now store the result of:

- **Dedupe** — the walk accumulates into a `Set`, so a bundle stores each permission once. This is what makes the stored array bounded *by construction*: every entry must be in the vocabulary, and no entry appears twice, so `permissions.length ≤ knownSpaceLevelPermissions().size` forever.
- **Ceiling** — a body longer than the whole vocabulary can hold nothing but duplicates and is refused (400, `param: "permissions"`, naming both numbers) *before* it is walked.
- Unknown-string refusal and the empty-list refusal are unchanged in behaviour and in message.

The bound is **derived from `knownSpaceLevelPermissions()`, not a chosen constant**: modules contribute space-level permissions at boot, so a hand-picked `.max(N)` in the Zod schema would be both a second (wronger) bound and a cap that could refuse a legitimate "grant everything" role on a module-heavy deployment. Keeping it in the service — where the vocabulary is already loaded — leaves exactly one bound, exact under any `MODULES`. No route contract change, so no OpenAPI/api-types churn.

**No data repair script.** Custom roles shipped with #1260 and are not deployed, and unknown strings were already refused at write, so there is no stored array to normalise retroactively.

## Tests

`apps/api/test/integration/routes/roles.test.ts` — one new test, `stores each permission once, and refuses a list longer than the vocabulary`, paired as the file's discipline requires: an array of `size` duplicates → 201 storing `["agents:read"]`, and `size + 1` → 400 naming the size. It reads `size` from `GET /api/roles/vocabulary` rather than restating a number.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test \
  apps/api/test/integration/routes/roles.test.ts \
  apps/api/test/integration/routes/space-member-management.test.ts \
  apps/api/test/unit/permissions.test.ts
→ 55 pass, 0 fail (335 expect() calls)

bunx tsc --noEmit -p apps/api → clean
bunx eslint + prettier on both touched files → clean
```

Negative control: with the ceiling short-circuited and the `Set` bypassed, the new test fails on both halves (48 stored duplicates, no 400) — it discriminates.

## Notes for the orchestrator

- **Overlap with #1343** (custom bundle reports permissions it does not grant / cannot be edited as stored): none in the diff. #1343 owns the read/write asymmetry — `toWire` reporting the stored array while `spacePermissions()` filters it against the live vocabulary — which survives this change, since a module unloading can still make a stored string unknown. This PR only makes the stored array short and duplicate-free; #1343 can build on `normalizePermissions` if it wants a shared normaliser.
- No migration (platform 0063 stayed unused — a Zod bound plus dedupe at write time was enough, and a DB constraint could not express "one entry per vocabulary member" without pinning the vocabulary into SQL), no env var, no deploy ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
