### PR TITLE
fix(ee): narrow customer.source.expiring to an actual card

### DIFF
--- a/packages/module-ee/src/stripe/webhooks.ts
+++ b/packages/module-ee/src/stripe/webhooks.ts
@@ -572,8 +572,7 @@ async function processEvent(event: Stripe.Event): Promise<void> {
       }
       const { orgId } = subMetadata;
 
-      const previousAttributes = (event.data as { previous_attributes?: Record<string, unknown> })
-        .previous_attributes;
+      const previousAttributes = event.data.previous_attributes;
       const itemPeriodEnd = subscriptionPeriodEnd(subscription);
       const newPlan = planForSubscription(subscription, plans);
 
@@ -644,9 +643,7 @@ async function processEvent(event: Stripe.Event): Promise<void> {
         "items" in previousAttributes &&
         !subscription.cancel_at_period_end
       ) {
-        const previousPriceId = (
-          previousAttributes.items as { data?: Array<{ price?: { id?: string } }> }
-        )?.data?.[0]?.price?.id;
+        const previousPriceId = previousAttributes.items?.data[0]?.price.id;
         const oldPlan = Object.values(plans).find((p) => p?.stripePriceId === previousPriceId);
 
         if (oldPlan && oldPlan.id !== newPlan.id) {
@@ -773,8 +770,18 @@ async function processEvent(event: Stripe.Event): Promise<void> {
     }
 
     case "customer.source.expiring": {
-      // Pre-dunning: card expiring soon (sent ~30 days before expiry by Stripe)
-      const source = event.data.object as Stripe.Card;
+      // Pre-dunning: card expiring soon (sent ~30 days before expiry by Stripe).
+      // The payload is a `CustomerSource` — `Account | BankAccount | Card | Source`.
+      // Only a `Card` carries `exp_month` / `exp_year`; the other members have no
+      // expiry to announce, so there is nothing to send.
+      const source = event.data.object;
+      if (source.object !== "card") {
+        logger.debug("Source expiring is not a card — no email", {
+          eventId: event.id,
+          sourceObject: source.object,
+        });
+        break;
+      }
       const expiringCustomerId = refId(source.customer);
 
       if (expiringCustomerId) {
@@ -785,7 +792,7 @@ async function processEvent(event: Stripe.Event): Promise<void> {
 
         if (expiringAccount) {
           sendBillingEmail(expiringAccount.orgId, "card-expiring", {
-            cardLast4: source.last4 ?? "????",
+            cardLast4: source.last4,
             expiryMonth: `${String(source.exp_month).padStart(2, "0")}/${String(source.exp_year).slice(-2)}`,
             updateUrl: billingSettingsUrl(getAppUrl()),
             locale: "fr",

--- a/packages/module-ee/test/integration/services/webhook-emails.test.ts
+++ b/packages/module-ee/test/integration/services/webhook-emails.test.ts
@@ -24,7 +24,7 @@ const WEBHOOK_SECRET = "whsec_test_secret_for_webhook_verification";
  */
 describe("webhook billing emails", () => {
   const orgId = "00000000-0000-4000-a000-000000000050";
-  const sentEmails: Array<{ to: string; subject: string }> = [];
+  const sentEmails: Array<{ to: string; subject: string; html: string }> = [];
 
   beforeEach(async () => {
     await truncateEeTables();
@@ -32,8 +32,8 @@ describe("webhook billing emails", () => {
     sentEmails.length = 0;
 
     initBillingEmail({
-      sendMail: async (to, subject) => {
-        sentEmails.push({ to, subject });
+      sendMail: async (to, subject, html) => {
+        sentEmails.push({ to, subject, html });
       },
       getRecipients: async () => ["billing@test.com"],
       getOrgName: async () => null,
@@ -270,6 +270,56 @@ describe("webhook billing emails", () => {
     });
   });
 
+  describe("customer.source.expiring", () => {
+    it("renders the real expiry when the source is a card", async () => {
+      await seedBillingAccount({ orgId, stripeCustomerId: "cus_expiring_001" });
+
+      const { body, signature } = signedEvent({
+        id: "evt_email_expiring_001",
+        type: "customer.source.expiring",
+        data: {
+          object: {
+            id: "card_expiring_001",
+            object: "card",
+            customer: "cus_expiring_001",
+            last4: "4242",
+            exp_month: 3,
+            exp_year: 2027,
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(sentEmails).toHaveLength(1);
+      expect(sentEmails[0]?.html).toContain("03/27");
+      expect(sentEmails[0]?.html).not.toContain("undefined");
+    });
+
+    it("sends nothing for a non-card source, which carries no expiry", async () => {
+      await seedBillingAccount({ orgId, stripeCustomerId: "cus_expiring_002" });
+
+      const { body, signature } = signedEvent({
+        id: "evt_email_expiring_002",
+        type: "customer.source.expiring",
+        data: {
+          object: {
+            id: "src_expiring_002",
+            object: "source",
+            customer: "cus_expiring_002",
+            type: "card",
+          },
+        },
+      });
+
+      await handleWebhook(body, signature);
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(sentEmails).toHaveLength(0);
+    });
+  });
+
   describe("no email on events without account", () => {
     it("does not send email when invoice.paid has unknown customer", async () => {
       const { body, signature } = signedEvent({
@@ -294,8 +344,8 @@ describe("webhook billing emails", () => {
   describe("sends to every billing recipient", () => {
     it("sends one email per recipient", async () => {
       initBillingEmail({
-        sendMail: async (to, subject) => {
-          sentEmails.push({ to, subject });
+        sendMail: async (to, subject, html) => {
+          sentEmails.push({ to, subject, html });
         },
         getRecipients: async () => ["billing@test.com", "cfo@test.com"],
         getOrgName: async () => null,


### PR DESCRIPTION
Closes #1331

## Root cause

`packages/module-ee/src/stripe/webhooks.ts` (the `customer.source.expiring` arm) cast `event.data.object` to `Stripe.Card`. In stripe 22.6.1 that payload is a `CustomerSource` — `Account | BankAccount | Card | Source` (`stripe/cjs/resources/Events.d.ts:977`, `CustomerSources.d.ts:5`). Only `Card` carries `exp_month` / `exp_year`, so for a legacy `Source` the template computed `String(undefined).padStart(2, "0")` + `String(undefined).slice(-2)` and mailed the customer `"undefined/ed"` as their card expiry.

Two neighbouring casts in the `customer.subscription.updated` arm were unnecessary in 22.6.1 and actively harmful: `event.data.previous_attributes` is typed `Partial<Subscription>` upstream, so `as { previous_attributes?: Record<string, unknown> }` and `previousAttributes.items as { data?: … }` erased the compiler's ability to flag a relocation of `items[].price.id` — exactly what an SDK major moves.

## Fix

- Narrow on `source.object !== "card"` and `break` with one debug line. Nothing is lost: the other three members have no expiry to announce, so there is no email to send. With the payload correctly typed, `source.last4 ?? "????"` was dead (`Card.last4: string`, non-nullable) and the `??` is gone.
- Drop both `previous_attributes` casts. `previousAttributes.items?.data[0]?.price.id` now typechecks against the real `ApiList<SubscriptionItem>`, so the next relocation is a compile error instead of a silent `undefined`.

No behaviour change for the card path — same email, same values.

## Tests

`packages/module-ee/test/integration/services/webhook-emails.test.ts` gains a `customer.source.expiring` block (two cases: a `card` payload renders `03/27` and contains no `"undefined"`; a `source` payload sends nothing). The file's captured-email harness now records `html` alongside `to`/`subject`, which is what lets the expiry be asserted at all.

```
pg-test-lock.sh … bun test packages/module-ee/test/integration/services/webhooks.test.ts \
                            packages/module-ee/test/integration/services/webhook-emails.test.ts
→ 44 pass, 0 fail, 119 expect() calls
bunx tsc --noEmit -p packages/module-ee → clean
bunx eslint + prettier on both touched files → clean
```

Negative control: with the `as Stripe.Card` cast restored, the non-card case fails (`9 pass / 1 fail`) — the email goes out with `"undefined/ed"`. Reverted before committing.

## Notes for the orchestrator

- Based on `fix/issue-1324`, so this PR carries that chain's five commits too. Merge order: #1323 → #1325 → #1324 → this.
- Overlap with the sibling chain is confined to `webhooks.ts`; the chain touched the checkout and subscription arms, this touches the `customer.source.expiring` arm and the two casts in `customer.subscription.updated`. No shared lines.
- No migration, no env var, no OpenAPI change. Nothing to order at deploy.
- For #1332 (live contract suite): the `CustomerSource` union is the kind of shape a live contract test would pin — the non-card branch here is asserted only against a synthetic payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
