### PR TITLE
fix(cli): keep a malformed syncSpaces from bricking every profile

### DIFF
--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -10,7 +10,7 @@
  */
 
 import { mapWithConcurrency } from "@appstrate/core/map-with-concurrency";
-import { resolveActiveProfile, type Profile } from "../lib/config.ts";
+import { resolveActiveProfile, syncSpaceIds, type Profile } from "../lib/config.ts";
 import { ApiError } from "../lib/api.ts";
 import { listSpaces, resolveSpaceRef, type Space } from "../lib/spaces.ts";
 import { DEFAULT_IO, type CommandIO } from "../lib/io.ts";
@@ -660,13 +660,14 @@ async function selectedSpaces(
     }
     return [...new Set(chosen.map((space) => space.id))];
   }
-  if (!profile.syncSpaces) return spaces.filter(suppliesSkills).map((space) => space.id);
+  const configured = syncSpaceIds(profileName, profile);
+  if (!configured) return spaces.filter(suppliesSkills).map((space) => space.id);
   // A stored list outlives the grants it was written against. An id this
   // profile no longer reaches is dropped with a note, not a failure: losing
   // access is a decision elsewhere, and it must not break the other spaces.
   const listed = new Map(spaces.map((space) => [space.id, space]));
   const kept: string[] = [];
-  for (const id of profile.syncSpaces) {
+  for (const id of configured) {
     const space = listed.get(id);
     if (space && suppliesSkills(space)) {
       kept.push(id);

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -32,7 +32,41 @@ export interface Profile {
   email: string;
   orgId?: string;
   spaceId?: string;
-  syncSpaces?: string[];
+  syncSpaces?: string[] | InvalidSyncSpaces;
+}
+
+/**
+ * A `syncSpaces` that is not a list of space IDs, carried verbatim instead of
+ * thrown. `readConfig` runs at the first line of every command for every
+ * profile, so throwing there turned one typo in one profile into a CLI with no
+ * way left to repair or even log out of it (#1363). The value stays on the
+ * profile so a write that touches another key round-trips the typo rather than
+ * silently deleting it — deleting it would turn a narrowed sync back into
+ * "every space" without saying so. Read the list through `syncSpaceIds`, which
+ * is where the malformed case turns into the repair instruction.
+ */
+export interface InvalidSyncSpaces {
+  readonly invalid: unknown;
+}
+
+function isInvalidSyncSpaces(value: string[] | InvalidSyncSpaces): value is InvalidSyncSpaces {
+  return !Array.isArray(value);
+}
+
+/**
+ * The space IDs this profile narrows skill sync to, or `undefined` when it
+ * narrows nothing. Throws — naming the profile, the key and the file — when the
+ * stored value is malformed, so the one command that reads the list is the one
+ * command a typo stops.
+ */
+export function syncSpaceIds(profileName: string, profile: Profile): string[] | undefined {
+  const value = profile.syncSpaces;
+  if (value === undefined) return undefined;
+  if (isInvalidSyncSpaces(value))
+    throw new Error(
+      `Invalid syncSpaces for profile "${profileName}" in ${getConfigPath()}: expected an array of space IDs, e.g. syncSpaces = ["spc_abc123"].`,
+    );
+  return value;
 }
 
 export interface Config {
@@ -134,7 +168,7 @@ export async function readConfig(): Promise<Config> {
       email: row.email,
       orgId: typeof row.orgId === "string" ? row.orgId : undefined,
       spaceId: typeof row.spaceId === "string" ? row.spaceId : undefined,
-      ...(row.syncSpaces === undefined ? {} : { syncSpaces: readSyncSpaces(name, row.syncSpaces) }),
+      ...(row.syncSpaces === undefined ? {} : { syncSpaces: readSyncSpaces(row.syncSpaces) }),
     };
   }
   return { defaultProfile, profiles };
@@ -144,15 +178,24 @@ export async function readConfig(): Promise<Config> {
  * Hand-edited, unlike every other field here, so a malformed value is a typo to
  * report rather than a corrupt write to ignore: a skipped row would surface as
  * "profile not configured" and send the user to `login`, which overwrites the
- * pins they were editing. The message names the profile and the fix instead.
- * Trimming and deduplicating here keeps the rest of the CLI comparing raw IDs.
+ * pins they were editing — and would leave `logout` unable to remove the very
+ * section that needs removing. It is kept instead, and reported by
+ * `syncSpaceIds`. Trimming and deduplicating here keeps the rest of the CLI
+ * comparing raw IDs.
  */
-function readSyncSpaces(profileName: string, value: unknown): string[] {
+function readSyncSpaces(value: unknown): string[] | InvalidSyncSpaces {
   if (!Array.isArray(value) || !value.every((id) => typeof id === "string" && id.trim().length > 0))
-    throw new Error(
-      `Invalid syncSpaces for profile "${profileName}" in ${getConfigPath()}: expected an array of space IDs, e.g. syncSpaces = ["spc_abc123"].`,
-    );
+    return { invalid: value };
   return [...new Set((value as string[]).map((id) => id.trim()))];
+}
+
+/** The TOML shape of a profile: identical to the in-memory one except that a
+ *  malformed `syncSpaces` unwraps back to the raw value it was read from. */
+function storedProfile(profile: Profile): Record<string, unknown> {
+  const { syncSpaces } = profile;
+  if (syncSpaces !== undefined && isInvalidSyncSpaces(syncSpaces))
+    return { ...profile, syncSpaces: syncSpaces.invalid };
+  return { ...profile };
 }
 
 /** Overwrite the config file atomically (tmp + rename). */
@@ -163,7 +206,12 @@ export async function writeConfig(config: Config): Promise<void> {
   const tmp = `${path}.${process.pid}.${Date.now()}.tmp`;
   const payload = stringifyToml({
     defaultProfile: config.defaultProfile,
-    profile: config.profiles,
+    // A malformed `syncSpaces` goes back exactly as it was read: a command that
+    // rewrites some other key must not quietly drop the user's typo, because
+    // dropping it widens the next sync to every space.
+    profile: Object.fromEntries(
+      Object.entries(config.profiles).map(([name, profile]) => [name, storedProfile(profile)]),
+    ),
   });
   await writeFile(tmp, payload, { mode: 0o600 });
   try {

--- a/apps/cli/test/config.test.ts
+++ b/apps/cli/test/config.test.ts
@@ -19,6 +19,7 @@ import {
   listProfiles,
   resolveProfileName,
   resolveActiveProfileOrNull,
+  syncSpaceIds,
   type Config,
 } from "../src/lib/config.ts";
 import { useTempConfigHome } from "./helpers/auth-fixture.ts";
@@ -368,7 +369,9 @@ describe("resolveActiveProfileOrNull", () => {
 });
 
 describe("sync space configuration validation", () => {
-  it("rejects malformed selections without rewriting the user's config", async () => {
+  /** Two profiles, `work` carrying a hand-edited `syncSpaces` that is not a
+   *  list of space IDs. Returns the config path so a test can re-read it. */
+  async function withMalformedWorkProfile(value: string): Promise<string> {
     await setProfile("default", {
       instance: "https://app.example.com",
       userId: "u_test",
@@ -376,14 +379,48 @@ describe("sync space configuration validation", () => {
       orgId: "org_1",
       spaceId: "spc_active",
     });
+    await setProfile("work", {
+      instance: "https://app.example.com",
+      userId: "u_work",
+      email: "alice@work.example.com",
+      orgId: "org_2",
+    });
     const { writeFile } = await import("node:fs/promises");
     const path = join(configHome.dir(), "appstrate", "config.toml");
-    const valid = await readFile(path, "utf8");
-    for (const value of ['"spc_active"', '[""]', '["spc_active", 123]']) {
-      const malformed = `${valid}\nsyncSpaces = ${value}\n`;
-      await writeFile(path, malformed);
-      await expect(readConfig()).rejects.toThrow("Invalid syncSpaces");
-      expect(await readFile(path, "utf8")).toBe(malformed);
+    await writeFile(path, `${await readFile(path, "utf8")}syncSpaces = ${value}\n`);
+    return path;
+  }
+
+  // #1363: `readConfig` runs first in every command, so throwing on a typo in
+  // one profile left no command able to repair or log out of it.
+  it("keeps every profile loadable when one has a malformed selection", async () => {
+    const path = await withMalformedWorkProfile('"spc_active"');
+    const { writeFile } = await import("node:fs/promises");
+    const base = (await readFile(path, "utf8")).replace(/syncSpaces = .*\n/, "");
+    for (const value of ['"spc_active"', '[""]', '["spc_active", 123]', "42"]) {
+      await writeFile(path, `${base}syncSpaces = ${value}\n`);
+      const config = await readConfig();
+      expect(Object.keys(config.profiles).sort()).toEqual(["default", "work"]);
+      expect(config.profiles.default?.syncSpaces).toBeUndefined();
+      expect(syncSpaceIds("default", config.profiles.default!)).toBeUndefined();
+      expect(() => syncSpaceIds("work", config.profiles.work!)).toThrow(
+        /Invalid syncSpaces for profile "work"/,
+      );
     }
+  });
+
+  it("lets logout remove the offending profile", async () => {
+    const path = await withMalformedWorkProfile('"spc_active"');
+    expect(await deleteProfile("work")).toBe(true);
+    expect(await listProfiles()).toEqual(["default"]);
+    expect(await readFile(path, "utf8")).not.toContain("syncSpaces");
+  });
+
+  it("writes a malformed selection back verbatim when another profile changes", async () => {
+    const path = await withMalformedWorkProfile('"spc_active"');
+    await updateProfile("default", { spaceId: "spc_other" });
+    expect(await readFile(path, "utf8")).toContain('syncSpaces = "spc_active"');
+    const reread = await readConfig();
+    expect(() => syncSpaceIds("work", reread.profiles.work!)).toThrow("Invalid syncSpaces");
   });
 });

--- a/apps/cli/test/skills-multi-context.test.ts
+++ b/apps/cli/test/skills-multi-context.test.ts
@@ -393,6 +393,19 @@ describe("multi-space skill distribution — access decides the sources", () => 
     ]);
   });
 
+  // #1363: a malformed `syncSpaces` no longer breaks `readConfig`, so the one
+  // command that reads the list is the one command that has to refuse it —
+  // rather than silently syncing every space it can reach.
+  it("fails the sync when the configured syncSpaces is malformed", async () => {
+    installSpaces(TWO_SPACES, BOTH);
+    await updateProfile("default", { syncSpaces: { invalid: "spc_library" } });
+    const { io, stderr } = createMemoryIO();
+
+    await expect(skillsSyncCommand({}, io)).rejects.toBeInstanceOf(ExitError);
+
+    expect(stderr()).toContain('Invalid syncSpaces for profile "default"');
+  });
+
   it("narrows to syncSpaces, and skips a configured space that access no longer covers", async () => {
     installSpaces(TWO_SPACES, BOTH);
     await updateProfile("default", { syncSpaces: ["spc_library"] });


### PR DESCRIPTION
Closes #1363

## Root cause

`readSyncSpaces` threw from inside `readConfig`'s per-profile loop (`apps/cli/src/lib/config.ts:137` → `:150-156` before this PR). `readConfig` is the first call of `login`, `logout`, `whoami`, `token`, `api`, `openapi` and every `org` / `space` subcommand, none of which wraps it. A single hand-edited typo in one profile — `syncSpaces = "spc_abc"`, the natural TOML mistake for a flag whose help says "repeatable" — therefore failed every command for every profile, and `logout` could not remove the offending section either. Skipping the row instead was not an option: the profile would read as "not configured", `logout` would answer "already signed out" and leave the bad section in place.

## Fix

Per-profile failure, deferred to the one reader.

- `Profile.syncSpaces` becomes `string[] | InvalidSyncSpaces`; `readSyncSpaces` returns `{ invalid: rawValue }` instead of throwing, so every profile still loads and every command that does not read the list keeps working — `logout` included.
- New `syncSpaceIds(profileName, profile)` is where the malformed case turns into the error, with the same message as before (profile + key + file + example). `selectedSpaces` in `apps/cli/src/commands/skills.ts` reads through it, so `skills sync` — the only consumer — is the only command a typo stops, and it fails loudly rather than silently syncing every reachable space.
- `writeConfig` unwraps the marker back to the raw value, so an unrelated write (`space switch` on another profile) round-trips the user's typo instead of quietly deleting it. Deleting it would widen the next sync from a narrowed list to every space with no message.

The union means the compiler, not a convention, forces the malformed case to be handled: exactly one call site had to narrow.

## Tests

`apps/cli/test/config.test.ts` — the old "rejects malformed selections" test is replaced by three that assert the new contract: every profile stays loadable (across four malformed shapes) while `syncSpaceIds` throws for the offending one; `logout`'s `deleteProfile` removes the bad section; an unrelated `updateProfile` writes the malformed value back verbatim.
`apps/cli/test/skills-multi-context.test.ts` — end-to-end guard that `skills sync` exits with `Invalid syncSpaces for profile "default"` rather than falling through to the every-space default.

```
cd apps/cli && TEST_TIER=0 bun test test/config.test.ts test/skills-multi-context.test.ts   → 45 pass, 0 fail
cd apps/cli && TEST_TIER=0 bun test test/login-org.test.ts test/skills-command.test.ts \
  test/spaces.test.ts test/org-command.test.ts test/space-command.test.ts test/logout.test.ts → 168 pass, 0 fail
bunx tsc --noEmit -p apps/cli   → clean
bunx eslint / prettier on the four touched files → clean
```

## Notes for the orchestrator

- Based on `fix/issue-1362`; PR targets that branch. The overlap with #1362 is `apps/cli/src/commands/skills.ts`: two lines inside `selectedSpaces` (`profile.syncSpaces` → `syncSpaceIds(...)`), a different function from the `reachableSpaces` #1362 added.
- No migration, no env var, no OpenAPI change. CLI-only.
- The exported `InvalidSyncSpaces` type and `syncSpaceIds` are new public members of `apps/cli/src/lib/config.ts` — internal to the CLI app, not `@appstrate/core`, so no lockstep or publish implication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
