### PR TITLE
fix(ee): refuse to attach a subscription Stripe has already ended

### DIFF
--- a/packages/module-ee/src/stripe/webhooks.ts
+++ b/packages/module-ee/src/stripe/webhooks.ts
@@ -10,6 +10,7 @@ import { logger } from "../logger.ts";
 import {
   getPlans,
   isPlanId,
+  ENDED_SUBSCRIPTION_STATUSES,
   HELD_SUBSCRIPTION_STATUSES,
   type Plans,
   type PlanDefinition,
@@ -108,12 +109,26 @@ function unattachedAccount(orgId: string): SQL {
 /**
  * The predicate for `checkout.session.completed` and `invoice.paid`: they carry
  * AUTHORITATIVE data and also write the account already carrying that subscription.
+ *
+ * `noHeldSubscription()` deliberately matches a cancelled account, so this predicate alone
+ * does NOT prove the subscription is alive — callers MUST first gate on the live object
+ * from Stripe ({@link isEndedSubscription}), or a late event re-attaches a dead id.
  */
 function attachableSubscription(orgId: string, subscriptionId: string): SQL {
   return and(
     eq(billingAccounts.orgId, orgId),
     or(noHeldSubscription(), eq(billingAccounts.stripeSubscriptionId, subscriptionId)),
   )!;
+}
+
+/**
+ * A subscription Stripe will never bill again. The event payload cannot decide this — it
+ * freezes at emission and Stripe guarantees no delivery order, so a `checkout.session.completed`
+ * delivered after the cancellation still describes a live subscription. Only the retrieved
+ * object does, which is why both attach paths retrieve before granting entitlements.
+ */
+function isEndedSubscription(subscription: Stripe.Subscription): boolean {
+  return ENDED_SUBSCRIPTION_STATUSES.has(subscription.status);
 }
 
 /** One line for an event on a subscription this org is not on — a replacement's tail. */
@@ -127,6 +142,21 @@ function logSupersededSubscription(
     type: event.type,
     orgId,
     subscriptionId,
+  });
+}
+
+/** One line for an attach refused because Stripe no longer holds the subscription. */
+function logEndedSubscription(
+  event: Stripe.Event,
+  orgId: string,
+  subscription: Stripe.Subscription,
+): void {
+  logger.warn("Stripe event skipped — subscription has ended, no entitlement granted", {
+    eventId: event.id,
+    type: event.type,
+    orgId,
+    subscriptionId: subscription.id,
+    status: subscription.status,
   });
 }
 
@@ -243,6 +273,27 @@ async function processEvent(event: Stripe.Event): Promise<void> {
         break;
       }
 
+      // The session froze at completion; Stripe may have cancelled the subscription since
+      // (deliveries are unordered). Retrieve the live object BEFORE granting: throwing on
+      // failure deletes the claim so Stripe retries, as on the invoice.paid path — the
+      // grant is billing-critical and must not proceed on unverified state.
+      let checkoutSubscription: Stripe.Subscription;
+      try {
+        checkoutSubscription = await getStripe().subscriptions.retrieve(subscriptionId);
+      } catch (err) {
+        logger.error("Failed to retrieve subscription for checkout attach", {
+          eventId: event.id,
+          subscriptionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        throw err;
+      }
+
+      if (isEndedSubscription(checkoutSubscription)) {
+        logEndedSubscription(event, orgId, checkoutSubscription);
+        break;
+      }
+
       const [linked] = await db
         .update(billingAccounts)
         .set({
@@ -250,7 +301,9 @@ async function processEvent(event: Stripe.Event): Promise<void> {
           creditQuota: plan.creditQuota,
           stripeCustomerId: customerId,
           stripeSubscriptionId: subscriptionId,
-          subscriptionStatus: "active",
+          // The live status, not a hardcoded "active": a checkout that opens a trial is
+          // `trialing`, and the row must not claim a state Stripe does not hold.
+          subscriptionStatus: checkoutSubscription.status,
           updatedAt: new Date(),
         })
         .where(attachableSubscription(orgId, subscriptionId))
@@ -271,19 +324,10 @@ async function processEvent(event: Stripe.Event): Promise<void> {
       // the periodic resync repairs a miss).
       await syncOrgStorageEntitlement(orgId);
 
-      // Email: subscription confirmation — retrieve real period end from Stripe
-      let checkoutPeriodEnd: Date | null = null;
-      try {
-        const sub = await getStripe().subscriptions.retrieve(subscriptionId);
-        checkoutPeriodEnd = subscriptionPeriodEnd(sub);
-      } catch {
-        // Best-effort — send email without precise date if Stripe call fails
-      }
-
       sendBillingEmail(orgId, "subscription-confirmed", {
         planName: plan.name,
         price: plan.monthlyPrice,
-        periodEnd: (checkoutPeriodEnd ?? new Date()).toISOString(),
+        periodEnd: (subscriptionPeriodEnd(checkoutSubscription) ?? new Date()).toISOString(),
         locale: "fr",
       });
       break;
@@ -392,6 +436,13 @@ async function processEvent(event: Stripe.Event): Promise<void> {
         break;
       }
       const { orgId } = metadata;
+
+      // Same guard as the checkout attach: an invoice settled after the cancellation must
+      // not re-attach the dead subscription with a fresh quota.
+      if (isEndedSubscription(subscription)) {
+        logEndedSubscription(event, orgId, subscription);
+        break;
+      }
 
       const plan = planForSubscription(subscription, plans);
       if (!plan) {

--- a/packages/module-ee/test/integration/services/webhooks.test.ts
+++ b/packages/module-ee/test/integration/services/webhooks.test.ts
@@ -60,6 +60,88 @@ describe("handleWebhook", () => {
       // Quota allocated immediately at checkout (no wait for invoice.paid).
       expect(account!.creditQuota).toBe(20000);
     });
+
+    it("refuses to attach a subscription Stripe has already cancelled", async () => {
+      // Post-`customer.subscription.deleted` state: free, no held subscription, 0 credits.
+      await seedBillingAccount({
+        orgId,
+        planId: "free",
+        stripeCustomerId: "cus_dead_001",
+        stripeSubscriptionId: null,
+        subscriptionStatus: null,
+        creditQuota: 0,
+      });
+
+      // The session froze before the cancellation; Stripe's live object says otherwise.
+      setSubscriptionResponse({
+        id: "sub_dead_001",
+        object: "subscription",
+        status: "canceled",
+        metadata: { orgId, planId: "starter" },
+        items: { object: "list", data: [{ id: "si_dead", price: { id: "price_starter_test" } }] },
+      });
+
+      const { body, signature } = signedEvent({
+        id: "evt_checkout_dead_001",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            customer: "cus_dead_001",
+            subscription: "sub_dead_001",
+            metadata: { orgId, planId: "starter" },
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+
+      const db = getEeDb();
+      const [account] = await db
+        .select()
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId));
+
+      expect(account!.planId).toBe("free");
+      expect(account!.stripeSubscriptionId).toBeNull();
+      expect(account!.subscriptionStatus).toBeNull();
+      expect(account!.creditQuota).toBe(0);
+    });
+
+    it("records the live subscription status, not a hardcoded active", async () => {
+      await seedBillingAccount({ orgId, creditQuota: 0 });
+
+      setSubscriptionResponse({
+        id: "sub_trial_001",
+        object: "subscription",
+        status: "trialing",
+        metadata: { orgId, planId: "starter" },
+        items: { object: "list", data: [{ id: "si_trial", price: { id: "price_starter_test" } }] },
+      });
+
+      const { body, signature } = signedEvent({
+        id: "evt_checkout_trial_001",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            customer: "cus_trial_checkout_001",
+            subscription: "sub_trial_001",
+            metadata: { orgId, planId: "starter" },
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+
+      const db = getEeDb();
+      const [account] = await db
+        .select()
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId));
+
+      expect(account!.subscriptionStatus).toBe("trialing");
+      expect(account!.stripeSubscriptionId).toBe("sub_trial_001");
+      expect(account!.creditQuota).toBe(20000);
+    });
   });
 
   describe("customer.subscription.created", () => {
@@ -341,6 +423,51 @@ describe("handleWebhook", () => {
 
       expect(account!.creditsUsed).toBe(500);
       expect(account!.creditQuota).toBe(20000);
+    });
+
+    it("grants nothing when the paid invoice belongs to a cancelled subscription", async () => {
+      await seedBillingAccount({
+        orgId,
+        planId: "free",
+        stripeCustomerId: "cus_invoice_dead",
+        stripeSubscriptionId: null,
+        subscriptionStatus: null,
+        creditsUsed: 0,
+        creditQuota: 0,
+      });
+
+      setSubscriptionResponse({
+        id: "sub_invoice_dead",
+        object: "subscription",
+        status: "canceled",
+        metadata: { orgId, planId: "starter" },
+        items: { object: "list", data: [{ id: "si_dead", price: { id: "price_starter_test" } }] },
+      });
+
+      const { body, signature } = signedEvent({
+        id: "evt_invoice_dead_001",
+        type: "invoice.paid",
+        data: {
+          object: {
+            id: "in_dead_001",
+            customer: "cus_invoice_dead",
+            billing_reason: "subscription_cycle",
+            parent: { subscription_details: { subscription: "sub_invoice_dead" } },
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+
+      const db = getEeDb();
+      const [account] = await db
+        .select()
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId));
+
+      expect(account!.planId).toBe("free");
+      expect(account!.stripeSubscriptionId).toBeNull();
+      expect(account!.creditQuota).toBe(0);
     });
   });
 


### PR DESCRIPTION
Closes #1323

## Root cause

`packages/module-ee/src/stripe/webhooks.ts` — `attachableSubscription()` (`:112` on main) is the shared attach predicate for `checkout.session.completed` and `invoice.paid`. Its `noHeldSubscription()` arm deliberately matches a cancelled account (only `customer.subscription.deleted` NULLs `stripeSubscriptionId`), so the org's *next* paid checkout is not dropped — but neither handler ever consulted the subscription's live state. A `checkout.session.completed` delivered after the cancellation therefore re-attached the **dead** id with `subscriptionStatus: "active"` and the plan's full `creditQuota` (`:246-256` on main). `invoice.paid` has the identical hole through the same predicate: a paid invoice for a cancelled subscription re-attached it and reset the credit counter.

## Fix

Both attach paths now gate on the subscription retrieved from Stripe — the event payload freezes at emission and Stripe guarantees no delivery order, so only the retrieved object can decide this. One shared predicate `isEndedSubscription()` over the existing `ENDED_SUBSCRIPTION_STATUSES` (`canceled`, `incomplete_expired`) from `src/config.ts`, plus one `logEndedSubscription()` line next to the existing `logSupersededSubscription()`.

- `checkout.session.completed`: the `subscriptions.retrieve` it already made *after* the write (for the confirmation email's period end) moves **before** the write and becomes the gate. Its failure now throws instead of being swallowed — that deletes the event claim so Stripe retries, exactly the reasoning already documented on the `invoice.paid` retrieve; the grant is billing-critical and must not proceed on unverified state. No second Stripe call is added: the email reuses the same object.
- `checkout.session.completed` also records `checkoutSubscription.status` instead of a hardcoded `"active"` — with the authoritative object in hand there is no reason for the row to claim a state Stripe does not hold (a checkout that opens a trial is `trialing`). This mirrors `customer.subscription.created`, which already writes the live status.
- `invoice.paid`: same guard right after org resolution.
- `attachableSubscription()`'s doc comment now states the obligation, so the next caller does not repeat the omission.

No tombstone table: Stripe's live state already carries the cancellation and also covers `incomplete_expired` and cases where the `deleted` event was never received, so extra state would be a second, weaker source of truth.

## Tests

`packages/module-ee/test/integration/services/webhooks.test.ts` — 3 regression tests: checkout on a cancelled subscription leaves the free account untouched; checkout records `trialing` rather than `active`; `invoice.paid` on a cancelled subscription grants nothing.

Negative control: with the guard reverted, exactly those 3 fail (27 pass / 3 fail); with the fix, green.

```
pg-test-lock.sh sh -c '. ./.env && bun test packages/module-ee/test'
  → 434 pass, 26 skip, 0 fail (460 tests, 31 files)
bunx tsc --noEmit -p packages/module-ee   → clean
bunx eslint / prettier on both touched files → clean
```

## Notes for the orchestrator

- No migration, no env var, no OpenAPI change. Deploy ordering unaffected.
- Behaviour change worth a release note: a paid invoice for an already-cancelled subscription no longer re-grants quota. That is the documented anti-abuse stance of the `customer.subscription.deleted` handler ("credits are NOT re-granted… users who need credits again must contact support"), now enforced on the attach side too.
- Overlap: #1331 (`Stripe.Card` cast) lives in the same file but in the `customer.source.expiring` case — no textual overlap. #1324 (`updates` missing `creditQuota` in `customer.subscription.updated`) and #1325 (concurrent checkouts) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
