### PR TITLE
fix(module-ee): widen cost_credits to bigint so an overflow cannot wedge the sweep

### DIFF
--- a/packages/module-ee/drizzle/migrations/0007_bigint_cost_credits.sql
+++ b/packages/module-ee/drizzle/migrations/0007_bigint_cost_credits.sql
@@ -1,0 +1,18 @@
+-- Widen the cumulative credit total so it cannot overflow mid-sweep.
+--
+--   ee_usage_records.cost_credits — integer => bigint.
+--
+-- `cost_credits` is CUMULATIVE per usage context, and the `unattributed` bucket
+-- is one row per org that never resets, so an `integer` ceiling of 2 147 483 647
+-- credits (~$2.15M) is reachable. The sweep writes it as
+-- `round((cost_usd + delta) * 1000)` and derives the org debit from a RETURNING
+-- expression over the same column, both INSIDE the transaction that claims the
+-- ledger rows: an `integer out of range` there rolls the whole pass back, so a
+-- single overflowing row stops billing for EVERY tenant on every tick.
+--
+-- Cheap now, an incident later: int4 => int8 is a table rewrite, and this widens
+-- a column while every value in it still fits in four bytes.
+--
+-- No DML: the USING conversion is implicit and lossless (every int4 is an int8).
+-- Re-runnable — re-applying the same type is a no-op.
+ALTER TABLE "ee_usage_records" ALTER COLUMN "cost_credits" SET DATA TYPE bigint;

--- a/packages/module-ee/drizzle/migrations/meta/0007_snapshot.json
+++ b/packages/module-ee/drizzle/migrations/meta/0007_snapshot.json
@@ -1,0 +1,459 @@
+{
+  "id": "5f1ec2b5-804b-4f15-a818-4d4ab6053882",
+  "prevId": "9af6f70f-1556-45ac-b6a7-57f9d9986e7a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ee_billing_accounts": {
+      "name": "ee_billing_accounts",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "credits_used": {
+          "name": "credits_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "credit_quota": {
+          "name": "credit_quota",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "billing_cc": {
+          "name": "billing_cc",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ee_billing_stripe_customer": {
+          "name": "idx_ee_billing_stripe_customer",
+          "columns": [
+            {
+              "expression": "stripe_customer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ee_billing_stripe_subscription": {
+          "name": "idx_ee_billing_stripe_subscription",
+          "columns": [
+            {
+              "expression": "stripe_subscription_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ee_billing_cursor": {
+      "name": "ee_billing_cursor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "boolean",
+          "primaryKey": true,
+          "notNull": true,
+          "default": true
+        },
+        "last_llm_usage_id": {
+          "name": "last_llm_usage_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "floor_id": {
+          "name": "floor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ee_billing_cursor_single_row": {
+          "name": "ee_billing_cursor_single_row",
+          "value": "\"ee_billing_cursor\".\"id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ee_billing_managers": {
+      "name": "ee_billing_managers",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_by": {
+          "name": "added_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ee_billing_managers_org_id_user_id_pk": {
+          "name": "ee_billing_managers_org_id_user_id_pk",
+          "columns": [
+            "org_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ee_billed_llm_usage": {
+      "name": "ee_billed_llm_usage",
+      "schema": "",
+      "columns": {
+        "llm_usage_id": {
+          "name": "llm_usage_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pricing_status": {
+          "name": "pricing_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'priced'"
+        },
+        "billed_at": {
+          "name": "billed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ee_free_tier_claims": {
+      "name": "ee_free_tier_claims",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ee_usage_records": {
+      "name": "ee_usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_type": {
+          "name": "context_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "context_id": {
+          "name": "context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_credits": {
+          "name": "cost_credits",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "numeric(24, 12)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_ee_usage_records_context": {
+          "name": "uq_ee_usage_records_context",
+          "columns": [
+            {
+              "expression": "context_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "context_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ee_usage_records_org_id": {
+          "name": "idx_ee_usage_records_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ee_usage_records_created_at": {
+          "name": "idx_ee_usage_records_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ee_stripe_events": {
+      "name": "ee_stripe_events",
+      "schema": "",
+      "columns": {
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/module-ee/drizzle/migrations/meta/_journal.json
+++ b/packages/module-ee/drizzle/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1788887495383,
       "tag": "0006_cutover_floor_and_pricing_status",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1789068582305,
+      "tag": "0007_bigint_cost_credits",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/module-ee/drizzle/schema.ts
+++ b/packages/module-ee/drizzle/schema.ts
@@ -5,6 +5,7 @@ import {
   uuid,
   text,
   boolean,
+  bigint,
   integer,
   numeric,
   timestamp,
@@ -90,6 +91,17 @@ export const billingAccounts = pgTable(
  * Drizzle maps `numeric` to a decimal STRING in TS (no `mode` option at
  * drizzle-orm 0.39) — deliberate: the value never round-trips through a JS
  * float. Callers that need a number convert explicitly.
+ *
+ * `cost_credits` is `bigint` for the same unbounded-growth reason. It is the
+ * cumulative credit total for the context, so an `integer` would top out at
+ * 2 147 483 647 credits (~$2.15M) — reachable by the `unattributed` bucket,
+ * which never resets. The overflow would not be one org's problem: the
+ * `round(...)::bigint` write and the `RETURNING` delta both run INSIDE the
+ * sweep transaction, so an `integer out of range` there rolls back the whole
+ * pass — no ledger row claimed, no watermark advanced — and billing stops for
+ * every tenant on every tick until the row is found. `bigint` moves the
+ * ceiling to ~$9.2e15, and `mode: "number"` keeps the TS type a plain number:
+ * a JS number is exact to 2^53 credits (~$9e12), far past any real total.
  */
 export const orgUsageRecords = pgTable(
   "ee_usage_records",
@@ -98,7 +110,7 @@ export const orgUsageRecords = pgTable(
     orgId: uuid("org_id").notNull(),
     contextType: text("context_type").notNull(),
     contextId: text("context_id").notNull(),
-    costCredits: integer("cost_credits").notNull(),
+    costCredits: bigint("cost_credits", { mode: "number" }).notNull(),
     /** Cumulative raw dollar total for this context — the delta-billing basis. */
     costUsd: numeric("cost_usd", { precision: 24, scale: 12 }).default("0").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/packages/module-ee/src/billing/usage-recorder.ts
+++ b/packages/module-ee/src/billing/usage-recorder.ts
@@ -407,6 +407,13 @@ export async function billLedgerRows(
   // `unattributed` bucket grows without bound, so a float column's absolute
   // error would grow with it.)
   //
+  // WIDTH: `cost_credits` is `bigint` and both casts below are `::bigint`. The
+  // cumulative grows without bound on the durable `unattributed` bucket, and an
+  // `integer out of range` raised here would abort the CALLER's transaction —
+  // one org's overflowing row would stop the sweep for every tenant. See the
+  // column's note in drizzle/schema.ts. The RETURNING delta comes back as a
+  // string (postgres.js renders int8 as text), hence the `Number()` below.
+  //
   // ROUNDING INVARIANT: exactly ONE rounding rule — half away from zero — is
   // shared by `dollarsToCredits` in src/credits.ts (JS `Math.round`, which is
   // half-away-from-zero for the non-negative dollars we bill) and every `round()`
@@ -429,11 +436,11 @@ export async function billLedgerRows(
         target: [orgUsageRecords.contextType, orgUsageRecords.contextId],
         set: {
           costUsd: sql`${orgUsageRecords.costUsd} + ${dollars}`,
-          costCredits: sql`round((${orgUsageRecords.costUsd} + ${dollars}) * ${CREDITS_PER_DOLLAR})::int`,
+          costCredits: sql`round((${orgUsageRecords.costUsd} + ${dollars}) * ${CREDITS_PER_DOLLAR})::bigint`,
         },
       })
       .returning({
-        deltaCredits: sql<number>`${orgUsageRecords.costCredits} - round((${orgUsageRecords.costUsd} - ${dollars}) * ${CREDITS_PER_DOLLAR})::int`,
+        deltaCredits: sql<number>`${orgUsageRecords.costCredits} - round((${orgUsageRecords.costUsd} - ${dollars}) * ${CREDITS_PER_DOLLAR})::bigint`,
       });
     const deltaCredits = Number(row!.deltaCredits);
     if (deltaCredits > 0) perOrg.set(b.orgId, (perOrg.get(b.orgId) ?? 0) + deltaCredits);

--- a/packages/module-ee/test/helpers/seed.ts
+++ b/packages/module-ee/test/helpers/seed.ts
@@ -16,6 +16,7 @@ import {
   billingCursor,
   billingManagers,
 } from "../../drizzle/schema.ts";
+import { CREDITS_PER_DOLLAR } from "../../src/credits.ts";
 import type { LlmUsageLedgerRow } from "@appstrate/core/module";
 import { mockLedger } from "./mock-platform.ts";
 
@@ -55,11 +56,18 @@ export async function seedBillingAccount(overrides: {
   return account!;
 }
 
+/**
+ * `costUsd` is the context's CUMULATIVE dollar total and must stay consistent
+ * with `costCredits` (`costCredits === round(costUsd * CREDITS_PER_DOLLAR)`) —
+ * the sweep derives its debit from the difference between the two. It defaults
+ * to the whole-dollar equivalent of `costCredits`, which satisfies that.
+ */
 export async function seedUsageRecord(overrides: {
   orgId: string;
   contextType?: string;
   contextId: string;
   costCredits: number;
+  costUsd?: number;
 }) {
   const db = getEeDb();
   const [record] = await db
@@ -69,6 +77,7 @@ export async function seedUsageRecord(overrides: {
       contextType: overrides.contextType ?? "run",
       contextId: overrides.contextId,
       costCredits: overrides.costCredits,
+      costUsd: (overrides.costUsd ?? overrides.costCredits / CREDITS_PER_DOLLAR).toFixed(12),
     })
     .returning();
   return record!;

--- a/packages/module-ee/test/integration/services/billing-sweeper.test.ts
+++ b/packages/module-ee/test/integration/services/billing-sweeper.test.ts
@@ -17,6 +17,7 @@ import {
   seedBillingAccount,
   seedLlmUsage,
   seedBillingCursor,
+  seedUsageRecord,
   markLlmUsageBilled,
 } from "../../helpers/seed.ts";
 import {
@@ -234,6 +235,42 @@ describe("billing sweep — cursor consumer", () => {
     expect(record!.contextType).toBe("unattributed");
     expect(Number(record!.costUsd)).toBeCloseTo(0.0008, 6);
     expect(record!.costCredits).toBe(1);
+  });
+
+  it("keeps sweeping when a context's cumulative credits exceed the int4 ceiling", async () => {
+    // The durable `unattributed` bucket never resets, so its cumulative
+    // `cost_credits` grows for the lifetime of the deployment. Past 2 147 483 647
+    // credits (~$2.15M) an `integer` column — and the `round(...)::int` casts
+    // that wrote it — raised "integer out of range" INSIDE the sweep
+    // transaction, rolling back the whole pass: no row claimed, no watermark
+    // advanced, billing dead for EVERY tenant until someone found the row.
+    await seedBillingCursor(0);
+    const beyondInt4 = 3_000_000_000; // credits, i.e. $3M cumulative
+    await seedUsageRecord({
+      orgId,
+      contextType: "unattributed",
+      contextId: orgId,
+      costCredits: beyondInt4,
+      costUsd: beyondInt4 / 1000,
+    });
+    seedLlmUsage({ orgId, costUsd: 0.05, contextType: null, contextId: null });
+
+    const result = await runBillingSweep();
+
+    // The pass committed: the row was claimed and the watermark moved.
+    expect(result.billed).toBe(1);
+    expect(await cursorValue()).toBe(1);
+
+    // Only the DELTA is debited — the $3M already on the record is not re-billed.
+    expect(await creditsUsed()).toBe(50);
+
+    const db = getEeDb();
+    const [record] = await db
+      .select()
+      .from(orgUsageRecords)
+      .where(eq(orgUsageRecords.contextId, orgId));
+    expect(record!.costCredits).toBe(beyondInt4 + 50);
+    expect(Number(record!.costUsd)).toBeCloseTo(3_000_000.05, 6);
   });
 
   it("bills a chat-context row and keys the usage record by chat session", async () => {

--- a/packages/module-ee/test/integration/services/migrate.test.ts
+++ b/packages/module-ee/test/integration/services/migrate.test.ts
@@ -312,6 +312,72 @@ describe("migration chain upgrades", () => {
     );
     expect(named).toEqual([]);
   });
+
+  it("0006 → 0007 widens cost_credits to bigint past the int4 ceiling", async () => {
+    await resetToBlankSlate();
+    for (const tag of [
+      "0000_init",
+      "0001_cursor_billing",
+      "0002_numeric_cost",
+      "0003_normalize_free_subscription_status",
+      "0004_billing_managers_and_contact",
+      "0005_rename_ee_tables",
+      "0006_cutover_floor_and_pricing_status",
+    ]) {
+      await applyMigration(tag);
+    }
+
+    const [before] = await db.execute(
+      sql.raw(
+        `SELECT data_type FROM information_schema.columns
+         WHERE table_name = 'ee_usage_records' AND column_name = 'cost_credits'`,
+      ),
+    );
+    expect(before!.data_type).toBe("integer");
+
+    // A pre-existing row must survive the type change with its value intact.
+    const org = "00000000-0000-4000-a000-0000000000f1";
+    await db.execute(sql.raw(`INSERT INTO ee_billing_accounts (org_id) VALUES ('${org}')`));
+    await db.execute(
+      sql.raw(
+        `INSERT INTO ee_usage_records (org_id, context_type, context_id, cost_credits, cost_usd)
+         VALUES ('${org}', 'unattributed', '${org}', 2000000000, 2000000)`,
+      ),
+    );
+
+    await applyMigration("0007_bigint_cost_credits");
+
+    const [after] = await db.execute(
+      sql.raw(
+        `SELECT data_type FROM information_schema.columns
+         WHERE table_name = 'ee_usage_records' AND column_name = 'cost_credits'`,
+      ),
+    );
+    expect(after!.data_type).toBe("bigint");
+
+    const [kept] = await db.execute(
+      sql.raw(`SELECT cost_credits FROM ee_usage_records WHERE org_id = '${org}'`),
+    );
+    expect(Number(kept!.cost_credits)).toBe(2_000_000_000);
+
+    // The point of the widening: a cumulative past 2 147 483 647 credits now
+    // accumulates instead of aborting the sweep transaction that writes it.
+    await db.execute(
+      sql.raw(
+        `UPDATE ee_usage_records
+         SET cost_credits = round((cost_usd + 1000000) * 1000)::bigint,
+             cost_usd = cost_usd + 1000000
+         WHERE org_id = '${org}'`,
+      ),
+    );
+    const [grown] = await db.execute(
+      sql.raw(`SELECT cost_credits FROM ee_usage_records WHERE org_id = '${org}'`),
+    );
+    expect(Number(grown!.cost_credits)).toBe(3_000_000_000);
+
+    // Re-runnable: applying it a second time is a no-op, not an error.
+    await applyMigration("0007_bigint_cost_credits");
+  });
 });
 
 // The proof of the header's claim, held where a future edit that re-points this
@@ -328,6 +394,6 @@ describe("isolation from the platform test database", () => {
     const [applied] = await live.execute<{ count: number }>(sql`
       SELECT count(*)::int AS count FROM drizzle.ee_migrations
     `);
-    expect(applied?.count).toBe(7);
+    expect(applied?.count).toBe(8);
   });
 });


### PR DESCRIPTION
Closes #1330

## Root cause

`ee_usage_records.cost_credits` was declared `integer` (`packages/module-ee/drizzle/schema.ts:101`) while holding a **cumulative** credit total per usage context. The durable `unattributed` bucket is one row per org that never resets, so that total grows for the lifetime of the deployment and an int4 ceiling of 2 147 483 647 credits (~$2.15M) is reachable.

The overflow was not one org's problem. `billLedgerRows` writes the column as `round((cost_usd + delta) * 1000)::int` and derives the org debit from a `RETURNING` expression over the same cast (`packages/module-ee/src/billing/usage-recorder.ts:432` and `:436`) — both **inside** the transaction that claims the ledger rows. An `integer out of range` there rolls the whole pass back: no row claimed, no watermark advanced. Billing stops fleet-wide, on every tick, until someone finds the offending row.

## Fix

- **EE migration 0007** (`0007_bigint_cost_credits.sql`): `ALTER TABLE ee_usage_records ALTER COLUMN cost_credits SET DATA TYPE bigint`. Pure DDL, no data repair — the USING conversion is implicit and lossless. int4 => int8 is a table rewrite, so it lands now, while every stored value still fits in four bytes; the same migration after an overflow is an incident.
- **Schema**: `bigint("cost_credits", { mode: "number" })`. `mode: "number"` keeps the TS type a plain number and keeps every existing `record.costCredits` assertion working; a JS number is exact to 2^53 credits (~$9e12), far past any real total.
- **Sweep**: both casts become `::bigint`. Widening the column alone would not have helped — `round(numeric)::int` overflows at 2^31 regardless of the column's width, and that cast is the actual throw site (see the negative control below). The `RETURNING` delta already goes through `Number()`, which is exactly what postgres.js needs for an int8 it renders as text.

Deliberately **not** widened: `ee_billing_accounts.credits_used`. It is reset to 0 on every renewal (`src/stripe/webhooks.ts:418`), so it is period-scoped rather than unbounded — a different question from the one this issue raises.

No refactor: three source lines plus the migration. The rest is comments and tests.

## Tests

Two regressions, one per half of the fix.

- `packages/module-ee/test/integration/services/billing-sweeper.test.ts` — seeds an `unattributed` bucket already at 3 000 000 000 credits ($3M cumulative), sweeps one $0.05 row, and asserts the pass commits, only the 50-credit delta is debited, and the record lands at 3 000 000 050.
- `packages/module-ee/test/integration/services/migrate.test.ts` — a `0006 → 0007` upgrade case: the column is `integer` before and `bigint` after, a pre-existing 2 000 000 000-credit row survives intact, a cumulative past the int4 ceiling then accumulates, and re-applying is a no-op. The file's journal-count assertion moves 7 → 8, which is what proves the migration is self-applied at `init()`.
- `packages/module-ee/test/helpers/seed.ts` — `seedUsageRecord` gains `costUsd`, defaulted to the whole-dollar equivalent of `costCredits`, so a seeded row satisfies the invariant the sweep reads (`cost_credits === round(cost_usd * CREDITS_PER_DOLLAR)`) instead of leaving the column at 0. Three existing callers are unaffected (they sum or delete the rows).

Commands (from the worktree root, serialised on the shared Postgres):

```
pg-test-lock.sh sh -c 'set -a && . ./.env && set +a && bun test packages/module-ee/test/integration/services/{billing-sweeper,migrate,repair-account,post-signup,org-drain}.test.ts'
```

- `billing-sweeper` + `migrate` → **72 pass, 0 fail**
- `billing-sweeper` + `repair-account` + `post-signup` + `org-drain` → **104 pass, 0 fail**
- `bunx tsc --noEmit -p packages/module-ee` → clean
- `bunx eslint` + `bunx prettier --check` on the five touched TS files → clean
- `bun run verify:no-migration-dml` → green (69 files, 2 trees)

**Negative control**: reverting just the two casts to `::int` makes the new sweeper test fail with the production symptom, `PostgresError: integer out of range`, on the exact `insert … on conflict … returning` statement. Restored and re-run green afterwards.

## Notes for the orchestrator

- **Migration**: EE **0007** (the index reserved for this issue), `packages/module-ee/drizzle/migrations/0007_bigint_cost_credits.sql`, with `meta/0007_snapshot.json` and the `_journal.json` entry written by hand (`db:generate` needs a TTY). The snapshot diffs against 0006 in exactly three places: `id`, `prevId`, and `cost_credits.type`. `when` is a real current timestamp, strictly greater than 0006's — a `when` at or below the last applied `created_at` is silently skipped by the migrator.
- **Deploy ordering**: self-applied at module `init()` from the folder, like every EE migration. It is a table rewrite (`ACCESS EXCLUSIVE` for its duration), but `ee_usage_records` is small at present, so it is not a lock-window concern today. No env var, no platform migration, nothing to run by hand.
- **Base**: built on `fix/issue-1328`; the chain's own commits are untouched.
- **Overlap**: `packages/module-ee/src/billing/repair-account.ts` reads `SUM(cost_credits)` and is **sibling #1329's** territory — deliberately not touched. The SUM already returned a wider type than `credits_used` (`SUM(int4)` is `int8`), so widening the column to `bigint` changes nothing about that assignment cast. `usage-recorder.ts` is also touched by the #1326/#1328 chain, but in `billing-sweeper.ts` / `env.ts` and the batch-size logic — not in `billLedgerRows`, so no textual overlap.
- **Open decision**: none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
