### PR TITLE
fix(connect): guard the post-burn scope resolution on /connect/start

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -967,19 +967,44 @@ export function createIntegrationsRouter() {
     }
 
     if (auth.type === "oauth2") {
-      // Same scope-union semantics as POST /connect/oauth2.
-      const granted = claims.connection_id
-        ? await getCurrentScopesGranted({
-            scope,
-            integrationId: claims.package_id,
-            authKey: claims.auth_key,
-            actor,
-            connectionId: claims.connection_id,
-          })
-        : [];
-      const defaultScopes = (auth as { default_scopes?: string[] }).default_scopes ?? [];
-      const scopes = [...new Set([...defaultScopes, ...(claims.scopes ?? []), ...granted])];
-      const strategy = resolveStrategy(auth);
+      // Same scope-union semantics as POST /connect/oauth2 — except that here
+      // it runs AFTER the burn and reads the database, so an unguarded fault
+      // escaped to the global error handler and rendered raw
+      // `application/problem+json` inside the popup, on top of a link the click
+      // had already spent (issue #1352).
+      //
+      // Nothing is granted, minted or sent upstream until `begin` runs below,
+      // so a click that dies here is indistinguishable from no click at all:
+      // hand the jti back and the very same link works once the fault passes.
+      // That is the opposite of what the `begin` guard further down does with
+      // its unknown failures, which may have gone half way.
+      let scopes: string[];
+      let strategy: ReturnType<typeof resolveStrategy>;
+      try {
+        const granted = claims.connection_id
+          ? await getCurrentScopesGranted({
+              scope,
+              integrationId: claims.package_id,
+              authKey: claims.auth_key,
+              actor,
+              connectionId: claims.connection_id,
+            })
+          : [];
+        const defaultScopes = (auth as { default_scopes?: string[] }).default_scopes ?? [];
+        scopes = [...new Set([...defaultScopes, ...(claims.scopes ?? []), ...granted])];
+        strategy = resolveStrategy(auth);
+      } catch (err) {
+        logger.error("Hosted connect scope resolution failed", {
+          err: String(err),
+          packageId: claims.package_id,
+          authKey: claims.auth_key,
+        });
+        await releaseJti(claims.jti);
+        return c.html(
+          popupHtmlError("Could not start the connection. Please try again.", completionDetail),
+          500,
+        );
+      }
       if (!strategy.begin) {
         return c.html(
           popupHtmlError("This integration cannot be connected.", completionDetail),

--- a/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
+++ b/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
@@ -20,6 +20,10 @@ import { seedPackage } from "../../helpers/seed.ts";
 import { eq } from "drizzle-orm";
 import { integrationConnections, integrationOauthClients, packages } from "@appstrate/db/schema";
 import type { IntegrationManifest } from "@appstrate/core/integration";
+import {
+  buildConnectUrl,
+  connectClaimsFor,
+} from "../../../src/services/connect/connect-session.ts";
 
 const app = getTestApp();
 
@@ -523,5 +527,53 @@ describe("hosted connect portal — error completions are addressed (issue #1346
       expect(detail.packageId).toBeUndefined();
       expect(detail.state).toBeUndefined();
     }
+  });
+});
+
+describe("hosted connect portal — a fault while resolving scopes (issue #1352)", () => {
+  let ctx: TestContext;
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "myorg" });
+    await seedIntegration(ctx.orgId, oauthManifest("@myorg/gsuite"));
+  });
+
+  /**
+   * Mint a capability token straight from claims. The mint route validates
+   * `connection_id` against the caller's rows, and this case needs claims it
+   * would refuse: a malformed id makes `getCurrentScopesGranted`'s row read
+   * throw at the database the way a real fault there would. That read runs
+   * after the jti is burned and before anything is sent upstream — the window
+   * this test pins.
+   */
+  function mintUnreadableConnection(): string {
+    const { connectUrl } = buildConnectUrl(
+      connectClaimsFor({
+        scope: { orgId: ctx.orgId, spaceId: ctx.defaultSpaceId },
+        actor: { type: "user", id: ctx.user.id },
+        packageId: "@myorg/gsuite",
+        authKey: "google",
+        connectionId: "not-a-uuid",
+      }),
+    );
+    return new URL(connectUrl).searchParams.get("token")!;
+  }
+
+  it("renders the popup error page, not raw problem+json", async () => {
+    const res = await startConnect(mintUnreadableConnection());
+    expect(res.status).toBe(500);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("Please try again");
+    // Addressed like every other completion this handler emits (issue #1346).
+    expect(completionDetail(html)).toMatchObject({ ok: false, packageId: "@myorg/gsuite" });
+  });
+
+  it("hands the link back — this click spent nothing", async () => {
+    const token = mintUnreadableConnection();
+    expect((await startConnect(token)).status).toBe(500);
+    const again = await startConnect(token);
+    expect(again.status).toBe(500);
+    expect(await again.text()).not.toContain("already been used");
   });
 });


### PR DESCRIPTION
Closes #1352

## Root cause

`GET /connect/start` burns the single-use jti at `apps/api/src/routes/integrations.ts:960`, then runs `getCurrentScopesGranted` (a raw `db.select`) and `resolveStrategy` at `:970-982` — both **outside** the `try` that #1302 opened around `strategy.begin`. A database fault in that window escaped to the global error handler, so the popup rendered raw `application/problem+json` instead of the friendly page every other failure path there returns, and the click had already spent the link, so the retry it invited answered `410 already been used`.

## Fix

The two calls get their own guard, not a widened `begin` try. The burn policy differs: nothing is granted, minted or sent upstream until `begin` runs, so a click that dies here is indistinguishable from no click at all — log it, `releaseJti`, render the generic popup error, and the very same link works once the fault passes. `begin`'s guard deliberately keeps the opposite policy for its unknown failures, which may have gone half way (a state row minted); merging the two would have burned the link on a plain DB blip and, for a 4xx, told the user to "ask an administrator" about a database error.

Status is `500` — the failure is ours and nothing upstream was contacted. Already documented on the route as *"Integration cannot be connected / unexpected failure (HTML error page)"*, so no OpenAPI change and no `generate:api` churn.

## Tests

`apps/api/test/integration/routes/integrations-hosted-connect.test.ts` — new describe *"a fault while resolving scopes (issue #1352)"*, 2 cases: the popup gets HTML (not `problem+json`) carrying the package-addressed completion, and a second click on the same link is the same 500, never "already been used".

The lever is a malformed `connection_id` in directly-minted claims (the mint route validates that field, so the claims are built with `buildConnectUrl`/`connectClaimsFor`): the row read then throws at the database exactly the way a real fault there would.

- `TEST_TIER=0 bun test apps/api/test/integration/routes/integrations-hosted-connect.test.ts` → **21 pass / 0 fail**, 114 expects.
- Negative control (fix reverted, tests kept): both new cases fail — `content-type: application/problem+json` and `Expected: 500, Received: 410`.
- `bunx tsc --noEmit -p apps/api` → clean. `eslint` + `prettier` clean on both files.

## Notes for the orchestrator

- Stacked on `fix/issue-1346`; base is that branch.
- **Overlap with #1344**: none in code. That issue narrows the `releaseJti` inside the `begin` catch block, which this PR does not touch — the edit stops at the try boundary above it. This PR adds a *second*, independent `releaseJti` call site whose failure provably precedes any egress, which is the very criterion #1344 argues for, so the two should stay consistent after both land.
- No migration, no env var, no OpenAPI/`schema.d.ts` change. Nothing deploy-ordered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
