### PR TITLE
fix(cli): apply an organization revocation instead of failing the skills sync

### DIFF
--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -11,6 +11,7 @@
 
 import { mapWithConcurrency } from "@appstrate/core/map-with-concurrency";
 import { resolveActiveProfile, type Profile } from "../lib/config.ts";
+import { ApiError } from "../lib/api.ts";
 import { listSpaces, resolveSpaceRef, type Space } from "../lib/spaces.ts";
 import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
 import { formatError } from "../lib/ui.ts";
@@ -583,6 +584,42 @@ function unusableReason(space: Space): string {
 }
 
 /**
+ * The spaces this profile reaches, or `null` when the organization no longer
+ * lets it reach any.
+ *
+ * `GET /api/spaces` answers 403 to a caller the pinned organization does not
+ * admit: `orgContext` refuses one with no membership row ("You are not a member
+ * of this organization"), and `requirePermission("spaces", "read")` refuses one
+ * whose org role cannot read the catalog. Either way the server has stated that
+ * this profile draws no skills from this organization any more — a REVOCATION,
+ * which the sync must APPLY, not a fault to retry. Reported as a fault it exits
+ * 1, and under `--print-path` Claude Code then discards the run and keeps
+ * serving the stale plugin, so an offboarded machine kept every one of that
+ * organization's skills forever (issue #1362).
+ *
+ * Only 403 is a statement about this profile's grants. A 401 is about the
+ * SESSION — `apiFetch` turns it into a re-login `AuthError` after a refresh
+ * attempt, and a lapsed login must never take working skills away (same reason
+ * `bootstrapPlugin` keeps an existing plugin) — and a 5xx or a network error is
+ * a fault that leaves the tree untouched.
+ */
+async function reachableSpaces(
+  profileName: string,
+  profile: Profile,
+  report: Report,
+): Promise<Space[] | null> {
+  try {
+    return await listSpaces(profileName);
+  } catch (err) {
+    if (!(err instanceof ApiError) || err.status !== 403) throw err;
+    report.note(
+      `Organization "${profile.orgId}" no longer grants this profile access to its spaces (403) — removing every skill synced from it. Run: appstrate org switch`,
+    );
+    return null;
+  }
+}
+
+/**
  * Which spaces supply skills. The default is every space this profile is a
  * MEMBER of with `skills:read` there: being granted a space is what puts its
  * skills on the machine, and losing one is what takes them off again — neither
@@ -598,7 +635,10 @@ async function selectedSpaces(
   explicit: string[] | undefined,
   report: Report,
 ): Promise<string[]> {
-  const spaces = await listSpaces(profileName);
+  const spaces = await reachableSpaces(profileName, profile, report);
+  // The organization revoked this profile: no space supplies skills any more,
+  // so the ordinary removal plan takes every one of them off the disk.
+  if (!spaces) return [];
   // Skill sources no longer depend on the pin, so a pin that died would sync
   // clean and leave `.mcp.json` naming a space the server will refuse. Nothing
   // else notices any more: say it here, where the space list is already in hand.

--- a/apps/cli/test/skills-command.test.ts
+++ b/apps/cli/test/skills-command.test.ts
@@ -1243,6 +1243,18 @@ async function snapshot(root: string): Promise<Record<string, string>> {
  * therefore not be a skill source. */
 const MEMBER = { access: "member" as const, permissions: ["skills:read"] };
 
+/**
+ * Answer `GET /api/spaces` with a problem detail, serving everything else — the
+ * shape the platform sends when it refuses the listing outright.
+ */
+function failSpaceListing(status: number): void {
+  const serve = globalThis.fetch;
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) =>
+    new URL(String(input)).pathname === "/api/spaces"
+      ? Response.json({ status, title: "Forbidden", code: "forbidden" }, { status })
+      : serve(input, init)) as unknown as typeof fetch;
+}
+
 describe("skills sync — multiple spaces", () => {
   it("never sources a listed space this member never joined", async () => {
     // The org lists its `closed` spaces to every member so they can ask to be
@@ -1277,6 +1289,41 @@ describe("skills sync — multiple spaces", () => {
     await expect(skillsSyncCommand({}, io)).rejects.toBeInstanceOf(ExitError);
 
     expect(stderr()).toContain("older than the CLI");
+    expect(await readdir(join(pluginRoot(), "skills"))).toEqual(["pdf-tools"]);
+  });
+
+  it("removes every synced skill when the organization has revoked this profile", async () => {
+    // Offboarding deletes the membership row and nothing else — the CLI's
+    // refresh token survives it — so the profile still authenticates and
+    // `GET /api/spaces` answers 403. That is the server stating the grants are
+    // gone, and applying it is the point: reported as a fault it exited 1 and
+    // left the ex-member's machine holding every one of those skills forever,
+    // which under `--print-path` no amount of re-running ever cleared
+    // (issue #1362).
+    createSkillServer(ONE_SKILL).install();
+    await skillsSyncCommand({}, createMemoryIO().io);
+    expect(await readdir(join(pluginRoot(), "skills"))).toEqual(["pdf-tools"]);
+    failSpaceListing(403);
+    const { io, stderr } = createMemoryIO();
+
+    await skillsSyncCommand({}, io);
+
+    expect(stderr()).toContain("no longer grants this profile access to its spaces");
+    expect(await readdir(join(pluginRoot(), "skills"))).toEqual([]);
+  });
+
+  it("keeps every skill when the space listing fails for anything but a revocation", async () => {
+    // A 5xx says nothing about this profile's grants, so the tree is left
+    // exactly as it was and the run fails — the revocation branch must not
+    // widen into "the listing did not come back".
+    createSkillServer(ONE_SKILL).install();
+    await skillsSyncCommand({}, createMemoryIO().io);
+    failSpaceListing(503);
+    const { io, stderr } = createMemoryIO();
+
+    await expect(skillsSyncCommand({}, io)).rejects.toBeInstanceOf(ExitError);
+
+    expect(stderr()).not.toContain("no longer grants");
     expect(await readdir(join(pluginRoot(), "skills"))).toEqual(["pdf-tools"]);
   });
 


### PR DESCRIPTION
Closes #1362

## Root cause

`selectedSpaces` called `listSpaces` with no status discrimination (`apps/cli/src/commands/skills.ts:601` before this change), and the throw was caught by the whole-run handler at `:203-206` → `report.run` → exit 1. Every failure of `GET /api/spaces` was therefore a fault to retry, including the one that is a *statement about the caller's grants*.

Losing organization membership is exactly that statement. `DELETE /api/orgs/:orgId/members/:userId` → `removeMember` (`apps/api/src/services/organizations.ts:355`) deletes the membership row, the member's notifications, their space memberships and their schedules — and **nothing else**: no Better Auth session delete, no `revokeFamilyForUser`. So an offboarded user's CLI still authenticates fine, and `orgContext` (`apps/api/src/middleware/org-context.ts:64`) answers `403 "You are not a member of this organization"` — forever. Under `--print-path` (the marketplace `command` source) Claude Code discards the failing run each session and keeps serving the stale plugin, so the ex-employee's machine kept every one of that organization's skills indefinitely with nothing on any path to clear it.

## Fix

One new helper, `reachableSpaces`, between `selectedSpaces` and `listSpaces`: a 403 resolves to "no space supplies skills", which the ordinary removal plan then applies, with a `report.note` naming the remedy (`appstrate org switch`). No new deletion path — an empty source set is already a supported state, so the revocation reuses the machinery `suppliesSkills` uses for a *space*-level revocation. Everything else rethrows unchanged.

**Only 403, deliberately — not the 401/403 the issue proposed.** 403 is the server speaking about this profile's grants (no membership row, or an org role that cannot read the space catalog). A 401 is about the *session*: `apiFetch` already turns it into a re-login `AuthError` after a refresh attempt, and this file's existing doctrine is that a lapsed login must never take working skills away (`bootstrapPlugin`'s "an existing one is kept"). The evidence above closes the gap that would otherwise leave: offboarding provably produces 403, never 401, because member removal revokes no CLI token family. 5xx and network errors stay faults that leave the tree untouched.

## Tests

`apps/cli/test/skills-command.test.ts`, extending the existing `skills sync — multiple spaces` describe (+47 lines, one shared `failSpaceListing` helper):

- *removes every synced skill when the organization has revoked this profile* — sync, then 403 on `/api/spaces`: the run succeeds, the note is printed, `skills/` is empty.
- *keeps every skill when the space listing fails for anything but a revocation* — same setup with 503: `ExitError`, no note, the tree intact. Guards the branch against widening into "the listing did not come back".

```
cd apps/cli && TEST_TIER=0 bun test test/skills-command.test.ts   → 87 pass, 0 fail (261 expect)
bunx tsc --noEmit -p apps/cli                                     → clean
bunx eslint / prettier --check on both touched files              → clean
```

Negative control: with `err.status !== 403` flipped to `999` the revocation test fails with `process.exit(1) called` — the exact reported behaviour — so it exercises the fix rather than the setup.

## Notes for the orchestrator

- Based on `fix/issue-1320` (PR targets it, not `main`). That branch added `asSpace` in `apps/cli/src/lib/spaces.ts`; this change sits one layer up in `skills.ts` and does not touch it. The two are complementary and the distinction matters: #1320 refuses a *malformed* listing (a 200 that says nothing about standing, which must never be read as "member of nothing"), #1362 applies an *authoritative empty* one (a 403 that says exactly that).
- No migration, no env var, no OpenAPI change. CLI-only.
- Overlap with siblings: none. #1363 (`syncSpaces`) and #1364 (flock) touch other regions of the CLI; nothing here reads `syncSpaces` or the lock.
- Behaviour change worth a release note: a 403 space listing now *removes* skills and exits 0 where it used to exit 1 and remove nothing. That is the point of the issue, but it is the one case where a sync deletes on the strength of a server refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
