### PR TITLE
fix(deps): collapse the duplicate @better-auth/core and guard the single-instance invariant

### DIFF
--- a/apps/api/src/modules/oidc/services/enduser-token.ts
+++ b/apps/api/src/modules/oidc/services/enduser-token.ts
@@ -18,7 +18,7 @@
  */
 
 import * as jose from "jose";
-import { verifyJwsAccessToken } from "@better-auth/core/oauth2";
+import { verifyJwsAccessToken } from "better-auth/oauth2";
 import { getEnv } from "@appstrate/env";
 import type { OrgRole } from "@appstrate/core/permissions";
 import { logger } from "../../../lib/logger.ts";

--- a/apps/api/src/modules/oidc/test/integration/routes/realm-isolation.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/realm-isolation.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
-import { encodeBasicCredentials } from "@better-auth/core/oauth2";
+import { encodeBasicCredentials } from "better-auth/oauth2";
 import { eq } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { user as userTable, session as sessionTable } from "@appstrate/db/schema";

--- a/apps/api/src/modules/oidc/test/integration/services/oauth-flows.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/oauth-flows.test.ts
@@ -52,7 +52,7 @@ import {
   restoreProtectedResources,
 } from "../../../../../lib/protected-resources.ts";
 import { getMcpOrgResourceUri, orgIdFromMcpAudience } from "../../../../../lib/audiences.ts";
-import { encodeBasicCredentials } from "@better-auth/core/oauth2";
+import { encodeBasicCredentials } from "better-auth/oauth2";
 import { decodeJwt } from "jose";
 
 // The protected-resource registry is a process-wide singleton shared with the

--- a/apps/api/test/unit/better-auth-single-instance.test.ts
+++ b/apps/api/test/unit/better-auth-single-instance.test.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression for #1347 (and the bug #1295 fixed by hand): `@better-auth/core`
+ * must resolve to ONE copy for every consumer in `apps/api`'s import graph.
+ *
+ * `oauth2/verify.mjs` marks insufficient-scope errors in a module-level
+ * WeakSet, so `createInsufficientScopeError` (minted through `better-auth`)
+ * and `isInsufficientScopeError` (read by `@better-auth/oauth-provider` when
+ * building the step-up challenge) are only the same marker while both come
+ * from the same copy. #1295 was that invariant broken: `apps/api` pinned
+ * `jose ^6.2.12` while better-auth's transitive `jose` sat at 6.2.7, so bun
+ * materialised two peer instances of `@better-auth/core@1.7.3` and the MCP 403
+ * silently lost its `WWW-Authenticate` header.
+ *
+ * The behavioural half is covered by
+ * `src/modules/mcp/test/integration/mcp.test.ts` ("403s an authenticated
+ * caller lacking `mcp:read` with an `insufficient_scope` step-up challenge").
+ * What was unguarded — and is what this asserts — is the resolution itself,
+ * which depends on the peer graph rather than on any line of our code: it can
+ * split again on the next dependency bump, silently, with the code unchanged.
+ * `jose` is pinned in the root `overrides` (next to `zod`, which is why zod
+ * never split) so the peers cannot skew; this test is what notices if they do.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { dirname } from "node:path";
+
+/** Where `specifier` resolves to when imported from `fromDir`. */
+function resolveFrom(specifier: string, fromDir: string): string {
+  return Bun.resolveSync(specifier, fromDir);
+}
+
+/** The directory a package's own imports resolve from. */
+function packageDir(specifier: string, fromDir: string): string {
+  return dirname(resolveFrom(specifier, fromDir));
+}
+
+describe("better-auth instance identity", () => {
+  it("resolves one @better-auth/core for apps/api, better-auth and the oauth provider", () => {
+    const api = import.meta.dir;
+    const facade = packageDir("better-auth/oauth2", api);
+    const provider = packageDir("@better-auth/oauth-provider", api);
+
+    const fromApi = resolveFrom("@better-auth/core/oauth2", api);
+    const fromFacade = resolveFrom("@better-auth/core/oauth2", facade);
+    const fromProvider = resolveFrom("@better-auth/core/oauth2", provider);
+
+    expect(fromFacade).toBe(fromApi);
+    expect(fromProvider).toBe(fromApi);
+  });
+
+  it("resolves one better-auth, and one jose under it", () => {
+    const api = import.meta.dir;
+    const core = packageDir("@better-auth/core/oauth2", api);
+    const provider = packageDir("@better-auth/oauth-provider", api);
+
+    expect(resolveFrom("better-auth/oauth2", provider)).toBe(
+      resolveFrom("better-auth/oauth2", api),
+    );
+    expect(resolveFrom("jose", core)).toBe(resolveFrom("jose", api));
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -494,6 +494,7 @@
     "@ai-sdk/provider-utils": "^5.0.18",
     "@ai-sdk/react": "^4.0.51",
     "ai": "^7.0.48",
+    "jose": "6.2.12",
     "zod": "4.5.4",
   },
   "packages": {
@@ -2851,8 +2852,6 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@better-auth/oauth-provider/jose": ["jose@6.2.7", "", {}, "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w=="],
-
     "@conventional-changelog/git-client/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "@earendil-works/chord/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
@@ -2878,8 +2877,6 @@
     "@eslint/config-array/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "@modelcontextprotocol/sdk/hono": ["hono@4.12.32", "", {}, "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg=="],
-
-    "@modelcontextprotocol/sdk/jose": ["jose@6.2.4", "", {}, "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA=="],
 
     "@redocly/config/json-schema-to-ts": ["json-schema-to-ts@2.7.2", "", { "dependencies": { "@babel/runtime": "^7.18.3", "@types/json-schema": "^7.0.9", "ts-algebra": "^1.2.0" } }, "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ=="],
 
@@ -2924,8 +2921,6 @@
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "babel-plugin-macros/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
-
-    "better-auth/jose": ["jose@6.2.7", "", {}, "sha512-hq1OB1bALKfydZNoViyg6hPVGV4i93ny9Op+n4zP5RSf7SCZEXa/TsG2O3IEr7+WlHRTPnpqDmHfMH6qXAD60w=="],
 
     "better-call/@better-auth/utils": ["@better-auth/utils@0.5.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -21,6 +21,41 @@ const API_BARREL_BAN = {
   message:
     "Use the typed OpenAPI client from src/api/client.ts ($api / client) — the legacy fetch helpers are gone.",
 };
+// Supply-chain guard: the single-vendor Pi SDK. Shared so the `apps/api` block
+// below can re-state it — ESLint flat config REPLACES a rule across blocks
+// rather than merging it, so a later block that re-declares
+// `no-restricted-imports` for files this one already covers must carry every
+// pattern that still applies to them.
+const PI_SDK_BAN = {
+  // `**` (not `*`) so deep subpaths like pi-ai/dist/foo are caught.
+  group: ["@earendil-works/pi-*", "@earendil-works/pi-*/**"],
+  message:
+    "Import the Pi SDK only through the package-local pi-sdk barrel (pi-sdk.ts) — see docs/architecture/SUPPLY_CHAIN.md",
+};
+// Instance-identity guard. `@better-auth/core` modules hold state that is
+// private to the module copy — `oauth2/verify.mjs` marks insufficient-scope
+// errors in a module-level WeakSet — so a symbol must come from the SAME copy
+// as the better-auth code that reads it. Reaching for `@better-auth/core/*`
+// pins us to whichever copy the package manager happens to link for `apps/api`,
+// which is decided by the peer graph, not by us: #1295 was exactly that (two
+// copies split by a `jose` skew, the marker lookup missed, and the MCP 403 lost
+// its `WWW-Authenticate` step-up). `better-auth/*` re-exports the same symbols
+// from the copy better-auth itself uses, so it is right whatever the graph does.
+//
+// `utils/host` is the one exception, and it is carved out here rather than
+// disabled at the import site: `better-auth` re-exports no host classifier (its
+// own `utils/url.mjs` deliberately keeps the zod-carrying one out of the client
+// bundle), and `isLoopbackHost` is a pure predicate — no module state, so no
+// identity to get wrong. `oidc/services/redirect-uri.ts` needs the very
+// predicate DCR applies, and re-implementing it is the drift #1012 is about.
+const BETTER_AUTH_CORE_BAN = {
+  // Everything under `@better-auth/core`, except `@better-auth/core/utils/host`
+  // itself (deep subpaths of it stay banned). gitignore-style `group` can't
+  // re-include a child of an excluded prefix, so use a regex.
+  regex: "^@better-auth/core(?:/(?!utils/host$).*)?$",
+  message:
+    "Import better-auth symbols through the `better-auth/*` facade (e.g. better-auth/oauth2), not `@better-auth/core/*` — see #1295.",
+};
 // Every TypeScript file in the repo, minus the top-level `ignores` block below
 // (`**/dist`, `**/node_modules`, `.claude/`, the generated OpenAPI types).
 //
@@ -591,19 +626,20 @@ export default tseslint.config(
       parser: tseslint.parser,
     },
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              // `**` (not `*`) so deep subpaths like pi-ai/dist/foo are caught.
-              group: ["@earendil-works/pi-*", "@earendil-works/pi-*/**"],
-              message:
-                "Import the Pi SDK only through the package-local pi-sdk barrel (pi-sdk.ts) — see docs/architecture/SUPPLY_CHAIN.md",
-            },
-          ],
-        },
-      ],
+      "no-restricted-imports": ["error", { patterns: [PI_SDK_BAN] }],
+    },
+  },
+  {
+    // `apps/api` is the only workspace that depends on better-auth, so the
+    // instance-identity guard lives here. This block overlaps the Pi SDK block
+    // above on `apps/api/src/**` and therefore REPLACES its rule for those
+    // files — hence PI_SDK_BAN is restated, not dropped. Widened to
+    // `apps/api/**` so `test/` and the module-local `src/**/test/` dirs are
+    // covered too: a test that mints a marker from the wrong copy asserts the
+    // wrong thing.
+    files: ["apps/api/**/*.ts"],
+    rules: {
+      "no-restricted-imports": ["error", { patterns: [PI_SDK_BAN, BETTER_AUTH_CORE_BAN] }],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
   },
   "overrides": {
     "zod": "4.5.4",
+    "jose": "6.2.12",
     "ai": "^7.0.48",
     "@ai-sdk/react": "^4.0.51",
     "@ai-sdk/provider-utils": "^5.0.18"


### PR DESCRIPTION
Closes #1347

## Root cause

`@better-auth/core` carries `jose` as a **real peer**, so the version skew between `apps/api` (`jose: ^6.2.12`, `apps/api/package.json:47`, set by #1289) and better-auth's own transitive pin (6.2.7, `bun.lock`) made bun materialise two peer instances of `@better-auth/core@1.7.3`. Which copy a consumer links is decided by the peer graph, not by any line of our code — and `oauth2/verify.mjs` marks insufficient-scope errors in a **module-level WeakSet**, private to a copy. That is the bug #1295 fixed, one import site at a time (`apps/api/src/modules/mcp/router.ts:39-54`), leaving the invariant itself unguarded and one direct import still live at `apps/api/src/modules/oidc/services/enduser-token.ts:21`.

Reproduced in a clean worktree off `main`: `node_modules/.bun/` held `@better-auth+core@1.7.3+0ac89928…` (jose 6.2.12, linked by `apps/api`) and `+53b163a2…` (jose 6.2.7, linked by `better-auth` and `@better-auth/oauth-provider`).

## Fix

Three layers, smallest first:

1. **Collapse the duplicate** — pin `jose` in the root `overrides`, next to `zod`. zod is pinned there already, which is precisely why both core copies linked an identical zod and `instanceof APIError` kept working. After the change: exactly one `@better-auth/core` and one `jose`, with `apps/api`, `better-auth` and `@better-auth/oauth-provider` on the same copy. `bun install --frozen-lockfile` is green on the committed lock.
2. **Route the live imports through the façade** — `verifyJwsAccessToken` (`enduser-token.ts`) and `encodeBasicCredentials` (two oidc integration tests) now come from `better-auth/oauth2`, which re-exports `@better-auth/core/oauth2` from the copy better-auth itself links.
3. **Guard it** — an ESLint `no-restricted-imports` ban on `@better-auth/core/*` across `apps/api/**`, plus a unit test asserting the resolution is single.

Two judgement calls worth flagging:

- **`@better-auth/core/utils/host` is carved out of the ban**, in the rule rather than with a disable at the import site. better-auth re-exports no host classifier (its own `utils/url.mjs` deliberately keeps the zod-carrying one out of the client bundle — verified against the installed dist), and `isLoopbackHost` is a pure predicate with no module state to get wrong. `oidc/services/redirect-uri.ts` needs the very predicate DCR applies; re-implementing it is the drift #1012 is about. Deep subpaths under `utils/host` stay banned. This also means `@better-auth/core` must remain a direct dependency of `apps/api` — the issue's "drop the direct dependency" option is not available.
- **The Pi SDK ban is restated, not duplicated by accident.** ESLint flat config *replaces* a rule across blocks rather than merging it (the config file says so itself, at the web seam exemption), so a new block covering `apps/api/**` would have silently dropped the Pi guard for `apps/api/src/**`. `PI_SDK_BAN` is now a shared constant carried by both blocks. Verified by positive control.

## Tests

New: `apps/api/test/unit/better-auth-single-instance.test.ts` (2 tests) — asserts `@better-auth/core/oauth2` resolves to one path from `apps/api`, from `better-auth` and from `@better-auth/oauth-provider`, and that one `jose` sits under it. The behavioural half was already covered by `apps/api/src/modules/mcp/test/integration/mcp.test.ts` (the `insufficient_scope` step-up challenge); what was unguarded is the resolution, which can split again on the next bump with our code unchanged.

**Negative control**: restored the pre-fix `package.json` + `bun.lock`, wiped `node_modules`, reinstalled → 2 core copies, and the new test fails on the exact split (`+0ac89928…` vs `+53b163a2…`). Restored, reinstalled → 2 pass.

```
TEST_TIER=0 bun test apps/api/test/unit/better-auth-single-instance.test.ts        → 2 pass 0 fail
TEST_TIER=0 bun test .../oidc/test/integration/{routes/realm-isolation,services/oauth-flows}.test.ts → 20 pass 0 fail
TEST_TIER=0 bun test .../mcp/test/integration/mcp.test.ts                          → 20 pass 0 fail
TEST_TIER=0 bun test .../oidc/test/{unit/enduser-token-verify,integration/middleware/enduser-token-auth}.test.ts → 34 pass 0 fail
TEST_TIER=0 bun test apps/api/test/unit/redirect-uri.test.ts                       → 14 pass 0 fail (with realm-isolation)
bunx tsc --noEmit -p apps/api | -p packages/db | -p packages/core                   → clean
bunx eslint <touched files>                                                        → clean
```

ESLint positive controls (probe files, deleted after): `@better-auth/core/oauth2` in `src/` → error; the same in `test/` → error; `@better-auth/core/utils/host/deep` → error; `@better-auth/core/utils/host` → allowed. Pi SDK ban still fires in both `apps/api/src/` and `packages/runner-pi/src/`.

## Notes for the orchestrator

- **`bun.lock` changed** and must ride with `package.json`. The override also lifts `@modelcontextprotocol/sdk`'s `jose` from 6.2.4 to 6.2.12 (its range `^6.1.3` is satisfied); the MCP integration suite is green. Expect a lockfile conflict with any sibling that also touches deps — re-resolve by re-running `bun install`, not by hand-merging the lock.
- No migration, no env var, no OpenAPI change. Nothing to sequence at deploy.
- **Overlap with siblings**: none. #1348 (better-auth FK indexes) and #1349 (schema check reads the Drizzle object) touch `packages/db`; this PR touches `apps/api`, the root `package.json`/lock and `eslint.config.mjs`. If a sibling adds a `no-restricted-imports` block for `apps/api/**`, it must carry `PI_SDK_BAN` and `BETTER_AUTH_CORE_BAN` — the replace-not-merge trap is documented at both blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
