### PR TITLE
fix(cli): tell a busy skills-sync lock apart from one that cannot work

### DIFF
--- a/apps/cli/src/commands/logout.ts
+++ b/apps/cli/src/commands/logout.ts
@@ -49,34 +49,39 @@ export async function logoutCommand(
   };
   let credentialsCleared = false;
   try {
-    await withSyncLock(async () => {
-      try {
-        const tokens = await loadTokens(profileName);
-        hadTokens = !!tokens;
-        const profile = await getProfile(profileName);
-        if (tokens && profile) {
-          await revokeCliRefreshToken(
-            normalizeInstance(profile.instance),
-            CLI_CLIENT_ID,
-            tokens.refreshToken,
+    await withSyncLock(
+      async () => {
+        try {
+          const tokens = await loadTokens(profileName);
+          hadTokens = !!tokens;
+          const profile = await getProfile(profileName);
+          if (tokens && profile) {
+            await revokeCliRefreshToken(
+              normalizeInstance(profile.instance),
+              CLI_CLIENT_ID,
+              tokens.refreshToken,
+            );
+          }
+        } catch (err) {
+          io.stderr.write(
+            `warning: could not revoke refresh token server-side (${formatError(err)}); continuing with local cleanup.\n`,
           );
+        } finally {
+          await clearCredentials();
+          credentialsCleared = true;
         }
-      } catch (err) {
-        io.stderr.write(
-          `warning: could not revoke refresh token server-side (${formatError(err)}); continuing with local cleanup.\n`,
-        );
-      } finally {
-        await clearCredentials();
-        credentialsCleared = true;
-      }
-      const cleanup = await cleanupProfileSkills(profileName);
-      if (cleanup.pluginReset)
-        io.stderr.write(
-          "Appstrate plugin reset. Run `claude plugin update appstrate@appstrate` and restart Claude, or start a new session with automatic plugin refresh enabled.\n",
-        );
-      for (const failure of cleanup.warnings)
-        io.stderr.write(`warning: ${failure}. Retry appstrate logout --profile ${profileName}.\n`);
-    });
+        const cleanup = await cleanupProfileSkills(profileName);
+        if (cleanup.pluginReset)
+          io.stderr.write(
+            "Appstrate plugin reset. Run `claude plugin update appstrate@appstrate` and restart Claude, or start a new session with automatic plugin refresh enabled.\n",
+          );
+        for (const failure of cleanup.warnings)
+          io.stderr.write(
+            `warning: ${failure}. Retry appstrate logout --profile ${profileName}.\n`,
+          );
+      },
+      { io },
+    );
   } catch (err) {
     io.stderr.write(
       `warning: could not complete skills cleanup (${formatError(err)}). Retry appstrate logout --profile ${profileName}.\n`,

--- a/apps/cli/src/commands/skills.ts
+++ b/apps/cli/src/commands/skills.ts
@@ -120,86 +120,89 @@ export async function skillsSyncCommand(
   let pluginOk = false;
 
   try {
-    await withSyncLock(async () => {
-      const { profileName, profile } = await resolveActiveProfile(opts.profile);
-      const gap = connectionGap(profileName, profile);
-      if (gap && !printPath) throw new Error(`${gap.problem}. Run: ${gap.remedy}`);
-      const { state, corrupt } = await readSyncState();
-      if (corrupt) {
-        io.stderr.write(
-          "Sync state could not be used and has been ignored — this run re-materializes everything.\n",
-        );
-      }
-
-      if (gap) {
-        pluginOk = await bootstrapPlugin(gap, state, report);
-        return;
-      }
-
-      const context = syncContext(profileName, profile!);
-      // The pin is checked here although it is NOT part of the context: it is
-      // what `fixedFiles` was computed from at the start of the run, so a swap
-      // after it moved would commit a `.mcp.json` naming the previous space.
-      // The next run rewrites that file without treating anything as a switch.
-      const validate = async (): Promise<void> => {
-        const current = await resolveActiveProfile(opts.profile);
-        if (
-          !current.profile ||
-          !sameContext(context, syncContext(current.profileName, current.profile)) ||
-          current.profile.spaceId !== profile!.spaceId ||
-          JSON.stringify(current.profile.syncSpaces) !== JSON.stringify(profile!.syncSpaces)
-        ) {
-          throw new Error("Active sync context changed; run skills sync again.");
-        }
-      };
-      const spaceIds = await selectedSpaces(profileName, profile!, opts.space, report);
-      const catalogue = await resolveAll(
-        profileName,
-        source,
-        state,
-        targets,
-        report,
-        spaceIds,
-        context,
-      );
-      const plans = await Promise.all(
-        targets.map((target) => diffTarget(target, catalogue, state, source, context)),
-      );
-      if (plans.some((plan) => plan.contextChanged) && catalogue.unresolved.size > 0) {
-        throw new Error(
-          "Could not resolve the new context completely; previous installation preserved.",
-        );
-      }
-      for (const plan of plans) {
-        for (const slug of plan.blocked) {
-          report.skill(
-            `Skipped ${catalogue.bySlug.get(slug)!.packageId} on ${plan.target}: ${skillDir(plan.target, slug)} exists and is not managed by appstrate — remove or rename it`,
+    await withSyncLock(
+      async () => {
+        const { profileName, profile } = await resolveActiveProfile(opts.profile);
+        const gap = connectionGap(profileName, profile);
+        if (gap && !printPath) throw new Error(`${gap.problem}. Run: ${gap.remedy}`);
+        const { state, corrupt } = await readSyncState();
+        if (corrupt) {
+          io.stderr.write(
+            "Sync state could not be used and has been ignored — this run re-materializes everything.\n",
           );
         }
-      }
 
-      if (opts.dryRun) {
-        reportPlans(plans, io.stdout);
-        return;
-      }
-      const fixedFiles = pluginFixedFiles({
-        instance: profile!.instance,
-        orgId: profile!.orgId!,
-        spaceId: profile!.spaceId!,
-      });
-      pluginOk = await executePlans(
-        profileName,
-        source,
-        plans,
-        state,
-        catalogue.bySlug,
-        fixedFiles,
-        report,
-        context,
-        validate,
-      );
-      if (!printPath) reportPlans(plans, io.stdout);
-    });
+        if (gap) {
+          pluginOk = await bootstrapPlugin(gap, state, report);
+          return;
+        }
+
+        const context = syncContext(profileName, profile!);
+        // The pin is checked here although it is NOT part of the context: it is
+        // what `fixedFiles` was computed from at the start of the run, so a swap
+        // after it moved would commit a `.mcp.json` naming the previous space.
+        // The next run rewrites that file without treating anything as a switch.
+        const validate = async (): Promise<void> => {
+          const current = await resolveActiveProfile(opts.profile);
+          if (
+            !current.profile ||
+            !sameContext(context, syncContext(current.profileName, current.profile)) ||
+            current.profile.spaceId !== profile!.spaceId ||
+            JSON.stringify(current.profile.syncSpaces) !== JSON.stringify(profile!.syncSpaces)
+          ) {
+            throw new Error("Active sync context changed; run skills sync again.");
+          }
+        };
+        const spaceIds = await selectedSpaces(profileName, profile!, opts.space, report);
+        const catalogue = await resolveAll(
+          profileName,
+          source,
+          state,
+          targets,
+          report,
+          spaceIds,
+          context,
+        );
+        const plans = await Promise.all(
+          targets.map((target) => diffTarget(target, catalogue, state, source, context)),
+        );
+        if (plans.some((plan) => plan.contextChanged) && catalogue.unresolved.size > 0) {
+          throw new Error(
+            "Could not resolve the new context completely; previous installation preserved.",
+          );
+        }
+        for (const plan of plans) {
+          for (const slug of plan.blocked) {
+            report.skill(
+              `Skipped ${catalogue.bySlug.get(slug)!.packageId} on ${plan.target}: ${skillDir(plan.target, slug)} exists and is not managed by appstrate — remove or rename it`,
+            );
+          }
+        }
+
+        if (opts.dryRun) {
+          reportPlans(plans, io.stdout);
+          return;
+        }
+        const fixedFiles = pluginFixedFiles({
+          instance: profile!.instance,
+          orgId: profile!.orgId!,
+          spaceId: profile!.spaceId!,
+        });
+        pluginOk = await executePlans(
+          profileName,
+          source,
+          plans,
+          state,
+          catalogue.bySlug,
+          fixedFiles,
+          report,
+          context,
+          validate,
+        );
+        if (!printPath) reportPlans(plans, io.stdout);
+      },
+      { io },
+    );
   } catch (err) {
     report.run(formatError(err));
     pluginOk = false;

--- a/apps/cli/src/lib/skills-sync/lock.ts
+++ b/apps/cli/src/lib/skills-sync/lock.ts
@@ -8,20 +8,51 @@
  * — SIGKILL from a session closed seconds after it opened included. No pid to
  * trust, no age to guess, no heartbeat. Bun is the runtime on every channel
  * (npm shebang, curl binary), so the libc call comes through `bun:ffi`.
+ *
+ * **Why errno is read.** A non-zero return means "did not lock", not "someone
+ * else holds it". `EWOULDBLOCK` is the only answer that names a competitor;
+ * `ENOLCK` / `EOPNOTSUPP` (NFS without lockd, some 9p and virtiofs container
+ * mounts) mean the filesystem has no `flock` at all. Treating those as busy
+ * blocked the command for the full timeout and then reported a concurrent
+ * process that does not exist.
+ *
+ * **Why an unavailable lock fails open.** Where `flock` does not work — an
+ * unsupported mount, or Windows, which has no `flock(2)` and whose
+ * `LockFileEx` equivalent this project cannot test — the choice is between
+ * running the sync unsynchronised and not syncing at all. The lock guards a
+ * rare race (two syncs started within the same window); refusing every sync
+ * on those hosts is the larger breakage, so the body runs and the user is
+ * told on stderr. That is one path, not a Windows-specific one: a
+ * `LockFileEx` binding lands the day someone can verify it on Windows.
  */
 
-import { dlopen, FFIType } from "bun:ffi";
+import { dlopen, FFIType, read, type Pointer } from "bun:ffi";
 import { closeSync, openSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { getDataDir } from "../config.ts";
+import { DEFAULT_IO, type CommandIO } from "../io.ts";
+
+/** The outcome of one non-blocking attempt at the lock. */
+export type LockAttempt =
+  | { status: "acquired" }
+  | { status: "busy" }
+  | { status: "interrupted" }
+  | { status: "unsupported"; reason: string };
+
+/** Takes an open descriptor, tries once, never blocks, never throws. */
+export type TryLock = (fd: number) => LockAttempt;
 
 export interface SyncLockOptions {
   timeoutMs?: number;
   pollMs?: number;
+  /** Where the "running unlocked" warning goes. */
+  io?: CommandIO;
+  /** Test seam; production resolves the libc binding once per process. */
+  tryLock?: TryLock;
 }
 
-const DEFAULTS: Required<SyncLockOptions> = {
+const DEFAULTS: Required<Pick<SyncLockOptions, "timeoutMs" | "pollMs">> = {
   // Fits a large org's first sync, inside a marketplace command's timeout.
   timeoutMs: 60_000,
   pollMs: 500,
@@ -31,11 +62,14 @@ const DEFAULTS: Required<SyncLockOptions> = {
 const LOCK_EX = 2;
 const LOCK_NB = 4;
 
-/** glibc first; the musl spellings cover a Bun built for Alpine. */
-const LIBC_CANDIDATES =
-  process.platform === "darwin"
-    ? ["libSystem.B.dylib"]
-    : ["libc.so.6", "libc.musl-x86_64.so.1", "libc.musl-aarch64.so.1"];
+// <errno.h>. EINTR agrees across platforms; EWOULDBLOCK does not.
+const EINTR = 4;
+const EWOULDBLOCK_DARWIN = 35;
+const EWOULDBLOCK_LINUX = 11;
+
+const ACQUIRED: LockAttempt = { status: "acquired" };
+const BUSY: LockAttempt = { status: "busy" };
+const INTERRUPTED: LockAttempt = { status: "interrupted" };
 
 export class SyncLockBusyError extends Error {
   constructor() {
@@ -48,12 +82,18 @@ export function getLockPath(): string {
   return join(getDataDir(), "skills-sync", "sync.lock");
 }
 
-/** Released in a `finally`. Throws {@link SyncLockBusyError} past `timeoutMs`. */
+/**
+ * Released in a `finally`. Throws {@link SyncLockBusyError} past `timeoutMs`
+ * while another process holds the lock; runs `body` unlocked, after a warning
+ * on stderr, where the platform or the filesystem has no working `flock(2)`.
+ */
 export async function withSyncLock<T>(
   body: () => Promise<T>,
   options: SyncLockOptions = {},
 ): Promise<T> {
   const { timeoutMs, pollMs } = { ...DEFAULTS, ...options };
+  const io = options.io ?? DEFAULT_IO;
+  const tryLock = options.tryLock ?? sharedTryLock();
   const path = getLockPath();
   await mkdir(join(getDataDir(), "skills-sync"), { recursive: true, mode: 0o700 });
 
@@ -62,11 +102,21 @@ export async function withSyncLock<T>(
   const fd = openSync(path, "a", 0o600);
   try {
     const deadline = Date.now() + timeoutMs;
-    while (flock(fd, LOCK_EX | LOCK_NB) !== 0) {
+    for (;;) {
+      const attempt = tryLock(fd);
+      if (attempt.status === "acquired") return await body();
+      if (attempt.status === "unsupported") {
+        io.stderr.write(
+          `warning: skills sync lock unavailable (${attempt.reason}); continuing unlocked — do not run two syncs at once.\n`,
+        );
+        return await body();
+      }
       if (Date.now() >= deadline) throw new SyncLockBusyError();
-      await new Promise((resolve) => setTimeout(resolve, pollMs));
+      // A signal-interrupted call retries at once; a live holder is waited out.
+      if (attempt.status === "busy") {
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+      }
     }
-    return await body();
   } finally {
     // Closing the descriptor releases the lock — the same thing the kernel
     // does on exit, so there is no signal handling to get right.
@@ -74,24 +124,58 @@ export async function withSyncLock<T>(
   }
 }
 
-let flockSymbol: ((fd: number, operation: number) => number) | undefined;
+let cachedTryLock: TryLock | undefined;
 
-function flock(fd: number, operation: number): number {
-  if (!flockSymbol) {
-    const failures: string[] = [];
-    for (const name of LIBC_CANDIDATES) {
-      try {
-        flockSymbol = dlopen(name, {
-          flock: { args: [FFIType.i32, FFIType.i32], returns: FFIType.i32 },
-        }).symbols.flock;
-        break;
-      } catch (err) {
-        failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
-    if (!flockSymbol) {
-      throw new Error(`Cannot load flock(2) from libc — tried ${failures.join("; ")}`);
+function sharedTryLock(): TryLock {
+  return (cachedTryLock ??= resolveTryLock());
+}
+
+/**
+ * Binds `flock(2)`, or reports why it cannot be had. Exported for the tests
+ * that exercise a platform this machine is not.
+ */
+export function resolveTryLock(platform: NodeJS.Platform = process.platform): TryLock {
+  if (platform === "win32") return unsupported("Windows has no flock(2)");
+
+  /** glibc first; the musl spellings cover a Bun built for Alpine. */
+  const candidates =
+    platform === "darwin"
+      ? ["libSystem.B.dylib"]
+      : ["libc.so.6", "libc.musl-x86_64.so.1", "libc.musl-aarch64.so.1"];
+
+  const failures: string[] = [];
+  for (const name of candidates) {
+    try {
+      return bindFlock(name, platform);
+    } catch (err) {
+      failures.push(`${name}: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
-  return flockSymbol(fd, operation);
+  return unsupported(`cannot load flock(2) from libc — tried ${failures.join("; ")}`);
+}
+
+function unsupported(reason: string): TryLock {
+  const attempt: LockAttempt = { status: "unsupported", reason };
+  return () => attempt;
+}
+
+function bindFlock(library: string, platform: NodeJS.Platform): TryLock {
+  // errno is thread-local, so libc exposes it as a function returning `int*`.
+  const errnoLocation = platform === "darwin" ? "__error" : "__errno_location";
+  const { symbols } = dlopen(library, {
+    flock: { args: [FFIType.i32, FFIType.i32], returns: FFIType.i32 },
+    [errnoLocation]: { args: [], returns: FFIType.ptr },
+  });
+  const flock = symbols.flock as (fd: number, operation: number) => number;
+  const errnoAt = symbols[errnoLocation] as unknown as () => Pointer;
+  const wouldBlock = platform === "darwin" ? EWOULDBLOCK_DARWIN : EWOULDBLOCK_LINUX;
+
+  return (fd) => {
+    if (flock(fd, LOCK_EX | LOCK_NB) === 0) return ACQUIRED;
+    // Read straight away: errno holds until the next libc call on this thread.
+    const errno = read.i32(errnoAt());
+    if (errno === wouldBlock) return BUSY;
+    if (errno === EINTR) return INTERRUPTED;
+    return { status: "unsupported", reason: `flock(2) failed with errno ${errno}` };
+  };
 }

--- a/apps/cli/test/skills-lock.test.ts
+++ b/apps/cli/test/skills-lock.test.ts
@@ -14,7 +14,15 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { lstat, mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { getLockPath, SyncLockBusyError, withSyncLock } from "../src/lib/skills-sync/lock.ts";
+import { closeSync, openSync } from "node:fs";
+import {
+  getLockPath,
+  resolveTryLock,
+  SyncLockBusyError,
+  withSyncLock,
+  type LockAttempt,
+} from "../src/lib/skills-sync/lock.ts";
+import { createMemoryIO } from "./helpers/memory-io.ts";
 
 const originalDataHome = process.env.XDG_DATA_HOME;
 let dataHome: string;
@@ -121,6 +129,80 @@ describe("withSyncLock", () => {
     holder.kill("SIGKILL");
     await holder.exited;
     expect(await withSyncLock(async () => "taken", { timeoutMs: 30, pollMs: 5 })).toBe("taken");
+  });
+});
+
+describe("the flock binding", () => {
+  it("reads errno and calls a held lock busy", async () => {
+    // Two descriptors on one file: flock is per open file description, so the
+    // second attempt is exactly what a competing process would see.
+    await withSyncLock(async () => "seed");
+    const held = openSync(getLockPath(), "a", 0o600);
+    const rival = openSync(getLockPath(), "a", 0o600);
+    try {
+      const tryLock = resolveTryLock();
+      expect(tryLock(held)).toEqual({ status: "acquired" });
+      expect(tryLock(rival)).toEqual({ status: "busy" });
+    } finally {
+      closeSync(rival);
+      closeSync(held);
+    }
+  });
+
+  it("calls an errno that is not EWOULDBLOCK unsupported, not busy", () => {
+    // EBADF stands in for the ENOLCK / EOPNOTSUPP an flock-less mount returns:
+    // the point is that a non-EWOULDBLOCK errno must not enter the poll loop.
+    const attempt = resolveTryLock()(9999);
+    expect(attempt.status).toBe("unsupported");
+    expect(attempt).toMatchObject({ reason: expect.stringContaining("errno") });
+  });
+
+  it("reports Windows unsupported without reaching for libc", () => {
+    const attempt = resolveTryLock("win32")(1);
+    expect(attempt).toEqual({ status: "unsupported", reason: "Windows has no flock(2)" });
+  });
+});
+
+describe("withSyncLock without a working flock", () => {
+  it("runs the body unlocked and says so on stderr", async () => {
+    const { io, stderr } = createMemoryIO();
+    const result = await withSyncLock(async () => "ran", {
+      io,
+      tryLock: () => ({ status: "unsupported", reason: "Windows has no flock(2)" }),
+    });
+    expect(result).toBe("ran");
+    expect(stderr()).toContain("skills sync lock unavailable (Windows has no flock(2))");
+    expect(stderr()).toContain("continuing unlocked");
+  });
+
+  it("never reports a competing sync that does not exist", async () => {
+    // The bug: an unsupported filesystem waited out the whole timeout and then
+    // named another process. Nothing here is allowed to throw or to poll.
+    const { io } = createMemoryIO();
+    await expect(
+      withSyncLock(async () => "ran", {
+        io,
+        timeoutMs: 0,
+        tryLock: () => ({ status: "unsupported", reason: "flock(2) failed with errno 95" }),
+      }),
+    ).resolves.toBe("ran");
+  });
+
+  it("retries a signal-interrupted attempt instead of polling", async () => {
+    const attempts: LockAttempt[] = [
+      { status: "interrupted" },
+      { status: "interrupted" },
+      { status: "acquired" },
+    ];
+    // pollMs is long enough that a wait between attempts would blow the
+    // deadline; only an immediate retry gets to "acquired".
+    const result = await withSyncLock(async () => "ran", {
+      timeoutMs: 5_000,
+      pollMs: 60_000,
+      tryLock: () => attempts.shift() ?? { status: "acquired" },
+    });
+    expect(result).toBe("ran");
+    expect(attempts).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Closes #1364

## Root cause

`apps/cli/src/lib/skills-sync/lock.ts` bound only `flock`'s return value, so the poll loop read *any* non-zero as "another sync holds it" (`lock.ts:65-68` before this change). `ENOLCK` / `EOPNOTSUPP` from a mount without `flock` — NFS without lockd, some 9p / virtiofs container mounts — therefore blocked the marketplace command for the full 60 s and then threw `SyncLockBusyError`, naming a concurrent process that does not exist.

Separately, the libc candidate list (`lock.ts:35-38` before) was glibc/musl/libSystem only. On `win32` all three `dlopen`s failed and the helper threw: `skillsSyncCommand` exited 1 every time, and `logoutCommand` warned and skipped skill cleanup (credentials were still wiped, correctly).

## Fix

`bindFlock` now resolves `__error` (darwin) / `__errno_location` (glibc, musl) alongside `flock` in the same `dlopen`, and reads errno through `read.i32` immediately after a failed call. One attempt yields one of four answers:

- `EWOULDBLOCK` (35 darwin / 11 linux) → **busy**, keep polling until the deadline, then `SyncLockBusyError`. This is now the *only* road to that error.
- `EINTR` → **interrupted**, retry at once without burning a poll interval.
- anything else → **unsupported**, carrying `flock(2) failed with errno N`.
- `win32`, or every libc candidate failing to load → **unsupported** before any syscall; `resolveTryLock` no longer throws.

When the lock is unsupported `withSyncLock` **fails open**: it runs the body unlocked after writing `warning: skills sync lock unavailable (<reason>); continuing unlocked — do not run two syncs at once.` to the caller's `CommandIO`. The lock guards a narrow race (two syncs started in the same window); refusing every sync on those hosts is the larger breakage, and it is what made `skills sync` unusable on Windows and made `logout` skip skill cleanup. Both call sites now pass their `io` so the warning reaches the sink the command already owns.

**No `LockFileEx` path.** Windows takes the same degrade branch as an flock-less mount — one code path, not a Windows-specific one, and no code this project cannot verify. A real Windows binding can land the day someone can test it there.

The FFI seam is injectable (`SyncLockOptions.tryLock`, `resolveTryLock(platform)`) so the classification and the platform gate are testable on any host — DI, no `mock.module()`.

## Tests

`apps/cli/test/skills-lock.test.ts`, +6 cases (5 → 11), extending the existing file:

- errno read against **real libc**: two descriptors on one lock file → `busy`; `fd 9999` (EBADF) → `unsupported`, which is the exact bug — a non-EWOULDBLOCK errno must not enter the poll loop.
- `resolveTryLock("win32")` → `unsupported` without reaching for libc.
- unsupported → body runs, warning on stderr, and with `timeoutMs: 0` it still resolves instead of throwing "another sync is running".
- `interrupted` retries immediately (`pollMs: 60_000`, `timeoutMs: 5_000` — only an immediate retry reaches `acquired`).

```
cd apps/cli && TEST_TIER=0 bun test test/skills-lock.test.ts      → 11 pass, 0 fail (x3 runs, no flake)
cd apps/cli && TEST_TIER=0 bun test test/logout.test.ts test/skills-command.test.ts test/skills-multi-context.test.ts
                                                                  → 108 pass, 0 fail
bunx tsc --noEmit -p apps/cli                                     → clean
bunx eslint <4 touched files> ; bun run knip                      → clean (knip exit 0)
```

Negative controls, both confirmed: collapsing the classification back to "every non-zero is busy" fails the errno case, and removing the `win32` branch fails the Windows case.

## Notes for the orchestrator

- Based on `fix/issue-1363`; PR targets that branch. No overlap with the siblings — #1361 (self-update) and #1321 (`@napi-rs/keyring` markers) touch other files, and #1363's `config.ts` work is untouched here.
- No migration, no env var, no OpenAPI change. CLI-only.
- Behaviour change worth calling out in the release notes: on a host where `flock` does not work, `skills sync` now runs (with a stderr warning) instead of failing after 60 s. On every host where it does work — every CI runner, macOS and Linux dev machine — the behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
