### PR TITLE
fix(ee): sync the credit quota when a subscription changes plan

### DIFF
--- a/packages/module-ee/src/stripe/webhooks.ts
+++ b/packages/module-ee/src/stripe/webhooks.ts
@@ -584,7 +584,19 @@ async function processEvent(event: Stripe.Event): Promise<void> {
         updatedAt: new Date(),
       };
       if (itemPeriodEnd) updates.periodEnd = itemPeriodEnd;
-      if (newPlan) updates.planId = newPlan.id;
+      if (newPlan) {
+        updates.planId = newPlan.id;
+        // The plan and its ceiling are ONE fact: `changeSubscriptionPlan` deliberately
+        // writes neither, and `create_prorations` bills on the next cycle, so no
+        // `invoice.paid` follows a plan switch to repair a stale quota.
+        //
+        // `creditsUsed` is deliberately left alone — consumption already billed is never
+        // erased by a plan move (same rule as invoice.paid outside `subscription_cycle`).
+        // An upgrade therefore frees exactly the added headroom, and a downgrade below
+        // current consumption leaves the account over its ceiling until the renewal
+        // invoice resets the counter.
+        updates.creditQuota = newPlan.creditQuota;
+      }
 
       // Org from metadata (ordering-independent), written only if the org is still ON this
       // subscription. Nothing here ATTACHES one, so an `updated` naming another is a tail.

--- a/packages/module-ee/test/integration/services/webhooks.test.ts
+++ b/packages/module-ee/test/integration/services/webhooks.test.ts
@@ -701,6 +701,102 @@ describe("handleWebhook", () => {
       expect(account!.subscriptionStatus).toBe("past_due");
       expect(account!.cancelAtPeriodEnd).toBe(true);
     });
+
+    it("raises the credit quota on an upgrade, freeing the added headroom", async () => {
+      await seedBillingAccount({
+        orgId,
+        planId: "starter",
+        stripeCustomerId: "cus_update_002",
+        stripeSubscriptionId: "sub_update_002",
+        subscriptionStatus: "active",
+        creditsUsed: 20000,
+        creditQuota: 20000,
+      });
+
+      const { body, signature } = signedEvent({
+        id: "evt_sub_updated_upgrade",
+        type: "customer.subscription.updated",
+        data: {
+          object: {
+            id: "sub_update_002",
+            status: "active",
+            cancel_at_period_end: false,
+            metadata: { orgId, planId: "pro" },
+            items: {
+              data: [
+                {
+                  id: "si_upd_002",
+                  price: { id: "price_pro_test" },
+                  current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 3600,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+
+      const db = getEeDb();
+      const [account] = await db
+        .select()
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId));
+
+      expect(account!.planId).toBe("pro");
+      expect(account!.creditQuota).toBe(80000);
+      // Consumption already billed survives the move — the upgrade buys headroom,
+      // it does not erase the Starter spend.
+      expect(account!.creditsUsed).toBe(20000);
+    });
+
+    it("lowers the credit quota on a downgrade without erasing consumption", async () => {
+      await seedBillingAccount({
+        orgId,
+        planId: "pro",
+        stripeCustomerId: "cus_update_003",
+        stripeSubscriptionId: "sub_update_003",
+        subscriptionStatus: "active",
+        creditsUsed: 60000,
+        creditQuota: 80000,
+      });
+
+      const { body, signature } = signedEvent({
+        id: "evt_sub_updated_downgrade",
+        type: "customer.subscription.updated",
+        data: {
+          object: {
+            id: "sub_update_003",
+            status: "active",
+            cancel_at_period_end: false,
+            metadata: { orgId, planId: "starter" },
+            items: {
+              data: [
+                {
+                  id: "si_upd_003",
+                  price: { id: "price_starter_test" },
+                  current_period_end: Math.floor(Date.now() / 1000) + 30 * 24 * 3600,
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+
+      const db = getEeDb();
+      const [account] = await db
+        .select()
+        .from(billingAccounts)
+        .where(eq(billingAccounts.orgId, orgId));
+
+      expect(account!.planId).toBe("starter");
+      expect(account!.creditQuota).toBe(20000);
+      // Over the new ceiling on purpose: the renewal invoice resets the counter,
+      // a plan move never grants credits back.
+      expect(account!.creditsUsed).toBe(60000);
+    });
   });
 
   describe("customer.subscription.deleted", () => {


### PR DESCRIPTION
Closes #1324

## Root cause

`packages/module-ee/src/stripe/webhooks.ts` — the `customer.subscription.updated` arm built its `updates` object with `planId` but never `creditQuota`. Nothing else compensates: `packages/module-ee/src/stripe/plan.ts:18` documents that this webhook is *the single place a plan transition is applied*, and `changeSubscriptionPlan` uses `proration_behavior: "create_prorations"`, which defers the charge to the next cycle — so no `invoice.paid` (the other arm that writes `creditQuota`) follows a plan switch. A Starter account at 20 000/20 000 that upgraded to Pro became a Pro account still capped, and still blocked, at 20 000.

## Fix

Write the plan and its ceiling as one fact:

```ts
if (newPlan) {
  updates.planId = newPlan.id;
  updates.creditQuota = newPlan.creditQuota;
}
```

`creditsUsed` is deliberately **not** touched — that answers the downgrade question the issue asks. Consumption already billed is never erased by a plan move, which is exactly the rule `invoice.paid` applies outside `billing_reason === "subscription_cycle"`, and the rule `customer.subscription.deleted` applies (no re-grant). So an upgrade frees exactly the added headroom, and a downgrade below current consumption leaves the account over its ceiling until the renewal invoice resets the counter. Both halves are asserted in tests rather than left implicit. The reasoning is recorded as a comment at the site.

3 lines of behaviour + a comment; no refactor — the surrounding helpers (`planForSubscription`, `currentSubscription`) already existed and are reused unchanged.

## Tests

`packages/module-ee/test/integration/services/webhooks.test.ts` — two cases added to the existing `customer.subscription.updated` describe block:

- *raises the credit quota on an upgrade, freeing the added headroom* (starter 20 000/20 000 → pro: quota 80 000, `creditsUsed` still 20 000)
- *lowers the credit quota on a downgrade without erasing consumption* (pro 60 000/80 000 → starter: quota 20 000, `creditsUsed` still 60 000)

```
pg-test-lock.sh sh -c 'set -a && . ./.env && set +a && bun test packages/module-ee/test/integration/services/webhooks.test.ts'
→ 34 pass, 0 fail, 100 expect() calls
```

Negative control: with `updates.creditQuota = …` removed, both new tests fail with exactly the reported symptom (upgrade → `Expected 80000, Received 20000`; downgrade → `Expected 20000, Received 80000`); the other 32 stay green.

`bunx tsc --noEmit -p packages/module-ee` → clean. `bunx eslint` + `bunx prettier --check` on both touched files → clean.

## Notes for the orchestrator

- Based on `fix/issue-1325` (which itself carries #1323). The 3 changed source lines sit inside the same `updates` block no sibling touches; `webhooks.test.ts` gains a block appended after the existing `customer.subscription.updated` test, so a textual conflict with a sibling editing that file is possible but should be trivial.
- No migration, no env var, no OpenAPI change (`customer.subscription.updated` is a Stripe inbound webhook, not a platform route).
- No deploy ordering constraint. Existing accounts already stranded on a stale quota are **not** repaired by this change — it only fixes new plan transitions. If any production account is currently in that state, a one-off `scripts/migration/` pass would be the vehicle; I did not write one because it needs a look at the live data first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
