### PR TITLE
fix(ee): cancel the duplicate subscription a concurrent checkout leaves live

### DIFF
--- a/packages/module-ee/src/billing/org-cancellation.ts
+++ b/packages/module-ee/src/billing/org-cancellation.ts
@@ -7,50 +7,12 @@
  * unconfirmed cancellation leaves a subscription charging a customer that nothing names.
  */
 
-import Stripe from "stripe";
 import { eq, isNotNull } from "drizzle-orm";
 import { getEeDb } from "../db.ts";
 import { billingAccounts, orgUsageRecords } from "../../drizzle/schema.ts";
-import { getStripe } from "../stripe/client.ts";
+import { cancelSubscription } from "../stripe/cancel.ts";
 import { logger } from "../logger.ts";
 import { deleteBillingManagers } from "./managers.ts";
-
-/**
- * Stripe's sentence for "already canceled", returned as a 400 with no distinguishing
- * `code`. Anchored: reading any other 400 as success deletes the subscription id.
- */
-const ALREADY_CANCELED_MESSAGE =
-  /^A canceled subscription can only update its cancellation_details/;
-
-/** Is this failure indistinguishable from success — a subscription Stripe no longer has? */
-function isAlreadyCanceled(err: unknown): boolean {
-  if (!(err instanceof Stripe.errors.StripeInvalidRequestError)) return false;
-  if (err.code === "resource_missing" || err.statusCode === 404) return true;
-  return err.statusCode === 400 && ALREADY_CANCELED_MESSAGE.test(err.message);
-}
-
-/** Cancel `subscriptionId`; true when it is gone, "already gone" included. Never throws. */
-async function cancelSubscription(orgId: string, subscriptionId: string): Promise<boolean> {
-  try {
-    await getStripe().subscriptions.cancel(subscriptionId);
-    logger.info("Stripe subscription canceled for a deleted org", { orgId, subscriptionId });
-    return true;
-  } catch (err) {
-    if (isAlreadyCanceled(err)) {
-      logger.info("Stripe subscription was already gone for a deleted org", {
-        orgId,
-        subscriptionId,
-      });
-      return true;
-    }
-    logger.error("Failed to cancel Stripe subscription — billing rows kept for retry", {
-      orgId,
-      subscriptionId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    return false;
-  }
-}
 
 /** Remove the org's EE-owned rows: no EE table FKs the platform, so nothing cascades. */
 async function deleteOrgBillingRows(orgId: string): Promise<void> {
@@ -75,7 +37,7 @@ export async function cancelSubscriptionAndCleanUp(
       .set({ cancelRequestedAt: new Date(), updatedAt: new Date() })
       .where(eq(billingAccounts.orgId, orgId));
 
-    if (!(await cancelSubscription(orgId, subscriptionId))) return false;
+    if (!(await cancelSubscription(subscriptionId, { orgId, reason: "org-deleted" }))) return false;
   }
 
   await deleteOrgBillingRows(orgId);

--- a/packages/module-ee/src/stripe/cancel.ts
+++ b/packages/module-ee/src/stripe/cancel.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: LicenseRef-Appstrate-Commercial
+
+/**
+ * The one way EE ends a subscription at Stripe. Its two callers share nothing else — an org
+ * being deleted, and a duplicate checkout being reconciled — but both need the same
+ * subtlety: Stripe reports "already canceled" as an undistinguished 400, and reading that
+ * as a failure turns an idempotent retry into a permanent one.
+ */
+
+import Stripe from "stripe";
+import { getStripe } from "./client.ts";
+import { logger } from "../logger.ts";
+
+/**
+ * Stripe's sentence for "already canceled", returned as a 400 with no distinguishing
+ * `code`. Anchored: reading any other 400 as success drops a live subscription.
+ */
+const ALREADY_CANCELED_MESSAGE =
+  /^A canceled subscription can only update its cancellation_details/;
+
+/** Is this failure indistinguishable from success — a subscription Stripe no longer has? */
+function isAlreadyCanceled(err: unknown): boolean {
+  if (!(err instanceof Stripe.errors.StripeInvalidRequestError)) return false;
+  if (err.code === "resource_missing" || err.statusCode === 404) return true;
+  return err.statusCode === 400 && ALREADY_CANCELED_MESSAGE.test(err.message);
+}
+
+/**
+ * Cancel `subscriptionId`; true when it is gone, "already gone" included. Never throws:
+ * each caller carries its own retry (the deletion sweeper, a Stripe webhook redelivery)
+ * and needs the failure as a value it can act on, not as an exception.
+ *
+ * `context` is merged into the log line so the caller's reason is on the record.
+ */
+export async function cancelSubscription(
+  subscriptionId: string,
+  context: Record<string, unknown>,
+): Promise<boolean> {
+  try {
+    await getStripe().subscriptions.cancel(subscriptionId);
+    logger.info("Stripe subscription canceled", { subscriptionId, ...context });
+    return true;
+  } catch (err) {
+    if (isAlreadyCanceled(err)) {
+      logger.info("Stripe subscription was already gone", { subscriptionId, ...context });
+      return true;
+    }
+    logger.error("Failed to cancel Stripe subscription", {
+      subscriptionId,
+      ...context,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/packages/module-ee/src/stripe/checkout.ts
+++ b/packages/module-ee/src/stripe/checkout.ts
@@ -11,7 +11,13 @@ import { noBillingAccount, subscriptionExists } from "../http-errors.ts";
 /**
  * Start a Stripe Checkout for an org Stripe holds no subscription for. The test is
  * {@link planAction}, the same predicate the billing snapshot reports and
- * `changeSubscriptionPlan` refuses on — a double charge is the server's to prevent.
+ * `changeSubscriptionPlan` refuses on.
+ *
+ * It reads state Stripe writes only once a session is PAID, so it cannot stop two sessions
+ * opened before either payment — a double click, or two tabs. That duplicate is settled
+ * where the payment lands: `checkout.session.completed` attaches exactly one subscription
+ * to the account and cancels the other at Stripe (`reconcileSupersededCheckout`, in
+ * `stripe/webhooks.ts`).
  */
 export async function createCheckoutSession(
   orgId: string,

--- a/packages/module-ee/src/stripe/webhooks.ts
+++ b/packages/module-ee/src/stripe/webhooks.ts
@@ -3,6 +3,7 @@
 import Stripe from "stripe";
 import { z } from "zod";
 import { getStripe } from "./client.ts";
+import { cancelSubscription } from "./cancel.ts";
 import { getEeDb } from "../db.ts";
 import { billingAccounts, stripeEvents } from "../../drizzle/schema.ts";
 import { and, eq, isNull, notInArray, or, type SQL } from "drizzle-orm";
@@ -131,7 +132,11 @@ function isEndedSubscription(subscription: Stripe.Subscription): boolean {
   return ENDED_SUBSCRIPTION_STATUSES.has(subscription.status);
 }
 
-/** One line for an event on a subscription this org is not on — a replacement's tail. */
+/**
+ * One line for an event on a subscription this org is not on — a replacement's tail. Log
+ * only: a duplicate that is still billing came from a Checkout, and is cancelled by its own
+ * `checkout.session.completed` ({@link reconcileSupersededCheckout}).
+ */
 function logSupersededSubscription(
   event: Stripe.Event,
   orgId: string,
@@ -158,6 +163,55 @@ function logEndedSubscription(
     subscriptionId: subscription.id,
     status: subscription.status,
   });
+}
+
+/**
+ * The subscription the org's account carries right now — null when nothing does, which
+ * after a refused attach means the org has no billing row at all (every other shape
+ * satisfies {@link attachableSubscription}).
+ */
+async function heldSubscriptionId(orgId: string): Promise<string | null> {
+  const [account] = await getEeDb()
+    .select({ stripeSubscriptionId: billingAccounts.stripeSubscriptionId })
+    .from(billingAccounts)
+    .where(eq(billingAccounts.orgId, orgId));
+  return account?.stripeSubscriptionId ?? null;
+}
+
+/**
+ * A paid checkout the org cannot be attached to, because another subscription already holds
+ * the account. `createCheckoutSession` reads state Stripe writes only once a session is
+ * PAID, so two sessions opened before either payment both pass its guard and Stripe bills
+ * both. Only one can be the org's; the loser is cancelled here, because logging it leaves a
+ * live subscription charging a customer that nothing in the product names, indefinitely.
+ *
+ * Cancels only against positive evidence of the winner — on no billing row there is no
+ * duplicate to reconcile, and ending a paid subscription on that much would be guesswork.
+ * A refused cancellation throws: the handler wrote nothing, so the dropped claim lets
+ * Stripe's redelivery retry, and a cancel of an already-gone subscription is a no-op.
+ */
+async function reconcileSupersededCheckout(
+  event: Stripe.Event,
+  orgId: string,
+  subscriptionId: string,
+): Promise<void> {
+  logSupersededSubscription(event, orgId, subscriptionId);
+
+  // No winner to point at: no billing row (nothing to reconcile against), or a row already
+  // on this very subscription (no duplicate at all) — neither justifies ending a paid one.
+  const heldId = await heldSubscriptionId(orgId);
+  if (heldId === null || heldId === subscriptionId) return;
+
+  logger.warn("Duplicate paid subscription — cancelling the one that lost the attach", {
+    eventId: event.id,
+    orgId,
+    subscriptionId,
+    heldSubscriptionId: heldId,
+  });
+
+  if (!(await cancelSubscription(subscriptionId, { orgId, reason: "superseded-checkout" }))) {
+    throw new Error(`Failed to cancel superseded subscription ${subscriptionId} for org ${orgId}`);
+  }
 }
 
 export async function handleWebhook(body: string, signature: string): Promise<void> {
@@ -310,7 +364,7 @@ async function processEvent(event: Stripe.Event): Promise<void> {
         .returning({ orgId: billingAccounts.orgId });
 
       if (!linked) {
-        logSupersededSubscription(event, orgId, subscriptionId);
+        await reconcileSupersededCheckout(event, orgId, subscriptionId);
         break;
       }
 

--- a/packages/module-ee/test/integration/services/webhooks.test.ts
+++ b/packages/module-ee/test/integration/services/webhooks.test.ts
@@ -8,6 +8,7 @@ import {
   resetStripeMock,
   generateWebhookEvent,
   setSubscriptionResponse,
+  requests,
 } from "../../helpers/stripe.ts";
 import { handleWebhook } from "../../../src/stripe/webhooks.ts";
 import { billingAccounts, stripeEvents } from "../../../drizzle/schema.ts";
@@ -141,6 +142,82 @@ describe("handleWebhook", () => {
       expect(account!.subscriptionStatus).toBe("trialing");
       expect(account!.stripeSubscriptionId).toBe("sub_trial_001");
       expect(account!.creditQuota).toBe(20000);
+    });
+
+    it("cancels a duplicate paid subscription the account cannot be attached to", async () => {
+      // Two Checkout sessions opened before either was paid; the first one paid won the row.
+      await seedBillingAccount({
+        orgId,
+        planId: "starter",
+        stripeCustomerId: "cus_dup_001",
+        stripeSubscriptionId: "sub_dup_winner",
+        subscriptionStatus: "active",
+        creditQuota: 20000,
+      });
+
+      setSubscriptionResponse({
+        id: "sub_dup_loser",
+        object: "subscription",
+        status: "active",
+        metadata: { orgId, planId: "starter" },
+        items: { object: "list", data: [{ id: "si_dup", price: { id: "price_starter_test" } }] },
+      });
+
+      const { body, signature } = signedEvent({
+        id: "evt_checkout_dup_001",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            customer: "cus_dup_001",
+            subscription: "sub_dup_loser",
+            metadata: { orgId, planId: "starter" },
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+
+      const db = getEeDb();
+      const [account] = await db
+        .select()
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId));
+
+      // The winner keeps the account untouched...
+      expect(account!.stripeSubscriptionId).toBe("sub_dup_winner");
+      expect(account!.subscriptionStatus).toBe("active");
+      // ...and the loser is no longer billing the customer.
+      expect(requests).toContainEqual({
+        method: "DELETE",
+        path: "/v1/subscriptions/sub_dup_loser",
+        body: null,
+      });
+    });
+
+    it("does not cancel when the refusal names no winner — the org has no billing row", async () => {
+      setSubscriptionResponse({
+        id: "sub_orphan_001",
+        object: "subscription",
+        status: "active",
+        metadata: { orgId, planId: "starter" },
+        items: { object: "list", data: [{ id: "si_orphan", price: { id: "price_starter_test" } }] },
+      });
+
+      const { body, signature } = signedEvent({
+        id: "evt_checkout_orphan_001",
+        type: "checkout.session.completed",
+        data: {
+          object: {
+            customer: "cus_orphan_001",
+            subscription: "sub_orphan_001",
+            metadata: { orgId, planId: "starter" },
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+
+      expect(requests.filter((r) => r.method === "DELETE")).toEqual([]);
     });
   });
 


### PR DESCRIPTION
Closes #1325

## Root cause

`createCheckoutSession` (`packages/module-ee/src/stripe/checkout.ts:38`) gates on `planAction`, which reads `stripeSubscriptionId` / `subscriptionStatus` — state Stripe only writes once a session is **paid**. Two sessions opened before either payment both pass the guard, and if the user pays both, Stripe holds two live subscriptions.

Only one can hold the account row: the conditional UPDATE in `checkout.session.completed` (`stripe/webhooks.ts`, `attachableSubscription`) attaches the winner, and the loser fell through to `logSupersededSubscription` — a `logger.info` line. The result was a paid subscription billing the customer every month that nothing in the product named and nothing would ever cancel.

## Fix

The refused attach now reconciles instead of logging (`reconcileSupersededCheckout`): it reads the subscription that actually holds the account and, when that is a *different* one, cancels the arriving duplicate at Stripe.

- **Cancels only against positive evidence of a winner.** No billing row, or a row already carrying this very subscription, is not a duplicate — ending a paid subscription on that much would be guesswork, so those keep the log-only behaviour.
- **A refused cancellation throws**, which drops the event claim so Stripe's redelivery retries. Safe because the handler wrote nothing on this path and cancelling an already-gone subscription is a no-op.
- **Reconciliation, not reservation.** The issue offered either. A pending-checkout marker needs new state on the row (a migration) *and* still leaves reconciliation necessary for every duplicate a reservation cannot see — a second tab that loaded before the marker, a subscription created outside Checkout. Reconciliation alone closes the harm, so it is the whole fix.
- Small refactor: `subscriptions.cancel` + the "already canceled" classification (Stripe returns it as a 400 with no distinguishing `code`) lived privately in `billing/org-cancellation.ts`. Rather than copy a Stripe error-message regex into a second file, it moved to `stripe/cancel.ts` and both callers use it. Its log lines take the caller's reason as structured context instead of baking `"for a deleted org"` into the message.
- `createCheckoutSession`'s docstring claimed "a double charge is the server's to prevent" — the opposite of what the guard can do. It now states what the guard actually covers and points at where the duplicate is settled.

**Boundary (deliberate):** a duplicate created *outside* Checkout (Stripe dashboard/API) emits no `checkout.session.completed`, so it is still only logged. Auto-cancelling an operator-created subscription is a policy call, not a bug fix. Every checkout-originated duplicate is covered, whichever delivery order Stripe uses — the loser is always cancelled by its own `checkout.session.completed`.

## Tests

`packages/module-ee/test/integration/services/webhooks.test.ts` (+2 cases): a duplicate arriving at an account already holding a live subscription is cancelled at Stripe while the winner's row is untouched; an attach refused with no winner to point at cancels nothing.

```
pg-test-lock.sh … bun test packages/module-ee/test          → 436 pass, 26 skip, 0 fail
pg-test-lock.sh … bun test webhooks + checkout + post-signup → 67 pass, 0 fail
bunx tsc --noEmit -p packages/module-ee                      → clean
bunx eslint / prettier on the 5 touched files                → clean
```

Negative control: with `reconcileSupersededCheckout` reverted to the old `logSupersededSubscription` call, the new duplicate test fails (only the `GET /v1/subscriptions/…` is recorded, no `DELETE`) — the test proves the fix rather than the fixture.

## Notes for the orchestrator

- **Base is `fix/issue-1323`**, the sibling's branch. This builds directly on its `subscriptions.retrieve`-before-write: at the refusal point the subscription is already known live, which is what makes cancelling it correct.
- **Overlap:** `stripe/webhooks.ts` is shared with #1323 (base, already merged in here), #1324 and #1370. My change adds two helpers and rewrites one line inside the `checkout.session.completed` arm; #1324's fix is in the `customer.subscription.updated` arm, so a textual conflict is unlikely but both touch the same file.
- No migration, no env var, no OpenAPI/route contract change. No deploy ordering constraint.
- **Open product decision:** cancelling stops the *recurring* charge, but the duplicate's first invoice is already paid. Refunding it is a pricing policy call, not something this fix should decide — the new `logger.warn` ("Duplicate paid subscription — cancelling the one that lost the attach", with both subscription ids) is the hook for whatever policy is chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
