### PR TITLE
fix(connect): stop rendering error messages verbatim on session-less connect popups

### DIFF
--- a/apps/api/src/openapi/paths/integrations.ts
+++ b/apps/api/src/openapi/paths/integrations.ts
@@ -1015,7 +1015,7 @@ export const integrationsPaths = {
         },
         "403": {
           description:
-            "The space has no OAuth client registered for this auth and none could be auto-provisioned; the page names the action to take (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint.",
+            "The space has no OAuth client registered for this auth and none could be auto-provisioned; the page says the failure is permanent and to ask an administrator, while the operator-facing detail naming the exact remedy stays on the server log — this route carries no session (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint.",
         },
         "410": { description: "Invalid, expired, or already-used token (HTML error page)." },
         "500": {

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -482,9 +482,15 @@ export function createIntegrationsRouter() {
         });
         return c.html(popupHtmlError(userMessage, { state }));
       }
-      const msg = err instanceof Error ? err.message : "OAuth callback failed";
-      logger.error("Integration OAuth callback failed", { msg });
-      return c.html(popupHtmlError(`Error: ${msg}`, { state }));
+      // Not an `OAuthCallbackError`, so nothing authored this message for a
+      // reader: it is a DB fault, a TypeError, an SSRF refusal. Same rule as
+      // the branch above and as `/connect/start` (issue #1345) — this page is
+      // session-less, so the text goes to the log and the user gets the
+      // generic sentence.
+      logger.error("Integration OAuth callback failed", { err: String(err) });
+      return c.html(
+        popupHtmlError("Could not complete the connection. Please try again.", { state }),
+      );
     }
 
     // Persist via the OAuth2 strategy. The exchange above reconstructed the
@@ -968,12 +974,18 @@ export function createIntegrationsRouter() {
       //
       //  1. A client-side `ApiError` (4xx): the space has no OAuth client for
       //     this auth, auto-DCR against the provider was refused, the manifest
-      //     declares no issuer/endpoints. Permanent until someone acts, and the
-      //     `detail` names that action — the same message the programmatic
-      //     `POST …/connect/oauth2` already returns as its 403. Render it with
-      //     its own status, and hand the jti back: nothing was minted on the
-      //     strength of this click, so a retry once the admin has registered
-      //     the client can reuse the very same link instead of re-minting.
+      //     declares no issuer/endpoints. Permanent until someone acts — say
+      //     so, with its own status, so the popup does not invite a pointless
+      //     retry. Say it GENERICALLY though (issue #1345): this route carries
+      //     no session and its link is handed to end users outside the org,
+      //     while the `detail` that names the action names it in operator
+      //     terms — a client row id, `CONNECTION_ENCRYPTION_KEY`, an upstream
+      //     AS's own prose. That half stays on the log line above, exactly as
+      //     the callback keeps a provider's `error_description` there
+      //     (`oauth-error-diagnostic.ts`). Hand the jti back either way:
+      //     nothing was minted on the strength of this click, so a retry once
+      //     the admin has registered the client can reuse the very same link
+      //     instead of re-minting.
       //  2. Anything else (provider discovery error, network, an unexpected
       //     throw): transient or unknown. Keep the generic wording, keep the
       //     502, keep the jti burned — an unknown failure may have gone half
@@ -1001,9 +1013,13 @@ export function createIntegrationsRouter() {
             authKey: claims.auth_key,
           });
           await releaseJti(claims.jti);
-          // `err.message` is the problem `detail` — the public half of an
-          // ApiError by contract (never `cause`), and popupHtmlError escapes it.
-          return c.html(popupHtmlError(err.message, {}), err.status as ContentfulStatusCode);
+          return c.html(
+            popupHtmlError(
+              "This integration is not ready to be connected. Ask an administrator to finish setting it up, then open this link again.",
+              {},
+            ),
+            err.status as ContentfulStatusCode,
+          );
         }
         logger.error("Hosted connect OAuth begin failed", {
           err: String(err),

--- a/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
+++ b/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
@@ -18,7 +18,7 @@ import { truncateAll, db } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { eq } from "drizzle-orm";
-import { integrationConnections } from "@appstrate/db/schema";
+import { integrationConnections, integrationOauthClients } from "@appstrate/db/schema";
 import type { IntegrationManifest } from "@appstrate/core/integration";
 
 const app = getTestApp();
@@ -355,7 +355,7 @@ async function startConnect(token: string): Promise<Response> {
   });
 }
 
-describe("hosted connect portal — oauth2 dispatch without a client (issue #1263)", () => {
+describe("hosted connect portal — oauth2 dispatch without a client (issues #1263, #1345)", () => {
   let ctx: TestContext;
   beforeEach(async () => {
     await truncateAll();
@@ -363,17 +363,19 @@ describe("hosted connect portal — oauth2 dispatch without a client (issue #126
     await seedIntegration(ctx.orgId, oauthManifest("@myorg/gsuite"));
   });
 
-  it("renders the actionable 403 the programmatic path returns, not a generic 502", async () => {
+  it("renders a permanent 403, not a generic 502 — and not the operator detail", async () => {
     const token = await mintSession(ctx, "@myorg/gsuite", "google");
     const res = await startConnect(token);
-    // Parity with `POST …/connect/oauth2` on the same space: same status, same
-    // detail, naming the action to take.
+    // Status parity with `POST …/connect/oauth2` on the same space, and wording
+    // that says "permanent": no "try again", which is what a 502 would invite.
     expect(res.status).toBe(403);
     expect(res.headers.get("content-type")).toContain("text/html");
     const html = await res.text();
-    expect(html).toContain("Administrator must register OAuth client credentials");
-    expect(html).toContain("@myorg/gsuite");
+    expect(html).toContain("Ask an administrator");
     expect(html).not.toContain("Please try again");
+    // The `detail` that names the remedy is written for an operator, and this
+    // route has no session (issue #1345) — it belongs in the log line only.
+    expect(html).not.toContain("Administrator must register OAuth client credentials");
   });
 
   it("keeps the link reusable: a second click is the same 403, not 'already used'", async () => {
@@ -409,15 +411,47 @@ describe("hosted connect portal — oauth2 dispatch without a client (issue #126
     expect((await startConnect(token)).status).toBe(410);
   });
 
-  it("renders the auto-provisioning failure verbatim for a remote MCP auth", async () => {
+  it("keeps the auto-provisioning failure's own prose off a remote MCP popup", async () => {
     await seedIntegration(ctx.orgId, remoteMcpManifest("@myorg/remote-mcp"));
     const token = await mintSession(ctx, "@myorg/remote-mcp", "oauth");
     const res = await startConnect(token);
     expect(res.status).toBe(403);
     const html = await res.text();
-    // The remedy authored by the provisioning step reaches the user — the
-    // message the generic catch used to swallow.
-    expect(html).toContain("Could not automatically provision an OAuth client");
-    expect(html).toContain("@myorg/remote-mcp");
+    expect(html).toContain("Ask an administrator");
+    // This `detail` embeds the authorization server's OWN message verbatim
+    // (`resolveConnectClient` renders `provisioningFailure.message` as-is), so
+    // it is upstream-controlled text on a session-less page. Log only.
+    expect(html).not.toContain("Could not automatically provision an OAuth client");
+    expect(html).not.toContain("dynamic client registration");
+  });
+
+  it("never names the row or the env var when a client_secret cannot be decrypted", async () => {
+    // The ciphertext no longer opens (key rotated without re-encrypt, or
+    // corruption): `has_client_secret` still reads true from the column while
+    // the decrypt yields "", and `assertConnectClientUsable` refuses the
+    // client with a 403 whose detail names the client row's uuid and
+    // `CONNECTION_ENCRYPTION_KEY`. That is the disclosure of issue #1345.
+    const registered = await app.request(
+      "/api/integrations/@myorg/gsuite/auths/google/oauth-clients",
+      {
+        method: "POST",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ client_id: "abc", client_secret: "shh" }),
+      },
+    );
+    expect(registered.status).toBe(201);
+    const clientId = ((await registered.json()) as { id: string }).id;
+    await db
+      .update(integrationOauthClients)
+      .set({ clientSecretEncrypted: "not-a-valid-envelope" })
+      .where(eq(integrationOauthClients.id, clientId));
+
+    const res = await startConnect(await mintSession(ctx, "@myorg/gsuite", "google"));
+    expect(res.status).toBe(403);
+    const html = await res.text();
+    expect(html).toContain("Ask an administrator");
+    for (const internal of ["CONNECTION_ENCRYPTION_KEY", "cannot be decrypted", clientId]) {
+      expect(html).not.toContain(internal);
+    }
   });
 });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -11003,7 +11003,7 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description The space has no OAuth client registered for this auth and none could be auto-provisioned; the page names the action to take (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint. */
+            /** @description The space has no OAuth client registered for this auth and none could be auto-provisioned; the page says the failure is permanent and to ask an administrator, while the operator-facing detail naming the exact remedy stays on the server log — this route carries no session (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint. */
             403: {
                 headers: {
                     [name: string]: unknown;


### PR DESCRIPTION
Closes #1345

## Root cause

`GET /api/integrations/connect/start` is session-less and its link is handed to
end users outside the org, but `apps/api/src/routes/integrations.ts:1006`
rendered the raw `ApiError.message` from `strategy.begin` into the popup. That
`detail` is written for an operator, so three reachable messages disclosed
internals:

- `integration-connections.ts:977` — `OAuth client '<uuid>' … cannot be
  decrypted … Restore the CONNECTION_ENCRYPTION_KEY …` (row id + env var name +
  "a key-rotation/decrypt failure is in progress").
- `integration-connections.ts:1051` — auto-provisioning failure, which embeds
  the upstream authorization server's **own prose** verbatim.
- `integration-connections.ts:1057` — names the package/auth key.

The same class of defect sat one handler above at `:487` on the equally
session-less `/callback`: the non-`OAuthCallbackError` fallback rendered
`Error: ${err.message}` — any DB fault, TypeError or SSRF refusal.

## Fix

Both sites now render a generic sentence and keep the detail on the log line
that was already there — the rule `oauth-error-diagnostic.ts` states for the
provider's `error_description` on this same surface.

- `/connect/start`, 4xx branch: `"This integration is not ready to be connected.
  Ask an administrator to finish setting it up, then open this link again."`
  Everything #1302 added is kept: the ApiError status (403 ≠ 502, so the popup
  still reads "permanent" instead of inviting a pointless retry) and
  `releaseJti` (the link stays reusable).
- `/callback` generic branch: `"Could not complete the connection. Please try
  again."`, matching the `OAuthCallbackError` branch beside it.

No new helper: the "public sentence in the page, operator detail in the log"
split is the existing doctrine here, and inventing a public/operator field on
`ApiError` for two call sites would be debt, not DRY.

Deliberately **not** changed: `:526`, where the `identity_mismatch` detail is
surfaced on purpose. It does name the other account, so it is a disclosure
judgement of its own — a product decision, not this issue's mechanism.

The issue's secondary claim — that a third-party AS `error_description` is
echoed on `/callback` — is stale: `oauth-error-diagnostic.ts` already refuses
free text and appends only the RFC 6749 code. The upstream prose did leak, but
through `provisioningFailure.message` on `/connect/start`, which this PR closes.

## Tests

`apps/api/test/integration/routes/integrations-hosted-connect.test.ts` — the two
#1302 tests that asserted the verbatim render are inverted, and one is added for
the issue's headline case (a client row whose ciphertext no longer opens):

- `renders a permanent 403, not a generic 502 — and not the operator detail`
- `keeps the auto-provisioning failure's own prose off a remote MCP popup`
- `never names the row or the env var when a client_secret cannot be decrypted`

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test \
  apps/api/test/integration/routes/integrations-hosted-connect.test.ts \
  apps/api/test/integration/routes/integrations.test.ts \
  apps/api/test/integration/routes/integration-oauth-flow.test.ts \
  apps/api/test/integration/routes/integrations-connect-run-errors.test.ts \
  packages/core/test/connect-handshake.test.ts
→ 130 pass, 0 fail (635 expect() calls)
```

Negative control: with the one-line render reverted, exactly those 3 tests fail
(12 pass / 3 fail) — they are not vacuous `not.toContain` assertions.

`bunx tsc --noEmit -p apps/api` and `-p apps/web` clean; `bun run
verify:openapi` all checks passed; `bunx eslint` / `prettier --check` clean on
every touched file.

## Notes for the orchestrator

- No migration, no env var.
- **OpenAPI**: the `403` description on `/api/integrations/connect/start` said
  "the page names the action to take", which the fix makes false, so it was
  rewritten. That drifted `verify:api-types`; `bun run generate:api` was run and
  `apps/web/src/api/schema.d.ts` is committed (a one-line description change, no
  type change). Not a breaking change — no baseline regenerated.
- **Overlap with #1346**: unavoidable, same call site. #1346 changes
  `popupHtmlError`'s **second** argument (`{}` → `{ packageId }`); this PR
  changes the **first**. They compose, but a rebase will conflict on that
  statement — take both edits. My tests deliberately assert nothing about
  whether the package id appears in the page, so #1346 will not break them.
- **Overlap with #1352**: none textually. #1352 moves the `try` opening earlier
  (`:910`); the branch bodies I touched are inside it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
