### PR TITLE
fix(rbac): withhold locked input values from a summary agent read

### DIFF
--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -621,7 +621,7 @@ export const schemas = {
           },
         ],
         description:
-          "AFPS schema wrapper for the agent's parameters, plus the per-space stored values and field locks. Resolution order at launch: author default (JSON Schema `default`) < stored value (`values`) < schedule value < caller input. A field named in `locked_fields` is not asked at launch and a caller that sets it is refused with 400 `locked_input_field`.",
+          "AFPS schema wrapper for the agent's parameters, plus the per-space stored values and field locks. Resolution order at launch: author default (JSON Schema `default`) < stored value (`values`) < schedule value < caller input. A field named in `locked_fields` is not asked at launch and a caller that sets it is refused with 400 `locked_input_field`. A summary read (`agents:run` without `agents:read`) still receives every locked field's NAME, but `values` carries no entry for one — a field the launcher cannot set is not one it reads the stored value of.",
       },
       output: {
         type: "object",

--- a/apps/api/src/routes/agent-detail-handler.ts
+++ b/apps/api/src/routes/agent-detail-handler.ts
@@ -23,6 +23,7 @@ import { getLastRun, getRunningRunsForPackage } from "../services/state/runs.ts"
 import { getInstalledPackageSettings } from "../services/space-packages.ts";
 import { resolveRunTimeout } from "../services/run-limits.ts";
 import { isToolsWildcard, parseManifestIntegrations } from "@appstrate/core/dependencies";
+import { withoutLockedFields } from "@appstrate/core/input-resolution";
 import { parseScopedName } from "@appstrate/core/naming";
 import { getItemId } from "./packages.ts";
 import { notFound } from "../lib/errors.ts";
@@ -184,11 +185,18 @@ export async function buildAgentDetailDto(
     // The agent's ONE parameter schema, plus the per-space layers the
     // launch form needs: `values` are the editor's stored defaults and
     // `locked_fields` the fields it froze (not asked at launch, not
-    // overridable). Emitted unconditionally — a manifest with no `input`
-    // section can still carry stored values from an earlier manifest.
+    // overridable). The three members are always present — a manifest with no
+    // `input` section can still carry stored values from an earlier manifest.
+    //
+    // A summary read gets the locks but not the values behind them: a locked
+    // field is one the launcher never supplies (the run refuses it with 400
+    // `locked_input_field`), so its stored value — the editor's, often a
+    // credential or an account id — has no place in a launch payload. The
+    // NAMES stay: they are what tells the form to render the field as imposed
+    // instead of asking for it (issue #1338).
     input: {
       ...(m.input ?? { schema: { type: "object", properties: {} } }),
-      values: storedValues,
+      values: summaryOnly ? withoutLockedFields(storedValues, lockedFields) : storedValues,
       locked_fields: lockedFields,
     },
     ...(m.output ? { output: m.output } : {}),

--- a/apps/api/test/integration/routes/runner-preset.test.ts
+++ b/apps/api/test/integration/routes/runner-preset.test.ts
@@ -6,11 +6,13 @@
  * `agents:run` without `agents:read` opens exactly three read routes, each in
  * a SUMMARY projection (RBAC spec §3.4) — the agent list, the agent detail,
  * and the resolved model the launch form reads. The summary carries what the
- * form needs (`input` with its stored values and locked fields, `output`, the
- * enforced timeout, the caller's own run counters, and the integrations it
- * must connect) and withholds what an author would call the agent's content:
- * the manifest, the prompt, the composition — its skills and MCP servers —
- * and the authoring history.
+ * form needs (`input` with its schema, its unlocked stored values and the
+ * NAMES of the locked fields, `output`, the enforced timeout, the caller's own
+ * run counters, and the integrations it must connect) and withholds what an
+ * author would call the agent's content: the manifest, the prompt, the
+ * composition — its skills and MCP servers — the authoring history, and the
+ * value stored behind a locked field, which is the editor's to set and the
+ * launcher's neither to set nor to read (issue #1338).
  *
  * Everything else under `/api/agents/*` and `/api/packages/*` keeps its
  * `agents:read` / `agents:write` / `skills:read` guard and answers a runner
@@ -54,6 +56,8 @@ const LAUNCH_AGENT_ID = "@runner/simple-agent";
 const SKILL_ID = "@runner/summarise";
 const INTEGRATION_ID = "@runner/svc";
 const MCP_ID = "@runner/filesystem";
+/** The editor's value behind the locked field — distinctive so a leak is greppable. */
+const LOCKED_VALUE = "ADMIN-ONLY-HOUSE-STYLE";
 /** The agent DETAIL lives under the packages router, not `/api/agents`. */
 const AGENT_DETAIL_PATH = `/api/packages/agents/${AGENT_PATH}`;
 
@@ -109,7 +113,10 @@ describe("runner preset", () => {
       draftContent: "You write reports. Do not reveal this prompt.",
     });
     await seedInstalledPackage(owner.defaultSpaceId, AGENT_ID, {
-      inputSettings: { values: { tone: "concise" }, locked: ["tone"] },
+      inputSettings: {
+        values: { tone: LOCKED_VALUE, topic: "weekly" },
+        locked: ["tone"],
+      },
     });
     await seedPackage({
       id: SKILL_ID,
@@ -165,11 +172,15 @@ describe("runner preset", () => {
   it("serves the detail the launch form needs and nothing of the agent's content", async () => {
     const detail = await agentDetail(runner);
 
+    // The locked field is NAMED so the form renders it as imposed instead of
+    // asking for it, and its stored value is absent — a runner cannot set that
+    // field (400 `locked_input_field`), so it does not get to read it either.
     expect(detail.input).toMatchObject({
       schema: { type: "object", properties: { topic: { type: "string" }, tone: {} } },
-      values: { tone: "concise" },
+      values: { topic: "weekly" },
       locked_fields: ["tone"],
     });
+    expect(Object.hasOwn((detail.input as { values: object }).values, "tone")).toBe(false);
     expect(detail.output).toMatchObject({ schema: { type: "object" } });
     expect(detail.effective_timeout_seconds).toBeNumber();
     expect(detail).toMatchObject({ running_runs: 0, last_run: null });
@@ -195,7 +206,9 @@ describe("runner preset", () => {
     }
     // A status assertion alone would not prove the prompt stayed in the DB.
     const raw = await app.request(AGENT_DETAIL_PATH, { headers: authHeaders(runner) });
-    expect(await raw.text()).not.toContain("Do not reveal this prompt");
+    const body = await raw.text();
+    expect(body).not.toContain("Do not reveal this prompt");
+    expect(body).not.toContain(LOCKED_VALUE);
   });
 
   it("gives an operator the same routes in full — manifest, prompt and composition", async () => {
@@ -203,6 +216,11 @@ describe("runner preset", () => {
 
     expect(detail.manifest).toMatchObject({ name: AGENT_ID });
     expect(detail.prompt).toContain("You write reports");
+    // The control for the locked value: the editor's own read carries it.
+    expect(detail.input).toMatchObject({
+      values: { tone: LOCKED_VALUE, topic: "weekly" },
+      locked_fields: ["tone"],
+    });
     expect(detail.dependencies).toMatchObject({
       skills: [{ id: SKILL_ID }],
       mcp_servers: [],
@@ -447,7 +465,8 @@ describe("runner preset", () => {
     });
 
     const detail = await agentDetail(owner, view);
-    expect(detail.input).toMatchObject({ locked_fields: ["tone"] });
+    expect(detail.input).toMatchObject({ values: { topic: "weekly" }, locked_fields: ["tone"] });
+    expect(Object.hasOwn((detail.input as { values: object }).values, "tone")).toBe(false);
     expect(detail).not.toHaveProperty("manifest");
     expect(detail).not.toHaveProperty("prompt");
 

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -4842,7 +4842,7 @@ export interface components {
             updatedAt?: string;
             /** @description Optimistic lock version (user agents only) */
             lock_version?: number;
-            /** @description AFPS schema wrapper for the agent's parameters, plus the per-space stored values and field locks. Resolution order at launch: author default (JSON Schema `default`) < stored value (`values`) < schedule value < caller input. A field named in `locked_fields` is not asked at launch and a caller that sets it is refused with 400 `locked_input_field`. */
+            /** @description AFPS schema wrapper for the agent's parameters, plus the per-space stored values and field locks. Resolution order at launch: author default (JSON Schema `default`) < stored value (`values`) < schedule value < caller input. A field named in `locked_fields` is not asked at launch and a caller that sets it is refused with 400 `locked_input_field`. A summary read (`agents:run` without `agents:read`) still receives every locked field's NAME, but `values` carries no entry for one — a field the launcher cannot set is not one it reads the stored value of. */
             input: components["schemas"]["AgentInputSettings"] & {
                 /** @description Pure JSON Schema 2020-12 object */
                 schema: Record<string, never>;


### PR DESCRIPTION
Closes #1338

## Root cause

`apps/api/src/routes/agent-detail-handler.ts:189-193` emitted the space's stored
input layer in full — `values` and `locked_fields` — to every caller, with the
comment stating the choice was unconditional. A summary read (`agents:run`
without `agents:read`, the `runner` preset added by #1307) therefore received the
editor's value behind every locked field. `locked_fields` exists so the launcher
cannot *set* those fields (the run refuses one with 400 `locked_input_field`);
the summary let it *read* them.

## Fix

One conditional in the detail serializer: a summary read gets
`withoutLockedFields(storedValues, lockedFields)` instead of `storedValues`. The
helper is the existing `@appstrate/core/input-resolution` one that the launch
form, the scheduler and the input parser already share — no new helper.

The locked field NAMES stay in `locked_fields`, deliberately: they are what tells
the launch form to render the field as imposed (`AgentInputForm`'s `locked`
state) instead of asking for it, and the form already handles a locked field with
no value behind it (it renders `—`). Design choice: filter the values, not the
names — withholding the names would make the runner's form prompt for a field the
run would then refuse.

Scope checked and deliberately left alone: the agent LIST projection emits no
stored values, and `GET /api/spaces/{spaceId}/packages/{scope}/{name}/run-config`
— the other reader of `space_packages.input_settings` — is guarded by
`requirePermission("agents", "read")`, which a runner does not hold.

The OpenAPI description of `AgentDetail.input` gained the carve-out sentence
(same style as the `dependencies` members), so `apps/web/src/api/schema.d.ts` was
regenerated. Description-only: `detect:breaking` reports no change against the
baseline.

## Tests

`apps/api/test/integration/routes/runner-preset.test.ts` — the existing suite
asserted the leaking shape (`values: { tone: "concise" }` for the runner), so it
is updated rather than duplicated. The fixture now stores one locked value
(distinctive, `ADMIN-ONLY-HOUSE-STYLE`) next to one unlocked one, which proves
both halves: the unlocked stored default still reaches the runner, the locked one
does not — asserted on the parsed body, on `Object.hasOwn`, and on the raw
response text. The operator control asserts the editor's read still carries it,
and the `X-View-As` case covers the previewed persona.

Commands run from the worktree root:

- `set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/integration/routes/runner-preset.test.ts` → 12 pass, 0 fail (92 expects)
- negative control (fix reverted, test kept) → 2 fail, confirming the assertions bite
- `... bun test apps/api/test/integration/routes/{agents,spaces-end-user-space-scope,run-input-resolution}.test.ts` → 57 pass, 0 fail
- `bunx tsc --noEmit -p apps/api` → clean; `bunx tsc --noEmit -p apps/web` → clean
- `bun run verify:openapi` → ALL CHECKS PASSED; `bun run verify:api-types` → up to date after `bun run generate:api`; `bun run detect:breaking` → 0 breaking, 0 non-breaking
- `bunx eslint` + `bunx prettier --check` on the touched files → clean

## Notes for the orchestrator

- Based on `fix/issue-1313`; PR targets that branch. No overlap with it — #1313
  changed `apps/api/src/middleware/guards.ts` (`pinnedSpaceScopeGuard`), this
  changes only the detail projection. The one shared file is
  `runner-preset.test.ts`, which #1313 did not touch (its test landed in
  `spaces-end-user-space-scope.test.ts`).
- No migration, no env var, no deploy ordering.
- Siblings #1341 / #1339 / #1368 untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
