### PR TITLE
fix(models): follow the model listing cursor instead of reporting a truncated page as success

### DIFF
--- a/apps/api/src/openapi/paths/model-provider-credentials.ts
+++ b/apps/api/src/openapi/paths/model-provider-credentials.ts
@@ -328,7 +328,7 @@ export const modelProviderCredentialsPaths = {
       tags: ["Model Provider Credentials"],
       summary: "Enumerate the models an endpoint serves",
       description:
-        "Asks an endpoint once for its model listing (`GET <base_url>/models`) and returns the ids it serves, each described with a context window, max output tokens, input modalities and reasoning support. Those come from the listing body itself when the server publishes them per entry (vLLM `max_model_len`, Mistral `capabilities`, OpenRouter `context_length` / `architecture` / `supported_parameters`, LM Studio `max_context_length`) — read from the response already in hand, nothing else is requested — and from the vendored pricing catalog otherwise; `source` says which described a given model. `label` always comes from the catalog. Unlike `POST /{id}/refresh-models` this works BEFORE a credential exists — the operator supplies `provider_id` + `api_key` inline — and it **persists nothing**: no credential is created, no `available_model_ids` is written. Per-token cost is deliberately never returned: an endpoint serving a vendor's model id is not billed at the vendor's rate. Only providers with `authMode: api_key` are accepted — a subscription (OAuth) token is never read or spent to enumerate models. Rate limited to 6 requests per minute.",
+        "Asks an endpoint for its model listing (`GET <base_url>/models`) and returns the ids it serves, each described with a context window, max output tokens, input modalities and reasoning support. Those come from the listing body itself when the server publishes them per entry (vLLM `max_model_len`, Mistral `capabilities`, OpenRouter `context_length` / `architecture` / `supported_parameters`, LM Studio `max_context_length`) — read from the response already in hand, nothing else is requested — and from the vendored pricing catalog otherwise; `source` says which described a given model. `label` always comes from the catalog. Unlike `POST /{id}/refresh-models` this works BEFORE a credential exists — the operator supplies `provider_id` + `api_key` inline — and it **persists nothing**: no credential is created, no `available_model_ids` is written. Per-token cost is deliberately never returned: an endpoint serving a vendor's model id is not billed at the vendor's rate. Only providers with `authMode: api_key` are accepted — a subscription (OAuth) token is never read or spent to enumerate models. A listing that declares a next page (Anthropic `has_more` / `last_id`, Google `nextPageToken`) is followed to its end, so a paginated endpoint is enumerated whole; `truncated` says when a cap stopped the read instead. Rate limited to 6 requests per minute.",
       parameters: [{ $ref: "#/components/parameters/XOrgId" }],
       requestBody: {
         required: true,
@@ -372,13 +372,13 @@ export const modelProviderCredentialsPaths = {
       responses: {
         "200": {
           description:
-            "Listing outcome. `models` is empty unless `outcome` is `ok`; every metadata field is null (and `source` is null) when neither the listing nor a catalog described the id.",
+            "Listing outcome. `models` is empty unless `outcome` is `ok`; every metadata field is null (and `source` is null) when neither the listing nor a catalog described the id. `truncated` marks a list that is short of what the endpoint serves.",
           headers: STD_RESPONSE_HEADERS,
           content: {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["outcome", "models", "message"],
+                required: ["outcome", "models", "truncated", "message"],
                 properties: {
                   outcome: {
                     type: "string",
@@ -426,6 +426,11 @@ export const modelProviderCredentialsPaths = {
                         },
                       },
                     },
+                  },
+                  truncated: {
+                    type: "boolean",
+                    description:
+                      "`true` when the endpoint had more models to declare and a safety cap stopped the read (more than 1000 models, more than 10 listing pages, or a listing that declares a next page without publishing a cursor to follow). The ids returned are then a prefix of what the endpoint serves, not the whole of it. Always `false` for a non-`ok` outcome.",
                   },
                   message: {
                     type: ["string", "null"],

--- a/apps/api/src/routes/model-provider-credentials.ts
+++ b/apps/api/src/routes/model-provider-credentials.ts
@@ -370,7 +370,9 @@ export function createModelProviderCredentialsRouter() {
 
   // POST /api/model-provider-credentials/discover — what an endpoint serves,
   // described from its listing and the catalog, BEFORE a credential exists.
-  // Persists nothing, never echoes the key; gated like `refresh-models`.
+  // Persists nothing, never echoes the key; gated like `refresh-models`. The
+  // listing is followed across its pages, and `truncated` says when a cap cut
+  // the read short rather than letting a partial list pass for a whole one.
   router.post(
     "/discover",
     rateLimit(6),
@@ -384,11 +386,13 @@ export function createModelProviderCredentialsRouter() {
         return c.json({
           outcome: listing.error.toLowerCase(),
           models: [],
+          truncated: false,
           message: listing.message,
         });
       }
       return c.json({
         outcome: "ok",
+        truncated: listing.truncated,
         models: listing.models.map(({ id, hints }) => {
           const described = describeServedModel(target.providerId, id, hints);
           return {

--- a/apps/api/src/services/model-providers/model-listing.ts
+++ b/apps/api/src/services/model-providers/model-listing.ts
@@ -1,18 +1,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * What a credential's provider serves: one guarded `GET <baseUrl>/models`
+ * What a credential's provider serves: guarded `GET <baseUrl>/models` requests
  * (`fetchModelListing`, the credential test's transport), parsed per
  * `apiShape`. Per-entry capability fields some servers publish (vLLM
  * `max_model_len`, Mistral `capabilities`, OpenRouter `context_length` /
  * `architecture` / `supported_parameters`, LM Studio `max_context_length`)
  * are read from the entry in hand as hints.
+ *
+ * A listing that declares a next page is followed to its end: Anthropic's
+ * `/v1/models` answers 20 entries with `has_more` / `last_id`, so reading one
+ * page would hand the operator a silently short list. Following stops at
+ * {@link MAX_LISTING_PAGES} pages or {@link MAX_SERVED_MODELS} models, and a
+ * result cut by either cap says so (`truncated`) instead of passing for a
+ * complete listing.
  */
 
 import { fetchModelListing } from "../org-models.ts";
+import { logger } from "../../lib/logger.ts";
 
-/** Upper bound on models taken from one listing response. */
+/** Upper bound on models taken from a listing, across all of its pages. */
 const MAX_SERVED_MODELS = 1000;
+
+/** Upper bound on listing requests per call — a cursor that never ends must stop. */
+const MAX_LISTING_PAGES = 10;
 
 /** Input modalities a listing entry or a catalog entry can advertise, in canonical order. */
 export const INPUT_MODALITIES = ["text", "image"] as const;
@@ -38,20 +49,75 @@ type ListServedModelsError =
   "AUTH_FAILED" | "RATE_LIMITED" | "UNREACHABLE" | "BLOCKED_URL" | "BAD_RESPONSE" | "HTTP_ERROR";
 
 export type ListServedModelsResult =
-  | { ok: true; models: ServedModel[] }
+  | {
+      ok: true;
+      models: ServedModel[];
+      /** The endpoint had more to say and a cap stopped the read — `models` is short. */
+      truncated: boolean;
+    }
   | { ok: false; error: ListServedModelsError; status?: number; message: string };
 
-/** Where the ids sit in a `/models` response body, per `apiShape`. */
+/** The query that asks a listing for the page after the one in hand. */
+interface PageQuery {
+  name: string;
+  value: string;
+}
+
+/**
+ * How a `/models` response body is laid out, per `apiShape`: where the ids sit,
+ * and how it points at its next page.
+ */
 function listingShape(apiShape: string): {
   key: "data" | "models";
   field: "id" | "name";
   prefix: string;
+  /** Field whose `true` declares a next page; `null` when the cursor's presence is the signal. */
+  moreFlag: string | null;
+  /** Field carrying the cursor, and the query parameter that spends it. */
+  cursorField: string;
+  cursorParam: string;
 } {
-  // Google enumerates `{ models: [{ name: "models/<id>" }] }`; every other
-  // shape answers `{ data: [{ id: "<id>" }] }`.
+  // Google enumerates `{ models: [{ name: "models/<id>" }] }` and pages with
+  // `nextPageToken` / `?pageToken=`; every other shape answers
+  // `{ data: [{ id: "<id>" }] }` and pages on the OpenAI/Anthropic cursor
+  // (`has_more` + `last_id`, spent as `?after_id=`).
   return apiShape === "google-generative-ai" || apiShape === "google-vertex"
-    ? { key: "models", field: "name", prefix: "models/" }
-    : { key: "data", field: "id", prefix: "" };
+    ? {
+        key: "models",
+        field: "name",
+        prefix: "models/",
+        moreFlag: null,
+        cursorField: "nextPageToken",
+        cursorParam: "pageToken",
+      }
+    : {
+        key: "data",
+        field: "id",
+        prefix: "",
+        moreFlag: "has_more",
+        cursorField: "last_id",
+        cursorParam: "after_id",
+      };
+}
+
+/**
+ * What a listing body says about a next page. `more` without a `query` is an
+ * endpoint that declares more and gives nothing to ask with: unfollowable, and
+ * therefore truncated rather than complete.
+ */
+function nextPage(apiShape: string, body: unknown): { more: boolean; query: PageQuery | null } {
+  const { moreFlag, cursorField, cursorParam } = listingShape(apiShape);
+  const container = readRecord(body);
+  if (container === null) return { more: false, query: null };
+  const cursor = container[cursorField];
+  const usable = typeof cursor === "string" && cursor.length > 0;
+  if (moreFlag === null) {
+    return usable
+      ? { more: true, query: { name: cursorParam, value: cursor } }
+      : { more: false, query: null };
+  }
+  if (container[moreFlag] !== true) return { more: false, query: null };
+  return { more: true, query: usable ? { name: cursorParam, value: cursor } : null };
 }
 
 function readRecord(value: unknown): Record<string, unknown> | null {
@@ -112,7 +178,8 @@ function sniffHints(entry: Record<string, unknown>): ServedModelHints {
 /**
  * `null` = no listing at all (not "serves nothing"). Strict on the container,
  * lenient inside: an entry with no usable id is skipped. Response order,
- * deduped on id (first wins), capped at {@link MAX_SERVED_MODELS}.
+ * deduped on id (first wins), capped at {@link MAX_SERVED_MODELS} — one page's
+ * worth; `listServedModels` holds the same cap across a paginated listing.
  */
 export function parseServedModels(apiShape: string, body: unknown): ServedModel[] | null {
   const { key, field, prefix } = listingShape(apiShape);
@@ -137,14 +204,24 @@ export function parseServedModels(apiShape: string, body: unknown): ServedModel[
   return models;
 }
 
-/** List the models a credential's provider serves. */
-export async function listServedModels(config: {
+interface ListingConfig {
   apiShape: string;
   baseUrl: string;
   apiKey: string;
   providerId?: string;
-}): Promise<ListServedModelsResult> {
-  const listing = await fetchModelListing(config);
+}
+
+/** One page of a listing: its parsed body, or the verdict that stopped it. */
+type ListingPageResult =
+  | { ok: true; body: unknown; status: number }
+  | { ok: false; error: ListServedModelsError; status?: number; message: string };
+
+/** One guarded `GET <baseUrl>/models`, mapped from transport/HTTP failure to verdict. */
+async function fetchListingPage(
+  config: ListingConfig,
+  pageQuery?: PageQuery,
+): Promise<ListingPageResult> {
+  const listing = await fetchModelListing(config, pageQuery);
   if (!listing.ok) {
     // A refused URL keeps its verdict (fixed by `EGRESS_ALLOW_INTERNAL_HOSTS`,
     // not by retrying); anything else is "the provider did not answer".
@@ -176,9 +253,8 @@ export async function listServedModels(config: {
     };
   }
 
-  let body: unknown;
   try {
-    body = await res.json();
+    return { ok: true, body: await res.json(), status: res.status };
   } catch {
     return {
       ok: false,
@@ -187,15 +263,67 @@ export async function listServedModels(config: {
       message: "Model listing is not JSON",
     };
   }
+}
 
-  const models = parseServedModels(config.apiShape, body);
-  if (!models) {
-    return {
-      ok: false,
-      error: "BAD_RESPONSE",
-      status: res.status,
-      message: `Unrecognised model listing shape for ${config.apiShape}`,
-    };
+/**
+ * List the models a credential's provider serves, following the listing's own
+ * cursor across pages. Response order, deduped on id across pages (first wins).
+ */
+export async function listServedModels(config: ListingConfig): Promise<ListServedModelsResult> {
+  const models: ServedModel[] = [];
+  const seen = new Set<string>();
+  let pageQuery: PageQuery | undefined;
+
+  for (let page = 1; ; page++) {
+    const fetched = await fetchListingPage(config, pageQuery);
+    if (!fetched.ok) return fetched;
+
+    const parsed = parseServedModels(config.apiShape, fetched.body);
+    if (!parsed) {
+      return {
+        ok: false,
+        error: "BAD_RESPONSE",
+        status: fetched.status,
+        message: `Unrecognised model listing shape for ${config.apiShape}`,
+      };
+    }
+
+    for (const model of parsed) {
+      if (models.length === MAX_SERVED_MODELS) {
+        return truncatedListing(config, models, "model cap reached");
+      }
+      if (seen.has(model.id)) continue;
+      seen.add(model.id);
+      models.push(model);
+    }
+
+    const next = nextPage(config.apiShape, fetched.body);
+    if (!next.more) return { ok: true, models, truncated: false };
+    if (next.query === null) {
+      return truncatedListing(
+        config,
+        models,
+        "listing declares more pages but publishes no cursor",
+      );
+    }
+    if (page === MAX_LISTING_PAGES) {
+      return truncatedListing(config, models, "page cap reached");
+    }
+    pageQuery = next.query;
   }
-  return { ok: true, models };
+}
+
+/** A short listing is a success the caller must be able to see through. */
+function truncatedListing(
+  config: ListingConfig,
+  models: ServedModel[],
+  reason: string,
+): ListServedModelsResult {
+  logger.warn("model listing truncated — the endpoint serves more than was read", {
+    providerId: config.providerId,
+    apiShape: config.apiShape,
+    modelCount: models.length,
+    reason,
+  });
+  return { ok: true, models, truncated: true };
 }

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -1067,13 +1067,22 @@ type ModelListingFetchResult =
  * The guarded `GET <baseUrl>/models` request, shared by {@link testModelConfig}
  * (reads the status) and `listServedModels` (parses the body): the SSRF
  * pre-flight, the pinned transport and the pre-response failure mapping exist once.
+ *
+ * `pageQuery` asks for a page other than the first, spending the cursor the
+ * previous page published. It is appended to the URL the shape builds rather
+ * than merged into it: the request is always derived from the base URL, so the
+ * cursor cannot accumulate across pages and the first page stays byte-identical
+ * to a request that carries none.
  */
-export async function fetchModelListing(config: {
-  apiShape: string;
-  baseUrl: string;
-  apiKey: string;
-  providerId?: string;
-}): Promise<ModelListingFetchResult> {
+export async function fetchModelListing(
+  config: {
+    apiShape: string;
+    baseUrl: string;
+    apiKey: string;
+    providerId?: string;
+  },
+  pageQuery?: { name: string; value: string },
+): Promise<ModelListingFetchResult> {
   // Canonical egress guard (parse + scheme floor + allowlist-aware literal +
   // DNS-rebind host gate) before the fetch: a public hostname resolving to a
   // private/loopback/link-local address is refused, fail-closed, with the same
@@ -1088,7 +1097,10 @@ export async function fetchModelListing(config: {
     };
   }
 
-  const { url, headers } = buildModelTestRequest(config);
+  const { url: firstPageUrl, headers } = buildModelTestRequest(config);
+  const url = pageQuery
+    ? `${firstPageUrl}${firstPageUrl.includes("?") ? "&" : "?"}${pageQuery.name}=${encodeURIComponent(pageQuery.value)}`
+    : firstPageUrl;
 
   const start = performance.now();
   try {

--- a/apps/api/test/integration/routes/model-provider-credentials-discover.test.ts
+++ b/apps/api/test/integration/routes/model-provider-credentials-discover.test.ts
@@ -5,8 +5,10 @@
  * serves before any credential exists, and prefill each id from the vendored
  * catalog.
  *
- * The invariants under test: the endpoint spends the supplied key exactly once
- * against `GET <base_url>/models`, writes NOTHING (a `credential_id` round must
+ * The invariants under test: the endpoint spends the supplied key on
+ * `GET <base_url>/models` and on nothing else — once for a listing that fits in
+ * one page, once more per page a paginated listing declares — writes NOTHING (a
+ * `credential_id` round must
  * leave `available_model_ids` alone), never returns a per-token cost, and never
  * reads a subscription (OAuth) token. The harness also validates every JSON
  * body against the OpenAPI response schema, so these tests gate the documented
@@ -59,21 +61,67 @@ function registerPinnedUrlProvider(): void {
  * for them. A wrong key is a 401; `/bad/models` answers a body that is JSON
  * but carries no listing.
  */
+/** Listing requests the stub served, per credential — pagination must not spend more than it needs. */
+const listingRequests = new Map<string, number>();
+
+function countRequest(key: string): void {
+  listingRequests.set(key, (listingRequests.get(key) ?? 0) + 1);
+}
+
 const stub = Bun.serve({
   hostname: "127.0.0.1",
   port: 0,
   fetch(req) {
-    const { pathname } = new URL(req.url);
+    const { pathname, searchParams } = new URL(req.url);
     if (pathname === "/bad/models") {
       return Response.json({ nope: true });
+    }
+    // Gemini's listing: keyed by query parameter, paged by `nextPageToken`.
+    if (pathname === "/gemini/models") {
+      countRequest("gemini");
+      const token = searchParams.get("pageToken");
+      if (token === null) {
+        return Response.json({
+          models: [{ name: "models/gemini-page1" }],
+          nextPageToken: "tok-2",
+        });
+      }
+      if (token === "tok-2") {
+        return Response.json({ models: [{ name: "models/gemini-page2" }] });
+      }
+      return Response.json({ models: [] });
     }
     if (pathname === "/v1/models") {
       const anthropicKey = req.headers.get("x-api-key");
       if (anthropicKey !== null) {
-        if (anthropicKey !== "good-key") {
+        if (anthropicKey !== "good-key" && anthropicKey !== "paged-key") {
           return Response.json({ error: "unauthorized" }, { status: 401 });
         }
-        return Response.json({ data: [{ id: "claude-x", display_name: "Claude X" }] });
+        if (anthropicKey === "good-key") {
+          countRequest("anthropic");
+          return Response.json({ data: [{ id: "claude-x", display_name: "Claude X" }] });
+        }
+        // The Anthropic listing pages at 20 entries: `has_more` + `last_id`,
+        // spent as `after_id`. Two entries per page is the same protocol.
+        countRequest("paged");
+        const after = searchParams.get("after_id");
+        if (after === null) {
+          return Response.json({
+            data: [{ id: "claude-a" }, { id: "claude-b" }],
+            has_more: true,
+            first_id: "claude-a",
+            last_id: "claude-b",
+          });
+        }
+        if (after === "claude-b") {
+          return Response.json({
+            data: [{ id: "claude-c" }],
+            has_more: false,
+            first_id: "claude-c",
+            last_id: "claude-c",
+          });
+        }
+        return Response.json({ data: [], has_more: false });
       }
       // A server that publishes per-entry capability fields (vLLM's
       // `max_model_len`), routed by its own key so the catalog-only case above
@@ -83,9 +131,21 @@ const stub = Bun.serve({
           data: [{ id: "local-llm", max_model_len: 32768 }, { id: "gpt-4o" }],
         });
       }
+      // An endpoint whose cursor never ends — the page cap has to stop it.
+      if (req.headers.get("authorization") === "Bearer endless-key") {
+        countRequest("endless");
+        const after = searchParams.get("after_id");
+        const next = after === null ? 1 : Number(after.split("-")[1]) + 1;
+        return Response.json({
+          data: [{ id: `endless-${next}` }],
+          has_more: true,
+          last_id: `endless-${next}`,
+        });
+      }
       if (req.headers.get("authorization") !== "Bearer good-key") {
         return Response.json({ error: "unauthorized" }, { status: 401 });
       }
+      countRequest("openai");
       return Response.json({ data: [{ id: "gpt-4o" }, { id: "qwen3:8b" }] });
     }
     return new Response("not found", { status: 404 });
@@ -97,6 +157,7 @@ const BAD_BASE_URL = `http://127.0.0.1:${stub.port}/bad`;
 // `anthropic-messages` appends `/v1/models` itself, so its base URL stops at
 // the host.
 const ANTHROPIC_BASE_URL = `http://127.0.0.1:${stub.port}`;
+const GEMINI_BASE_URL = `http://127.0.0.1:${stub.port}/gemini`;
 
 interface DiscoverModel {
   id: string;
@@ -111,6 +172,7 @@ interface DiscoverModel {
 interface DiscoverBody {
   outcome: string;
   models: DiscoverModel[];
+  truncated: boolean;
   message: string | null;
 }
 
@@ -152,6 +214,7 @@ describe("POST /api/model-provider-credentials/discover", () => {
     await truncateAll();
     ctx = await createTestContext();
     registerPinnedUrlProvider();
+    listingRequests.clear();
   });
 
   it("enumerates an inline endpoint and prefills catalog metadata", async () => {
@@ -322,6 +385,69 @@ describe("POST /api/model-provider-credentials/discover", () => {
       base_url_override: GOOD_BASE_URL,
     });
     expect(res.status).toBe(400);
+  });
+
+  it("reads a one-page listing with exactly one request", async () => {
+    const res = await discover(ctx, {
+      provider_id: "openai-compatible",
+      api_key: "good-key",
+      base_url_override: GOOD_BASE_URL,
+    });
+
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as DiscoverBody).truncated).toBe(false);
+    expect(listingRequests.get("openai")).toBe(1);
+  });
+
+  it("follows the listing cursor instead of returning a silently short first page", async () => {
+    const res = await discover(ctx, {
+      provider_id: "anthropic-compatible",
+      api_key: "paged-key",
+      base_url_override: ANTHROPIC_BASE_URL,
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as DiscoverBody;
+    expect(body.outcome).toBe("ok");
+    // Page two exists only because `has_more` was followed — one fetch would
+    // have reported success with `claude-c` missing.
+    expect(body.models.map((m) => m.id)).toEqual(["claude-a", "claude-b", "claude-c"]);
+    expect(body.truncated).toBe(false);
+    // Two pages, two requests: the last page declares `has_more: false`, so
+    // nothing is spent asking for a third.
+    expect(listingRequests.get("paged")).toBe(2);
+  });
+
+  it("follows the Google listing's nextPageToken", async () => {
+    const res = await discover(ctx, {
+      provider_id: "google-ai",
+      api_key: "good-key",
+      base_url_override: GEMINI_BASE_URL,
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as DiscoverBody;
+    expect(body.outcome).toBe("ok");
+    expect(body.models.map((m) => m.id)).toEqual(["gemini-page1", "gemini-page2"]);
+    expect(body.truncated).toBe(false);
+    expect(listingRequests.get("gemini")).toBe(2);
+  });
+
+  it("reports truncated when a cursor that never ends hits the page cap", async () => {
+    const res = await discover(ctx, {
+      provider_id: "openai-compatible",
+      api_key: "endless-key",
+      base_url_override: GOOD_BASE_URL,
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as DiscoverBody;
+    expect(body.outcome).toBe("ok");
+    // Success, but declared short — the operator is not told this is the whole
+    // list. The cap bounds the requests spent on one call.
+    expect(body.truncated).toBe(true);
+    expect(listingRequests.get("endless")).toBe(10);
+    expect(body.models).toHaveLength(10);
   });
 
   it("returns 401 without authentication", async () => {

--- a/apps/api/test/integration/services/model-discovery.test.ts
+++ b/apps/api/test/integration/services/model-discovery.test.ts
@@ -139,6 +139,7 @@ function forbiddenListing(): { deps: ModelDiscoveryDeps; calls: () => number } {
 const served = (...modelIds: string[]): ListServedModelsResult => ({
   ok: true,
   models: modelIds.map((id) => ({ id, hints: {} })),
+  truncated: false,
 });
 const AUTH_FAILED: ListServedModelsResult = {
   ok: false,

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -2055,7 +2055,7 @@ export interface paths {
         put?: never;
         /**
          * Enumerate the models an endpoint serves
-         * @description Asks an endpoint once for its model listing (`GET <base_url>/models`) and returns the ids it serves, each described with a context window, max output tokens, input modalities and reasoning support. Those come from the listing body itself when the server publishes them per entry (vLLM `max_model_len`, Mistral `capabilities`, OpenRouter `context_length` / `architecture` / `supported_parameters`, LM Studio `max_context_length`) — read from the response already in hand, nothing else is requested — and from the vendored pricing catalog otherwise; `source` says which described a given model. `label` always comes from the catalog. Unlike `POST /{id}/refresh-models` this works BEFORE a credential exists — the operator supplies `provider_id` + `api_key` inline — and it **persists nothing**: no credential is created, no `available_model_ids` is written. Per-token cost is deliberately never returned: an endpoint serving a vendor's model id is not billed at the vendor's rate. Only providers with `authMode: api_key` are accepted — a subscription (OAuth) token is never read or spent to enumerate models. Rate limited to 6 requests per minute.
+         * @description Asks an endpoint for its model listing (`GET <base_url>/models`) and returns the ids it serves, each described with a context window, max output tokens, input modalities and reasoning support. Those come from the listing body itself when the server publishes them per entry (vLLM `max_model_len`, Mistral `capabilities`, OpenRouter `context_length` / `architecture` / `supported_parameters`, LM Studio `max_context_length`) — read from the response already in hand, nothing else is requested — and from the vendored pricing catalog otherwise; `source` says which described a given model. `label` always comes from the catalog. Unlike `POST /{id}/refresh-models` this works BEFORE a credential exists — the operator supplies `provider_id` + `api_key` inline — and it **persists nothing**: no credential is created, no `available_model_ids` is written. Per-token cost is deliberately never returned: an endpoint serving a vendor's model id is not billed at the vendor's rate. Only providers with `authMode: api_key` are accepted — a subscription (OAuth) token is never read or spent to enumerate models. A listing that declares a next page (Anthropic `has_more` / `last_id`, Google `nextPageToken`) is followed to its end, so a paginated endpoint is enumerated whole; `truncated` says when a cap stopped the read instead. Rate limited to 6 requests per minute.
          */
         post: operations["discoverModelProviderCredentialModels"];
         delete?: never;
@@ -13405,7 +13405,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Listing outcome. `models` is empty unless `outcome` is `ok`; every metadata field is null (and `source` is null) when neither the listing nor a catalog described the id. */
+            /** @description Listing outcome. `models` is empty unless `outcome` is `ok`; every metadata field is null (and `source` is null) when neither the listing nor a catalog described the id. `truncated` marks a list that is short of what the endpoint serves. */
             200: {
                 headers: {
                     "Request-Id": components["headers"]["RequestId"];
@@ -13434,6 +13434,8 @@ export interface operations {
                              */
                             source: "endpoint" | "catalog" | null;
                         }[];
+                        /** @description `true` when the endpoint had more models to declare and a safety cap stopped the read (more than 1000 models, more than 10 listing pages, or a listing that declares a next page without publishing a cursor to follow). The ids returned are then a prefix of what the endpoint serves, not the whole of it. Always `false` for a non-`ok` outcome. */
+                        truncated: boolean;
                         /** @description Human-readable detail for a non-`ok` outcome (e.g. "URL targets a blocked network"); null on `ok`. */
                         message: string | null;
                     };

--- a/apps/web/src/components/model-form-modal.tsx
+++ b/apps/web/src/components/model-form-modal.tsx
@@ -311,8 +311,15 @@ function ModelForm({
         }),
       },
       {
-        onSuccess: (data) => setDiscovery({ key, outcome: data.outcome, models: data.models }),
-        onError: () => setDiscovery({ key, outcome: "request_failed", models: [] }),
+        onSuccess: (data) =>
+          setDiscovery({
+            key,
+            outcome: data.outcome,
+            models: data.models,
+            truncated: data.truncated,
+          }),
+        onError: () =>
+          setDiscovery({ key, outcome: "request_failed", models: [], truncated: false }),
       },
     );
   };

--- a/apps/web/src/components/model-form/discovery-controls.tsx
+++ b/apps/web/src/components/model-form/discovery-controls.tsx
@@ -52,6 +52,12 @@ export function DiscoveryControls({
             {discovery.models.length > 0
               ? t("models.form.discoverCount", { count: discovery.models.length })
               : t("models.form.discoverEmpty")}
+            {/* A capped listing is short of what the endpoint serves — saying so
+                is the difference between "these are the models" and "these are
+                the first models". */}
+            {discovery.truncated ? (
+              <span className="block">{t("models.form.discoverTruncated")}</span>
+            ) : null}
           </div>
         ) : (
           <div className="text-destructive text-sm">{t(discoveryErrorKey(discovery.outcome))}</div>

--- a/apps/web/src/lib/model-discovery.ts
+++ b/apps/web/src/lib/model-discovery.ts
@@ -16,6 +16,8 @@ export interface DiscoveryState {
   key: string;
   outcome: DiscoveredModelsResponse["outcome"] | "request_failed";
   models: DiscoveredModel[];
+  /** The endpoint serves more than `models` lists — a cap stopped the read. */
+  truncated: boolean;
 }
 
 export function discoveryErrorKey(outcome: DiscoveryState["outcome"]): string {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -642,6 +642,7 @@
   "models.form.discoverCount_one": "{{count}} model detected",
   "models.form.discoverCount_other": "{{count}} models detected",
   "models.form.discoverEmpty": "This endpoint returned no model.",
+  "models.form.discoverTruncated": "The endpoint serves more models than could be read; this list is incomplete.",
   "models.form.discoverAuthFailed": "The endpoint refused the key.",
   "models.form.discoverBlockedUrl": "The platform blocks this address (private or local network). Add the host to EGRESS_ALLOW_INTERNAL_HOSTS server-side to allow it.",
   "models.form.discoverFailed": "Could not list the models this endpoint serves.",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -642,6 +642,7 @@
   "models.form.discoverCount_one": "{{count}} modèle détecté",
   "models.form.discoverCount_other": "{{count}} modèles détectés",
   "models.form.discoverEmpty": "Aucun modèle renvoyé par ce endpoint.",
+  "models.form.discoverTruncated": "Le endpoint sert plus de modèles que ce qui a pu être lu ; cette liste est incomplète.",
   "models.form.discoverAuthFailed": "Clé refusée par le endpoint.",
   "models.form.discoverBlockedUrl": "Cette adresse est bloquée par la plateforme (réseau privé ou local). Ajoute l'hôte à EGRESS_ALLOW_INTERNAL_HOSTS côté serveur pour l'autoriser.",
   "models.form.discoverFailed": "Impossible de lister les modèles de ce endpoint.",


### PR DESCRIPTION
Closes #1353

## Root cause

`listServedModels` (`apps/api/src/services/model-providers/model-listing.ts`) did exactly one `fetchModelListing` + one `parseServedModels`, then `return { ok: true, models }`. Anthropic's `/v1/models` answers 20 entries with `has_more` / `last_id`, and Google's answers a page plus `nextPageToken` — so an endpoint serving more than one page was reported as a complete listing that was silently short. `POST /api/model-provider-credentials/discover` passed that straight to the model form, which printed "N models detected" over a truncated list.

## Fix

**Follow the cursor.** The two pagination dialects are folded into the existing `listingShape(apiShape)` — it already forked Google (`{ models: [{ name }] }`) from everything else (`{ data: [{ id }] }`), and now also carries how each points at its next page: Google `nextPageToken` → `?pageToken=`, OpenAI/Anthropic `has_more` + `last_id` → `?after_id=`. `listServedModels` loops on it, deduping ids across pages.

`fetchModelListing` (`org-models.ts`) takes the cursor as a second argument and appends it to the URL its shape builds, so every page is derived from the base URL — the cursor cannot accumulate across pages and the first request is byte-identical to today's (no new query parameter is sent to endpoints that do not paginate). The per-page fetch/HTTP-verdict mapping moved into a `fetchListingPage` helper so the loop stays readable; the verdicts themselves are unchanged.

**Stop, and say so.** Reading stops at 1000 models or 10 pages. A result cut by either cap — or by a listing that declares `has_more` without publishing a cursor to follow — carries `truncated: true` and logs a warning, instead of passing for a whole listing. `truncated` is a new required field on the `/discover` 200 response (documented; `detect:breaking` classifies it non-breaking), and the model form prints a line under the detected-count when it is set.

Design note: the caps are anti-runaway guards, not the normal path. `truncated` exists so the degenerate case is visible rather than silent — which is the actual complaint in the issue, and would otherwise just move from "20 of 21" to "1000 of 1001".

## Tests

`apps/api/test/integration/routes/model-provider-credentials-discover.test.ts` — the stub gains a request counter and three endpoints: an Anthropic-shaped listing paged on `has_more`/`last_id`, a Gemini-shaped one paged on `nextPageToken`, and a cursor that never ends. Four new cases pin that both pages come back, that a one-page listing still spends exactly one request, that a complete paginated listing spends exactly one request per page and no more, and that the page cap reports `truncated: true`.

```
TEST_TIER=0 bun test apps/api/test/integration/routes/model-provider-credentials-discover.test.ts   → 17 pass / 0 fail
TEST_TIER=0 bun test .../routes/model-provider-credentials-discover.test.ts .../services/model-discovery.test.ts → 26 pass / 0 fail
TEST_TIER=0 bun test apps/api/test/unit/model-listing.test.ts                                        → 27 pass / 0 fail
(from apps/web) bun test src/components/test/model-form-modal.test.tsx                               → 20 pass / 0 fail
(from apps/web) bun test src/lib/test/model-discovery.test.ts src/components/model-form/test/model-pick-list.test.tsx → 13 pass / 0 fail
(from apps/web) bun test src/locales/test/locale-keys.test.ts --timeout 60000                         →  9 pass / 0 fail
bun run verify:openapi → ALL CHECKS PASSED   bun run verify:api-types → up to date   bun run detect:breaking → 0 breaking, 1 non-breaking
bunx tsc --noEmit -p apps/api → clean        bunx tsc --noEmit -p apps/web → clean
```

Negative control: with `MAX_LISTING_PAGES` forced to 1 (the old one-page behaviour), the three pagination cases fail — the tests exercise the loop, not the stub.

## Notes for the orchestrator

- No migration, no env var. `apps/web/src/api/schema.d.ts` is regenerated output (`bun run generate:api`), committed.
- The OpenAPI baseline was **not** regenerated: the added response field is non-breaking and `detect:breaking` passes against the existing baseline.
- **Overlap**: `apps/api/src/routes/model-provider-credentials.ts` (the `/discover` handler — two added lines) also belongs to #1356, and `apps/web/src/components/model-form-modal.tsx` (one `setDiscovery` call site) also belongs to #1355. Both edits are a few lines and additive; expect a trivial conflict at most.
- Two pre-existing harness quirks met while verifying, unrelated to this change: `apps/api/test/integration/services/model-discovery.test.ts` never boots the app, so it only passes alongside a file that does; and `apps/web/src/components/test/model-form-modal.test.tsx` needs `bun test` run from `apps/web` (the `@/` alias does not resolve from the repo root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
