### PR TITLE
fix(connect): address the hosted portal's error completions to their package

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -935,6 +935,17 @@ export function createIntegrationsRouter() {
     if (!claims) return c.html(popupHtmlError("This connect link is invalid or expired.", {}), 410);
     const scope = scopeFromClaims(claims);
     const actor = actorFromClaims(claims);
+    // From here on the claims name the integration this link was minted for, so
+    // every completion this handler emits must carry it (issue #1346). A
+    // completion that identifies NOTHING is for everyone by contract
+    // (`completionMatches` — the permissive tail exists for the two pages above,
+    // which resolved neither a package nor a state), and both carriers fan out,
+    // so a context-less error from a failing Gmail link drove an unrelated
+    // ClickUp card into an error naming Gmail. `packageId` is also the only
+    // identifier a hosted-connect surface holds — the OAuth `state` is minted
+    // later, past the redirect — so it is what makes these pages reach the card
+    // that opened them and nothing else.
+    const completionDetail = { packageId: claims.package_id };
     // Resolve the integration BEFORE consuming the jti — if the auth no longer
     // exists, the capability token stays unburned so the caller can retry once
     // the integration is back, rather than being forced to re-mint.
@@ -942,11 +953,17 @@ export function createIntegrationsRouter() {
     try {
       ({ auth } = await readIntegrationAuth(scope, claims.package_id, claims.auth_key));
     } catch {
-      return c.html(popupHtmlError("This integration is no longer available.", {}), 410);
+      return c.html(
+        popupHtmlError("This integration is no longer available.", completionDetail),
+        410,
+      );
     }
     // Single-use: burn the jti only once we know the link is actionable.
     if (!(await consumeJti(claims.jti, claims.exp))) {
-      return c.html(popupHtmlError("This connect link has already been used.", {}), 410);
+      return c.html(
+        popupHtmlError("This connect link has already been used.", completionDetail),
+        410,
+      );
     }
 
     if (auth.type === "oauth2") {
@@ -964,7 +981,10 @@ export function createIntegrationsRouter() {
       const scopes = [...new Set([...defaultScopes, ...(claims.scopes ?? []), ...granted])];
       const strategy = resolveStrategy(auth);
       if (!strategy.begin) {
-        return c.html(popupHtmlError("This integration cannot be connected.", {}), 500);
+        return c.html(
+          popupHtmlError("This integration cannot be connected.", completionDetail),
+          500,
+        );
       }
       // `begin` throws for two different reasons, and the popup must tell them
       // apart (issue #1263). Without a guard at all the throw escapes to the
@@ -1016,7 +1036,7 @@ export function createIntegrationsRouter() {
           return c.html(
             popupHtmlError(
               "This integration is not ready to be connected. Ask an administrator to finish setting it up, then open this link again.",
-              {},
+              completionDetail,
             ),
             err.status as ContentfulStatusCode,
           );
@@ -1026,7 +1046,10 @@ export function createIntegrationsRouter() {
           packageId: claims.package_id,
           authKey: claims.auth_key,
         });
-        return c.html(popupHtmlError("Could not start the connection. Please try again.", {}), 502);
+        return c.html(
+          popupHtmlError("Could not start the connection. Please try again.", completionDetail),
+          502,
+        );
       }
       return c.redirect(result.redirectUrl);
     }

--- a/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
+++ b/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
@@ -18,7 +18,7 @@ import { truncateAll, db } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { eq } from "drizzle-orm";
-import { integrationConnections, integrationOauthClients } from "@appstrate/db/schema";
+import { integrationConnections, integrationOauthClients, packages } from "@appstrate/db/schema";
 import type { IntegrationManifest } from "@appstrate/core/integration";
 
 const app = getTestApp();
@@ -452,6 +452,76 @@ describe("hosted connect portal — oauth2 dispatch without a client (issues #12
     expect(html).toContain("Ask an administrator");
     for (const internal of ["CONNECTION_ENCRYPTION_KEY", "cannot be decrypted", clientId]) {
       expect(html).not.toContain(internal);
+    }
+  });
+});
+
+/**
+ * The completion payload the popup broadcasts, as the browser would read it.
+ *
+ * The page inlines it as a single `var detail = {…};` statement of flat JSON
+ * (`buildIntegrationConnectCompletion` produces no nested object), so the line
+ * itself is the whole payload.
+ */
+function completionDetail(html: string): Record<string, unknown> {
+  const match = /^\s*var detail = (\{.*\});$/m.exec(html);
+  expect(match).not.toBeNull();
+  return JSON.parse(match![1]!) as Record<string, unknown>;
+}
+
+describe("hosted connect portal — error completions are addressed (issue #1346)", () => {
+  let ctx: TestContext;
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "myorg" });
+    await seedIntegration(ctx.orgId, apiKeyManifest("@myorg/gmail"));
+    await seedIntegration(ctx.orgId, oauthManifest("@myorg/gsuite"));
+  });
+
+  // A completion naming NOTHING is delivered to every waiting surface by
+  // contract (`completionMatches`), and both carriers fan out — so a failing
+  // Gmail link used to drive an open ClickUp card into an error naming Gmail.
+  it("names the package on the OAuth-begin refusal", async () => {
+    const res = await startConnect(await mintSession(ctx, "@myorg/gsuite", "google"));
+    expect(res.status).toBe(403);
+    expect(completionDetail(await res.text())).toMatchObject({
+      ok: false,
+      packageId: "@myorg/gsuite",
+    });
+  });
+
+  it("names the package when the link has already been used", async () => {
+    const token = await mintSession(ctx, "@myorg/gmail", "api");
+    expect((await startConnect(token)).status).toBe(302);
+    const again = await startConnect(token);
+    expect(again.status).toBe(410);
+    const detail = completionDetail(await again.text());
+    expect(detail).toMatchObject({ ok: false, packageId: "@myorg/gmail" });
+  });
+
+  it("names the package when the integration is gone", async () => {
+    const token = await mintSession(ctx, "@myorg/gmail", "api");
+    await db.delete(packages).where(eq(packages.id, "@myorg/gmail"));
+    const res = await startConnect(token);
+    expect(res.status).toBe(410);
+    expect(completionDetail(await res.text())).toMatchObject({
+      ok: false,
+      packageId: "@myorg/gmail",
+    });
+  });
+
+  // The other half of the rule: the two pages that run BEFORE the claims are
+  // decoded resolved no package and no state, so they stay context-less — that
+  // is the case `completionMatches`'s permissive tail exists for, and widening
+  // it is not what this fix does.
+  it("leaves the pre-claims pages context-less", async () => {
+    for (const query of ["", "?token=not-a-token"]) {
+      const res = await app.request(`/api/integrations/connect/start${query}`, {
+        redirect: "manual",
+      });
+      const detail = completionDetail(await res.text());
+      expect(detail.packageId).toBeUndefined();
+      expect(detail.state).toBeUndefined();
     }
   });
 });

--- a/packages/core/test/connect-handshake.test.ts
+++ b/packages/core/test/connect-handshake.test.ts
@@ -408,25 +408,41 @@ describe("completionMatches — the payloads the platform emits", () => {
   });
 
   it("delivers the context-less /connect/start errors to everyone", () => {
-    // routes/integrations.ts `/connect/start` — popupHtmlError(msg, {}), emitted
-    // before the token resolved a package or a state. This is the carve-out, and
-    // it is the reason a surface with no context can still show an error at all.
-    // The last two are the OAuth `begin` refusals: the configuration detail an
-    // ApiError carries (#1263, rendered verbatim with its 4xx) and the generic
-    // 502 wording every other failure keeps.
-    for (const msg of [
-      "Missing connect token",
-      "This connect link is invalid or expired.",
-      "This integration is no longer available.",
-      "This connect link has already been used.",
-      "This integration cannot be connected.",
-      "Administrator must register OAuth client credentials for '@acme/gmail' auth 'primary' before connection",
-      "Could not start the connection. Please try again.",
-    ]) {
+    // routes/integrations.ts `/connect/start` — popupHtmlError(msg, {}), and
+    // these two are the ONLY pages that still emit that shape: they run before
+    // the token resolved a package or a state, so they identify nothing. This is
+    // the carve-out, and it is the reason a surface with no context can still
+    // show an error at all.
+    for (const msg of ["Missing connect token", "This connect link is invalid or expired."]) {
       const contextLess = detail({ ok: false, error: msg });
       for (const [, target] of MATRIX_TARGETS) {
         expect(completionMatches(contextLess, target)).toBe(true);
       }
+    }
+  });
+
+  it("confines the rest of the /connect/start errors to that integration", () => {
+    // Everything past `readConnectToken` names `claims.package_id` (#1346): the
+    // link is gone, the jti is spent, the auth cannot be connected, and both
+    // OAuth `begin` outcomes — the 4xx refusal and the generic 502. These have a
+    // package and no state, so they reach the surfaces holding that package —
+    // the hosted card that opened the link, the SPA popup — and no other.
+    for (const msg of [
+      "This integration is no longer available.",
+      "This connect link has already been used.",
+      "This integration cannot be connected.",
+      "This integration is not ready to be connected. Ask an administrator to finish setting it up, then open this link again.",
+      "Could not start the connection. Please try again.",
+    ]) {
+      const addressed = detail({ ok: false, packageId: PKG, error: msg });
+      expect(completionMatches(addressed, hostedCard)).toBe(true);
+      expect(completionMatches(addressed, spaPopup)).toBe(true);
+      // The card on another integration no longer sees another flow's failure —
+      // the hijack of #1346. Nor does a card correlating by state alone, which
+      // shares no identifier with a payload that carries none.
+      expect(completionMatches(addressed, { packageId: OTHER_PKG })).toBe(false);
+      expect(completionMatches(addressed, oauthCardStateOnly)).toBe(false);
+      expect(completionMatches(addressed, {})).toBe(false);
     }
   });
 


### PR DESCRIPTION
Closes #1346

## Root cause

`apps/api/src/routes/integrations.ts` — every `/connect/start` failure past
`readConnectToken` passed `{}` as its completion detail while `claims.package_id`
sat a few lines above: the vanished auth, the spent jti, the unconnectable auth,
and both `strategy.begin` outcomes.

A completion that identifies nothing is delivered to **every** waiting surface by
contract — `packages/core/src/connect-handshake.ts:233`, the permissive tail
written for the pages that resolved neither a package nor a state — and both
carriers fan out (`BroadcastChannel` + `postMessage`). So a failing Gmail link
flipped an open ClickUp card into an error naming Gmail: the exact hijack
`packageId` was introduced to prevent.

## Fix

One local `completionDetail = { packageId: claims.package_id }`, minted right
after the claims are read, applied to the five sites past that point. `packageId`
is also the *only* identifier a hosted-connect surface holds — its OAuth state is
minted later, past the redirect — so this is what makes these pages reach the
card that opened the link, and nothing else.

The issue proposed one line at the `begin` refusal. The other four sites are the
same mechanism in the same handler; fixing one would have left four live hijacks,
so all five move together and the repeated literal is bound once.

The two pages *before* the token resolves anything (`Missing connect token`,
`This connect link is invalid or expired.`) keep `{}` — they are the case the
permissive tail exists for. The predicate itself is untouched.

## Tests

- `apps/api/test/integration/routes/integrations-hosted-connect.test.ts` — new
  describe (issue #1346), 4 cases reading the popup's inlined completion payload
  as a browser would: the OAuth-begin refusal, the spent link and the vanished
  integration each name their package; the two pre-claims pages stay
  context-less.
- `packages/core/test/connect-handshake.test.ts` — the "payloads the platform
  emits" matrix pinned the *old* sender (it listed five now-addressed messages as
  context-less). Split into the two that still are, plus a new case asserting the
  rest reach the hosted card and the SPA popup and neither another package's card
  nor a state-only one.

```
TEST_TIER=0 bun test apps/api/test/integration/routes/integrations-hosted-connect.test.ts   → 19 pass, 0 fail
TEST_TIER=0 bun test packages/core/test/connect-handshake.test.ts                           → 35 pass, 0 fail
bunx tsc --noEmit -p apps/api ; -p packages/core                                            → clean
bunx eslint / prettier --check on the 3 touched files                                       → clean
```

Negative control: with `completionDetail` forced back to `{}`, the three
addressed-completion cases fail and the pre-claims one stays green — the shape of
the bug.

## Notes for the orchestrator

- Based on `fix/issue-1345`; targets that branch. It changed the *message* at
  these render sites, this changes the *detail* — same call, different argument,
  no textual conflict expected once #1345 lands.
- No migration, no env var, no OpenAPI contract change (statuses and response
  media types are untouched; the popup body is not schema-described).
- Siblings #1352 and #1344 are untouched. #1344 (`releaseJti` after upstream DCR)
  concerns the same `catch` block in `/connect/start`; this PR only changes the
  second argument of the `popupHtmlError` call inside it, so the overlap is one
  adjacent line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
