### PR TITLE
fix(files): cap a creator's file lifecycle right at the credential ceiling

### DIFF
--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -434,6 +434,26 @@ export function callerPermissions(c: Context<AppEnv>): ReadonlySet<string> {
 }
 
 /**
+ * Does the CREDENTIAL this request arrived on admit `permission` at all?
+ *
+ * The ceiling question, not the grant question {@link callerPermissions}
+ * answers. An API key's scope list and a token's scope claim cap whatever
+ * their creator holds ({@link effectivePermissions}); a cookie session carries
+ * no ceiling and admits everything its role does.
+ *
+ * It exists for the one authorization in the platform that is NOT a role grant
+ * and therefore never passes through that intersection: a file's own creator
+ * manages their file (`keep` / `delete`) without holding `files:delete`. That
+ * ownership right must still not outreach the credential the request arrived
+ * on — a key minted with `agents:run` does not inherit its creator's files
+ * (RBAC spec §7.1).
+ */
+export function credentialAdmits(c: Context<AppEnv>, permission: Permission): boolean {
+  const ceiling = c.get("scopeCeiling");
+  return ceiling === undefined || ceiling.has(permission);
+}
+
+/**
  * Org-level grants of `role` as an org LISTING shows them, sorted. No space
  * half: the space slice is answered per space by `GET /api/spaces`.
  */

--- a/apps/api/src/modules/mcp/package-file-tools.ts
+++ b/apps/api/src/modules/mcp/package-file-tools.ts
@@ -100,7 +100,11 @@ async function readPackageFileBytes(
 ): Promise<PackageFileBytes> {
   const fileId = parseFileUri(uri);
   if (!fileId) throw new McpError(ErrorCode.InvalidParams, `Not a file URI: ${uri}`);
-  const resolved = await getFileForActor(ctx.scope, ctx.actor, fileId, ctx.permissions);
+  // Read-only surface: MCP exposes no `keep` / `delete` affordance, so a
+  // creator's ownership right never applies through it.
+  const resolved = await getFileForActor(ctx.scope, ctx.actor, fileId, ctx.permissions, {
+    creatorCanManage: false,
+  });
   if (!resolved) throw new McpError(ErrorCode.InvalidParams, `File not found: ${uri}`);
   if (!resolved.capabilities.download) {
     throw new McpError(ErrorCode.InvalidParams, `File is not downloadable: ${uri}`);

--- a/apps/api/src/modules/mcp/tools.ts
+++ b/apps/api/src/modules/mcp/tools.ts
@@ -1317,7 +1317,12 @@ export function buildFileResourceProvider(ctx: McpToolContext): AppstrateResourc
         throw new McpError(ErrorCode.InvalidParams, `Not a file resource URI: ${uri}`);
       }
 
-      const resolved = await getFileForActor(ctx.scope, ctx.actor, docId, ctx.permissions);
+      // Read-only surface: MCP exposes no `keep` / `delete` affordance, so a
+      // creator's ownership right never applies through the reported
+      // `capabilities` (the grant arm still does).
+      const resolved = await getFileForActor(ctx.scope, ctx.actor, docId, ctx.permissions, {
+        creatorCanManage: false,
+      });
       if (!resolved) {
         throw new McpError(ErrorCode.InvalidParams, `File not found: ${uri}`);
       }

--- a/apps/api/src/openapi/paths/files.ts
+++ b/apps/api/src/openapi/paths/files.ts
@@ -290,7 +290,9 @@ export const filesPaths = {
       summary: "Delete a file",
       description:
         "Delete a file (storage object + row) and release its quota. Allowed for a caller " +
-        "with the `files:delete` permission (owner/admin) or the file's own creator. " +
+        "with the `files:delete` permission (owner/admin), or the file's own creator on a " +
+        "credential that admits `files:delete` — an API key or token whose scopes omit it " +
+        "does not inherit its creator's files. " +
         "A file referenced by a run cannot be deleted until those consumer runs are removed.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
@@ -332,7 +334,9 @@ export const filesPaths = {
       description:
         "Pin a file so it is never swept by the retention GC: clears its `expires_at` " +
         "(sets it to null / permanent). Allowed for a caller with the `files:delete` " +
-        "permission (owner/admin) or the file's own creator. Idempotent — keeping an " +
+        "permission (owner/admin), or the file's own creator on a credential that admits " +
+        "`files:delete` — an API key or token whose scopes omit it does not inherit its " +
+        "creator's files. Idempotent — keeping an " +
         "already-permanent file is a no-op that returns 200 with the unchanged file. " +
         "An id the caller cannot read returns 404.",
       parameters: [

--- a/apps/api/src/routes/files.ts
+++ b/apps/api/src/routes/files.ts
@@ -23,16 +23,19 @@
  * DELETE/keep deliberately stay ungated at layer 1: they are authorized by
  * `capabilities.delete` / `capabilities.keep`, which grant the file's own
  * creator (an end-user cleaning up its own upload holds no org permission).
+ * That creator arm is an OWNERSHIP right, so no permission set narrows it —
+ * {@link fileLifecycleCeiling} does, with the credential's own scope ceiling,
+ * so a key minted without `files:delete` never inherits its creator's files.
  */
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { getEnv } from "@appstrate/env";
 import type { AppEnv } from "../types/index.ts";
 import { rateLimit, rateLimitByIp } from "../middleware/rate-limit.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { getActor, actorFromIds } from "../lib/actor.ts";
 import { getSpaceScope } from "../lib/scope.ts";
-import { callerPermissions } from "../lib/permissions.ts";
+import { callerPermissions, credentialAdmits } from "../lib/permissions.ts";
 import { forbidden, notFound, payloadTooLarge, unauthorized } from "../lib/errors.ts";
 import { reprDigestSha256 } from "../lib/digest.ts";
 import { getPublicAppOrigin } from "../lib/public-url.ts";
@@ -63,6 +66,20 @@ import {
   PREVIEW_MAX_BYTES,
 } from "../services/file-preview.ts";
 
+/**
+ * The lifecycle half of the file ACL for THIS request: may the credential it
+ * arrived on exercise a creator's own `keep` / `delete` right at all?
+ *
+ * A cookie session is unbounded and keeps the ownership right; an API key or a
+ * token keeps it only when its scopes name `files:delete` — the ceiling that
+ * `permissions` cannot apply, because ownership is not a role grant (RBAC spec
+ * §7.1). Every file resolution in this router passes it, so the DTO's
+ * `capabilities` and the two enforcement points below can never disagree.
+ */
+function fileLifecycleCeiling(c: Context<AppEnv>): { creatorCanManage: boolean } {
+  return { creatorCanManage: credentialAdmits(c, "files:delete") };
+}
+
 export function createFilesRouter() {
   const router = new Hono<AppEnv>();
 
@@ -91,7 +108,13 @@ export function createFilesRouter() {
     if (startingAfter) filters.startingAfter = startingAfter;
     filters.limit = parseListPagination(c, { defaultLimit: 20 }).limit;
 
-    const page = await listFilesForActor(scope, actor, filters, callerPermissions(c));
+    const page = await listFilesForActor(
+      scope,
+      actor,
+      filters,
+      callerPermissions(c),
+      fileLifecycleCeiling(c),
+    );
     return c.json(page);
   });
 
@@ -100,7 +123,13 @@ export function createFilesRouter() {
   router.get("/files/:id", rateLimit(120), requirePermission("files", "read"), async (c) => {
     const scope = getSpaceScope(c);
     const actor = getActor(c);
-    const resolved = await getFileForActor(scope, actor, c.req.param("id")!, callerPermissions(c));
+    const resolved = await getFileForActor(
+      scope,
+      actor,
+      c.req.param("id")!,
+      callerPermissions(c),
+      fileLifecycleCeiling(c),
+    );
     if (!resolved) throw notFound("File not found");
     return c.json(toFileDto(resolved.row, actor, resolved.capabilities, { mintPreview: true }));
   });
@@ -121,6 +150,7 @@ export function createFilesRouter() {
         actor,
         c.req.param("id")!,
         callerPermissions(c),
+        fileLifecycleCeiling(c),
       );
       if (!resolved) throw notFound("File not found");
       if (!resolved.capabilities.download) {
@@ -174,12 +204,21 @@ export function createFilesRouter() {
   router.delete("/files/:id", rateLimit(60), async (c) => {
     const scope = getSpaceScope(c);
     const actor = getActor(c);
-    const resolved = await getFileForActor(scope, actor, c.req.param("id")!, callerPermissions(c));
+    const resolved = await getFileForActor(
+      scope,
+      actor,
+      c.req.param("id")!,
+      callerPermissions(c),
+      fileLifecycleCeiling(c),
+    );
     if (!resolved) throw notFound("File not found");
     const { row } = resolved;
 
     if (!resolved.capabilities.delete) {
-      throw forbidden("Only the file creator or an admin can delete this file");
+      throw forbidden(
+        "Deleting this file needs the files:delete permission, or its creator on a " +
+          "credential whose scopes admit files:delete",
+      );
     }
 
     await deleteFile(scope, row.id);
@@ -200,12 +239,21 @@ export function createFilesRouter() {
   router.post("/files/:id/keep", rateLimit(60), async (c) => {
     const scope = getSpaceScope(c);
     const actor = getActor(c);
-    const resolved = await getFileForActor(scope, actor, c.req.param("id")!, callerPermissions(c));
+    const resolved = await getFileForActor(
+      scope,
+      actor,
+      c.req.param("id")!,
+      callerPermissions(c),
+      fileLifecycleCeiling(c),
+    );
     if (!resolved) throw notFound("File not found");
     const { row } = resolved;
 
     if (!resolved.capabilities.keep) {
-      throw forbidden("Only the file creator or an admin can keep this file");
+      throw forbidden(
+        "Keeping this file needs the files:delete permission, or its creator on a " +
+          "credential whose scopes admit files:delete",
+      );
     }
 
     const wasExpiring = row.expiresAt !== null;

--- a/apps/api/src/services/files.ts
+++ b/apps/api/src/services/files.ts
@@ -314,9 +314,15 @@ function isFileCreator(
  *    (`visible`) but get an opaque reference (`metadata: false`, `download:
  *    false`) — never the bytes, the real name, or the hash (kills the
  *    cross-member disclosure + CDN-abuse vectors).
- *  - `keep` / `delete` — the file's creator OR a caller holding
- *    `files:delete` (owner/admin). The management permission does NOT grant
+ *  - `keep` / `delete` — a caller holding `files:delete` (`opts.canManage`),
+ *    OR the file's own creator when the CREDENTIAL admits file lifecycle
+ *    (`opts.creatorCanManage`). The management permission does NOT grant
  *    metadata or download of another member's upload — only lifecycle control.
+ *
+ * The creator arm is an ownership right, not a role grant, so it is the one
+ * capability here that no permission set narrows: `opts.creatorCanManage` is
+ * its credential ceiling, and both lifecycle inputs default to FALSE so a
+ * caller that does not state its authority gets none.
  *
  * `opts.visible` is the container-ACL outcome (resolved by
  * {@link getFileForActor} / the list SQL / a valid preview token); when
@@ -325,7 +331,7 @@ function isFileCreator(
 export function getFileCapabilities(
   doc: { purpose: FilePurpose; userId: string | null; endUserId: string | null; mime: string },
   actor: Actor,
-  opts: { visible: boolean; canManage?: boolean },
+  opts: { visible: boolean; canManage?: boolean; creatorCanManage?: boolean },
 ): FileCapabilities {
   if (!opts.visible) {
     return {
@@ -347,8 +353,9 @@ export function getFileCapabilities(
   // not sensitive and stays visible to opaque readers.
   const metadata = isAgentOutput || isCreator;
   const preview = download && previewKind(doc.mime) !== null;
-  // Lifecycle control: creator OR the org's manage permission.
-  const manage = isCreator || (opts.canManage ?? false);
+  // Lifecycle control: the org's manage permission, or the creator's own
+  // ownership right as far as its credential reaches.
+  const manage = (opts.canManage ?? false) || (isCreator && (opts.creatorCanManage ?? false));
   return { visible: true, metadata, download, preview, keep: manage, delete: manage };
 }
 
@@ -1213,12 +1220,20 @@ const fileSelect = {
  * source) — `permissions` supplies the `files:delete` grant that decides the
  * `keep` / `delete` capabilities, and the `runs:read-all` grant that widens a
  * run container beyond the caller's own runs.
+ *
+ * `opts.creatorCanManage` is the other half of the lifecycle answer: the
+ * creator's ownership right is not a role grant, so `permissions` cannot
+ * narrow it and the CREDENTIAL must (see `credentialAdmits`). It defaults to
+ * FALSE — a caller that does not state its credential's reach grants no
+ * ownership override, and a surface with no `keep` / `delete` affordance says
+ * so explicitly.
  */
 export async function getFileForActor(
   scope: SpaceScope,
   actor: Actor,
   fileId: string,
   permissions: ReadonlySet<string>,
+  opts: { creatorCanManage?: boolean } = {},
 ): Promise<ResolvedFile | null> {
   if (!FILE_ID_RE.test(fileId)) return null;
   const [row] = await db
@@ -1271,6 +1286,7 @@ export async function getFileForActor(
   const capabilities = getFileCapabilities(row, actor, {
     visible: true,
     canManage: permissions.has("files:delete"),
+    creatorCanManage: opts.creatorCanManage,
   });
   return { row: row as FileRow, capabilities };
 }
@@ -1319,7 +1335,11 @@ export async function resolveChatAttachment(
   if (isFileUri(request.uri)) {
     const fileId = parseFileUri(request.uri);
     if (!fileId) throw invalidRequest(`Malformed file URI '${request.uri}'`);
-    const resolved = await getFileForActor(scope, actor, fileId, request.permissions);
+    // Attach = read: this resolver exposes no `keep` / `delete` affordance, so
+    // a creator's ownership right never applies through it.
+    const resolved = await getFileForActor(scope, actor, fileId, request.permissions, {
+      creatorCanManage: false,
+    });
     if (!resolved) throw notFound(`File '${fileId}' not found`);
     const { row } = resolved;
     return { uri: fileUri(row.id), name: row.name, mime: row.mime, size: row.size };
@@ -1448,12 +1468,17 @@ async function chatContextFileFilter(
  *
  * Keyset pagination on `(createdAt, id)` DESC — the same stable tuple cursor as
  * the end-users list.
+ *
+ * `opts.creatorCanManage` carries the same credential ceiling on the creator's
+ * own `keep` / `delete` right as {@link getFileForActor}, so a list row's
+ * `capabilities` and the enforcement on that row agree.
  */
 export async function listFilesForActor(
   scope: SpaceScope,
   actor: Actor,
   filters: ListFilesFilters,
   permissions: ReadonlySet<string>,
+  opts: { creatorCanManage?: boolean } = {},
 ): Promise<ListEnvelope<FileDto>> {
   const limit = Math.min(Math.max(filters.limit ?? 20, 1), 100);
   const fetchLimit = limit + 1;
@@ -1534,13 +1559,18 @@ export async function listFilesForActor(
     .limit(fetchLimit);
 
   const canManage = permissions.has("files:delete");
+  const { creatorCanManage } = opts;
   const hasMore = rows.length > limit;
   const data = (hasMore ? rows.slice(0, limit) : rows).map((r) => {
     const row = r as FileRow;
     // Every row passed the visibility SQL, so `visible: true`. No `mintPreview` —
     // list rows carry only the `previewable` boolean; the signed preview token is
     // minted on the single-file GET.
-    const capabilities = getFileCapabilities(row, actor, { visible: true, canManage });
+    const capabilities = getFileCapabilities(row, actor, {
+      visible: true,
+      canManage,
+      creatorCanManage,
+    });
     return toFileDto(row, actor, capabilities);
   });
   return { ...listResponse(data, { hasMore }), limit };
@@ -1764,8 +1794,9 @@ export async function deleteFile(scope: SpaceScope, fileId: string): Promise<voi
  * action (GitLab model): a file a caller explicitly keeps is exempted from
  * the expiry GC and never swept. Idempotent: pinning an already-permanent
  * file (NULL `expires_at`) is a no-op that returns the row unchanged.
- * Org+space scoped; authorization (creator OR `files:delete`) is enforced by
- * the caller (same rule as delete). Returns the updated row.
+ * Org+space scoped; authorization is `capabilities.keep` (see
+ * {@link getFileCapabilities}), enforced by the caller — same rule as delete.
+ * Returns the updated row.
  */
 export async function clearFileExpiry(scope: SpaceScope, fileId: string): Promise<FileRow> {
   const [row] = await db

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -683,11 +683,15 @@ export async function parseRequestInput(
           fileRefs.length > 0
             ? await Promise.all(
                 fileRefs.map(async ({ ref, id }) => {
+                  // Read-only surface (it resolves `appfile://` refs for a run
+                  // input): no `keep` / `delete` affordance, so a creator's
+                  // ownership right never applies through it.
                   const doc = await getFileForActor(
                     { orgId, spaceId },
                     actor,
                     id,
                     callerPermissions(c),
+                    { creatorCanManage: false },
                   );
                   // Cross-actor ACL (S2): the container ACL is the outer gate
                   // and narrows a run-contained output to the runs the caller

--- a/apps/api/test/integration/services/files.test.ts
+++ b/apps/api/test/integration/services/files.test.ts
@@ -687,6 +687,63 @@ describe("files service + routes", () => {
     expect(byAdmin.status).toBe(204);
   });
 
+  it("an API key does not inherit its creator's ownership right over their files", async () => {
+    // The file's creator is `ctx.user` — the very identity the key authenticates
+    // as. Its lifecycle right must not travel through a key whose scopes never
+    // asked for `files:delete` (RBAC spec §7.1).
+    const runId = await seedRunRow(scope);
+    const soon = new Date(Date.now() + 3 * 24 * 60 * 60 * 1000);
+    const makeOwnDoc = async () => {
+      const up = await stageUpload(scope, ctx.user.id, "own.txt", new TextEncoder().encode("own"));
+      const doc = await createFileFromUpload(scope, userActor, up, { runId });
+      await db.update(files).set({ expiresAt: soon }).where(eq(files.id, doc.id));
+      return doc;
+    };
+    const keyHeaders = async (scopes: string[]) => {
+      const key = await seedApiKey({
+        orgId: ctx.orgId,
+        spaceId: ctx.defaultSpaceId,
+        createdBy: ctx.user.id,
+        scopes,
+      });
+      return { Authorization: `Bearer ${key.rawKey}`, "X-Space-Id": ctx.defaultSpaceId };
+    };
+
+    const scoped = await keyHeaders(["files:read"]);
+    const doc1 = await makeOwnDoc();
+
+    // The key READS its creator's file (`files:read` is granted)...
+    const read = await app.request(`/api/files/${doc1.id}`, { headers: scoped });
+    expect(read.status).toBe(200);
+    // ...and the DTO says so: no lifecycle affordance on this credential.
+    const dto = (await read.json()) as { capabilities: { keep: boolean; delete: boolean } };
+    expect(dto.capabilities.delete).toBe(false);
+    expect(dto.capabilities.keep).toBe(false);
+
+    // ...but it neither deletes it nor pins it against the expiry GC.
+    const del = await app.request(`/api/files/${doc1.id}`, { method: "DELETE", headers: scoped });
+    expect(del.status).toBe(403);
+    const keep = await app.request(`/api/files/${doc1.id}/keep`, {
+      method: "POST",
+      headers: scoped,
+    });
+    expect(keep.status).toBe(403);
+    const [survivor] = await db.select().from(files).where(eq(files.id, doc1.id));
+    expect(survivor!.expiresAt).not.toBeNull();
+
+    // A key that DOES carry the scope keeps both rights.
+    const full = await keyHeaders(["files:read", "files:delete"]);
+    const doc2 = await makeOwnDoc();
+    const kept = await app.request(`/api/files/${doc2.id}/keep`, { method: "POST", headers: full });
+    expect(kept.status).toBe(200);
+    const doc3 = await makeOwnDoc();
+    const deleted = await app.request(`/api/files/${doc3.id}`, {
+      method: "DELETE",
+      headers: full,
+    });
+    expect(deleted.status).toBe(204);
+  });
+
   it("DELETE returns file_in_use while a consumer run references the file", async () => {
     const producerRun = await seedRunRow(scope);
     const { row: doc } = await publishStream(scope, producerRun, "shared.txt", "shared");
@@ -1151,9 +1208,14 @@ describe("files service + routes", () => {
     const upload = await createFileFromUpload(scope, creatorActor, up, { runId });
     const { row: output } = await publishStream(scope, runId, "o.txt", "output");
 
-    // Creator of the user_upload → full metadata + download + lifecycle.
+    // Creator of the user_upload → full metadata + download + lifecycle (on an
+    // unbounded credential: a cookie session, whose ceiling admits everything).
     expect(
-      (await getFileForActor(scope, creatorActor, upload.id, NO_GRANTS))?.capabilities,
+      (
+        await getFileForActor(scope, creatorActor, upload.id, NO_GRANTS, {
+          creatorCanManage: true,
+        })
+      )?.capabilities,
     ).toMatchObject({
       visible: true,
       metadata: true,
@@ -1359,9 +1421,10 @@ describe("files service + routes", () => {
       orgId: ctx.orgId,
       spaceId: ctx.defaultSpaceId,
       createdBy: ctx.user.id,
-      // Reads now require the family grant; the DELETE below deliberately does
-      // NOT (it is authorized by the file's creator capability).
-      scopes: ["files:read"],
+      // Reads take the family grant; the DELETE below is authorized by the
+      // file's creator capability, but that ownership right still travels only
+      // as far as the KEY's own scopes reach — hence `files:delete` here.
+      scopes: ["files:read", "files:delete"],
     });
     const euHeaders = {
       Authorization: `Bearer ${key.rawKey}`,
@@ -1391,6 +1454,24 @@ describe("files service + routes", () => {
     });
     const foreign = await app.request(`/api/files/${otherOut.id}`, { headers: euHeaders });
     expect(foreign.status).toBe(404);
+
+    // A key WITHOUT `files:delete` does not reach the creator path, even
+    // impersonating the file's own end-user creator.
+    const readOnlyKey = await seedApiKey({
+      orgId: ctx.orgId,
+      spaceId: ctx.defaultSpaceId,
+      createdBy: ctx.user.id,
+      scopes: ["files:read"],
+    });
+    const scopedDel = await app.request(`/api/files/${upload.id}`, {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${readOnlyKey.rawKey}`,
+        "X-Space-Id": ctx.defaultSpaceId,
+        "Appstrate-User": eu.id,
+      },
+    });
+    expect(scopedDel.status).toBe(403);
 
     // The end-user can DELETE its own file (creator path, no permission grant).
     const del = await app.request(`/api/files/${upload.id}`, {

--- a/apps/api/test/unit/services/files.test.ts
+++ b/apps/api/test/unit/services/files.test.ts
@@ -71,12 +71,12 @@ describe("getFileCapabilities", () => {
 
   it("keep/delete follow creator OR the files:delete grant (canManage)", () => {
     const doc = { purpose: "user_upload" as const, userId: "user-a", endUserId: null, mime };
-    // Creator, no manage grant → keep/delete via creator.
-    const creator = getFileCapabilities(doc, userA, { visible: true });
+    // Creator, no manage grant, credential admits lifecycle → keep/delete via creator.
+    const creator = getFileCapabilities(doc, userA, { visible: true, creatorCanManage: true });
     expect(creator.keep).toBe(true);
     expect(creator.delete).toBe(true);
     // Non-creator without the grant → no lifecycle control.
-    const stranger = getFileCapabilities(doc, userB, { visible: true });
+    const stranger = getFileCapabilities(doc, userB, { visible: true, creatorCanManage: true });
     expect(stranger.keep).toBe(false);
     expect(stranger.delete).toBe(false);
     // Non-creator WITH the grant → may keep/delete, but the manage permission
@@ -86,6 +86,25 @@ describe("getFileCapabilities", () => {
     expect(admin.delete).toBe(true);
     expect(admin.metadata).toBe(false);
     expect(admin.download).toBe(false);
+  });
+
+  it("the creator arm is capped by the credential ceiling, the grant arm is not", () => {
+    const doc = { purpose: "user_upload" as const, userId: "user-a", endUserId: null, mime };
+    // Creator on a credential that does not admit file lifecycle (an API key
+    // minted without `files:delete`): the ownership right does not survive it.
+    const scoped = getFileCapabilities(doc, userA, { visible: true, creatorCanManage: false });
+    expect(scoped.keep).toBe(false);
+    expect(scoped.delete).toBe(false);
+    // Reading its own upload is untouched — only lifecycle is capped.
+    expect(scoped.download).toBe(true);
+    expect(scoped.metadata).toBe(true);
+    // Omitting the option is the same fail-closed answer.
+    expect(getFileCapabilities(doc, userA, { visible: true }).delete).toBe(false);
+    // The grant arm already passed through the ceiling (`permissions` is
+    // role ∩ scopes), so holding it is enough on its own.
+    const granted = getFileCapabilities(doc, userA, { visible: true, canManage: true });
+    expect(granted.keep).toBe(true);
+    expect(granted.delete).toBe(true);
   });
 
   it("preview requires download AND a previewable mime", () => {

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -1321,7 +1321,7 @@ export interface paths {
         post?: never;
         /**
          * Delete a file
-         * @description Delete a file (storage object + row) and release its quota. Allowed for a caller with the `files:delete` permission (owner/admin) or the file's own creator. A file referenced by a run cannot be deleted until those consumer runs are removed.
+         * @description Delete a file (storage object + row) and release its quota. Allowed for a caller with the `files:delete` permission (owner/admin), or the file's own creator on a credential that admits `files:delete` — an API key or token whose scopes omit it does not inherit its creator's files. A file referenced by a run cannot be deleted until those consumer runs are removed.
          */
         delete: operations["deleteFile"];
         options?: never;
@@ -1360,7 +1360,7 @@ export interface paths {
         put?: never;
         /**
          * Keep a file (clear its expiry)
-         * @description Pin a file so it is never swept by the retention GC: clears its `expires_at` (sets it to null / permanent). Allowed for a caller with the `files:delete` permission (owner/admin) or the file's own creator. Idempotent — keeping an already-permanent file is a no-op that returns 200 with the unchanged file. An id the caller cannot read returns 404.
+         * @description Pin a file so it is never swept by the retention GC: clears its `expires_at` (sets it to null / permanent). Allowed for a caller with the `files:delete` permission (owner/admin), or the file's own creator on a credential that admits `files:delete` — an API key or token whose scopes omit it does not inherit its creator's files. Idempotent — keeping an already-permanent file is a no-op that returns 200 with the unchanged file. An id the caller cannot read returns 404.
          */
         post: operations["keepFile"];
         delete?: never;

--- a/docs/architecture/FILES.md
+++ b/docs/architecture/FILES.md
@@ -162,17 +162,17 @@ The `outcome` and `files` panes read the SAME query (the run's files in one page
 
 ## HTTP surface
 
-| Method + path                        | Guard                                             | Purpose                                                 |
-| ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------- |
-| `GET /api/files`                     | `files:read` + actor filter                       | Gallery listing, keyset-paginated                       |
-| `GET /api/files/{id}`                | `files:read` + container ACL                      | Metadata DTO; the only surface that mints `preview_url` |
-| `GET /api/files/{id}/content`        | `files:read` + `download` capability              | 307 → presigned GET, or proxy-stream                    |
-| `DELETE /api/files/{id}`             | `capabilities.delete` (creator OR `files:delete`) | Delete; 409 `file_in_use` on a linked file              |
-| `POST /api/files/{id}/keep`          | `capabilities.keep`                               | Clear `expires_at`                                      |
-| `GET /preview/files/{id}?t=…`        | signed token only, no auth pipeline               | Hardened preview bytes — contract below                 |
-| `GET /api/runs/{runId}/files`        | run HMAC                                          | The input manifest the runtime mounts                   |
-| `POST /api/runs/{runId}/files`       | run upload HMAC                                   | Publish an `agent_output`                               |
-| `GET /api/runs/{runId}/files/{name}` | run HMAC                                          | Fetch one mounted input by workspace name               |
+| Method + path                        | Guard                                         | Purpose                                                 |
+| ------------------------------------ | --------------------------------------------- | ------------------------------------------------------- |
+| `GET /api/files`                     | `files:read` + actor filter                   | Gallery listing, keyset-paginated                       |
+| `GET /api/files/{id}`                | `files:read` + container ACL                  | Metadata DTO; the only surface that mints `preview_url` |
+| `GET /api/files/{id}/content`        | `files:read` + `download` capability          | 307 → presigned GET, or proxy-stream                    |
+| `DELETE /api/files/{id}`             | `capabilities.delete` (see capability matrix) | Delete; 409 `file_in_use` on a linked file              |
+| `POST /api/files/{id}/keep`          | `capabilities.keep`                           | Clear `expires_at`                                      |
+| `GET /preview/files/{id}?t=…`        | signed token only, no auth pipeline           | Hardened preview bytes — contract below                 |
+| `GET /api/runs/{runId}/files`        | run HMAC                                      | The input manifest the runtime mounts                   |
+| `POST /api/runs/{runId}/files`       | run upload HMAC                               | Publish an `agent_output`                               |
+| `GET /api/runs/{runId}/files/{name}` | run HMAC                                      | Fetch one mounted input by workspace name               |
 
 **That table is the whole HTTP surface.** The nine pre-#1177 `/documents` registrations — `/api/documents…`, `/api/runs/{runId}/documents…`, `/preview/documents/{id}` — are gone, along with `lib/legacy-file-paths.ts` and the two spec-side alias generators. `v1.0.0-beta.51` **was** on the other side of them: it registers `/api/runs/{runId}/documents` and `/api/runs/{runId}/documents/{name}` and not one `/files` route, `runtime-pi/publish.ts` posts deliverables to `…/documents` under `X-Document-Name`, and `runtime-pi/provision.ts` fetches its input manifest from the same path. What makes the removal safe is not that nobody spoke them — it is that the PAIRING of such an artifact with this platform is refused at boot: the env schema will not start unless `APP_VERSION` and both runtime image tags agree (`findRuntimeImageTagMismatch`, `@appstrate/core/image-ref`). That check has blind spots — its own carve-outs, enumerated with the comparison in `@appstrate/core/image-ref`, and, since it is an env-schema check evaluated at boot, containers **already running** when the platform restarts. The last one is why the upgrade carries a drain step; see OPERATOR ACTIONS in the changelog entry for #1177. What is verified on the consumer side is narrower: the released CLI never called the retired paths, the billing module (then the separate `cloud/` repo, now `packages/module-ee`) and `connect-helper/` contain no retired wire shape, and the SPA is baked into the platform image so a served build cannot be older than the platform serving it. Every retired path is a 404, and `/api/documents` is correspondingly absent from `SPACE_SCOPED_PREFIXES` (`apps/api/src/middleware/space-context.ts`) — the entry existed only so the alias handlers could pin the space id.
 
@@ -323,12 +323,14 @@ Parent teardowns use the same invariant: they lock the parent first (closing the
 
 ### Capability matrix (D2 + upload privacy)
 
-`getFileCapabilities(doc, actor, { visible, canManage })` is the ONE access computation every consumer (REST route, DTO serializer, preview mint, MCP `resources/read`) derives its gates from — no ad-hoc re-derivation:
+`getFileCapabilities(doc, actor, { visible, canManage, creatorCanManage })` is the ONE access computation every consumer (REST route, DTO serializer, preview mint, MCP `resources/read`) derives its gates from — no ad-hoc re-derivation:
 
-| purpose        | `visible` (container ACL) | `metadata` (real name/mime/sha256) | `download` (bytes) | `preview`              | `keep` / `delete`         |
-| -------------- | ------------------------- | ---------------------------------- | ------------------ | ---------------------- | ------------------------- |
-| `agent_output` | any container reader      | ✅ any reader                      | ✅ any reader      | ✅ if previewable mime | creator OR `files:delete` |
-| `user_upload`  | any container reader      | ✅ creator only                    | ✅ creator only    | ✅ creator + mime      | creator OR `files:delete` |
+| purpose        | `visible` (container ACL) | `metadata` (real name/mime/sha256) | `download` (bytes) | `preview`              | `keep` / `delete`          |
+| -------------- | ------------------------- | ---------------------------------- | ------------------ | ---------------------- | -------------------------- |
+| `agent_output` | any container reader      | ✅ any reader                      | ✅ any reader      | ✅ if previewable mime | `files:delete` OR creator* |
+| `user_upload`  | any container reader      | ✅ creator only                    | ✅ creator only    | ✅ creator + mime      | `files:delete` OR creator* |
+
+\* The creator arm (`creatorCanManage`) is an **ownership** right, not a role grant, so no permission set narrows it — the CREDENTIAL does. `credentialAdmits(c, "files:delete")` (`apps/api/src/lib/permissions.ts`) reads the request's scope ceiling: a cookie session is unbounded and keeps the right, an API key or OIDC token keeps it only when its own scopes name `files:delete`. Without that cap a key minted with, say, `agents:run` would delete — and pin against the retention GC — every file its creator ever produced, because under API-key auth the actor IS the key's creator (RBAC spec §7.1). The two lifecycle routes carry no `files:*` guard at layer 1 (an end-user cleaning up its own upload holds no org permission), so this ceiling is the only thing between a scope-limited credential and its creator's files. It is `false` by default: `getFileForActor` / `listFilesForActor` grant no ownership override unless the caller states one, and the read-only surfaces (MCP `resources/read`, the `appfile://` run-input resolver, the chat attachment resolver) pass `false` explicitly — they expose no lifecycle affordance. `files:delete` is not end-user-grantable (`OIDC_ALLOWED_SCOPES`), so an end-user JWT never carries the creator arm either; end-user cleanup runs through an API key that holds the scope.
 
 A non-creator run reader of a `user_upload` stays `visible` but gets an **opaque reference**: `projectFileMetadata` degrades the DTO/MCP read to a generic name (`file`) + mime (`application/octet-stream`) with **no sha256**, and `/content` is a 403 with **no `Repr-Digest`**. This kills the cross-member disclosure + CDN-abuse vectors. The `files:delete` management permission grants lifecycle control ONLY — never metadata or bytes of another member's upload.
 


### PR DESCRIPTION
Closes #1315

## Root cause

`getFileCapabilities` (`apps/api/src/services/files.ts:358`, pre-fix `:351`) computed
`manage = isCreator || canManage`, and the two lifecycle routes
(`apps/api/src/routes/files.ts` `DELETE /files/:id`, `POST /files/:id/keep`) deliberately
carry no `files:*` guard at layer 1 — an end-user cleaning up its own upload holds no org
permission. Under API-key auth the actor is the key's **creator** (RBAC spec §7.1), so
`isCreator` was true for every file that user ever produced: a key minted with
`scopes: ["agents:run"]` could `DELETE` any of them and `POST …/keep` to pin them against
the retention GC. `permissions` (role ∩ scopes) could not stop it, because the creator arm
is an ownership right and never passes through that intersection.

## Fix

The credential's own **scope ceiling** now caps the creator arm.

- `credentialAdmits(c, permission)` (`apps/api/src/lib/permissions.ts`) — the ceiling
  question, sibling to `callerPermissions`'s grant question. `c.get("scopeCeiling")` is
  `undefined` for a cookie session (unbounded, ownership right intact) and is the scope list
  for an API key / OIDC token (kept only when it names `files:delete`).
- `getFileCapabilities(doc, actor, { visible, canManage, creatorCanManage })` —
  `manage = canManage || (isCreator && creatorCanManage)`. Both lifecycle inputs default to
  **false**, so a caller that does not state its authority gets none.
- `getFileForActor` / `listFilesForActor` take `opts.creatorCanManage` (optional,
  fail-closed). The file router passes `fileLifecycleCeiling(c)` on **every** resolution, so
  the DTO's `capabilities` and the two enforcement points can never disagree; the read-only
  surfaces (MCP `resources/read`, the `appfile://` run-input resolver, the chat attachment
  resolver) pass `false` explicitly — they expose no lifecycle affordance.
- Reused the sibling's `isFileCreator` helper (it is what `isCreator` already reads through).

Nothing widens: the grant arm (`files:delete`) is untouched, and `download` / `metadata` /
`preview` are untouched — a scope-limited key still reads its creator's files with
`files:read`. The two 403 messages now name the scope instead of saying "creator or admin".

**Deliberate narrowings** (both are the fix, not collateral):
- An API key whose scopes omit `files:delete` no longer manages its creator's files. A key
  held by an `operator`/`runner`/`viewer` can never carry that scope (`validateScopes`
  filters to the creator's own authority), so those roles lose *headless* file cleanup;
  their cookie sessions are unaffected.
- `files:delete` is not in `OIDC_ALLOWED_SCOPES`, so an end-user JWT never carries the
  creator arm. End-user cleanup runs through an API key that holds the scope — the
  integration test covers exactly that, plus the negative arm.

Docs: `docs/architecture/FILES.md` capability matrix gains the ceiling footnote; the two
OpenAPI descriptions state the rule; `apps/web/src/api/schema.d.ts` regenerated.

## Tests

- `apps/api/test/unit/services/files.test.ts` — new `it("the creator arm is capped by the
  credential ceiling, the grant arm is not")`; updated the existing creator case to state
  its unbounded credential.
- `apps/api/test/integration/services/files.test.ts` — new `it("an API key does not inherit
  its creator's ownership right over their files")`: `files:read`-only key → `GET` 200 with
  `capabilities.delete/keep` **false**, `DELETE` 403, `keep` 403, `expires_at` intact;
  `files:read + files:delete` key → 200 / 204. The end-user test gains a negative arm (a
  `files:read`-only key impersonating the file's end-user creator → 403).

Commands run from the worktree root:
- `set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/integration/services/files.test.ts apps/api/test/unit/services/files.test.ts` → **76 pass, 0 fail**
- `… bun test apps/api/test/integration/services/files-hardening-e2e.test.ts apps/api/test/integration/modules/mcp-files.test.ts apps/api/test/integration/routes/files-preview.test.ts` → **56 pass, 0 fail**
- `… bun test apps/api/test/integration/services/files-storage-matrix.test.ts apps/api/test/integration/routes/runs-read-isolation.test.ts` → **21 pass, 6 skip, 0 fail**
- `bunx tsc --noEmit -p apps/api` → clean; `bunx tsc --noEmit -p apps/web` → clean
- `bun run verify:openapi` → ALL CHECKS PASSED; `bun run generate:api` (committed) → `bun run verify:api-types` green
- `bunx eslint` + `bunx prettier --write` on every touched file

## Notes for the orchestrator

- **Base**: `fix/issue-1314`. Both branches edit `apps/api/src/services/files.ts`,
  `apps/api/test/integration/services/files.test.ts`, `docs/architecture/FILES.md`,
  `apps/web/src/api/schema.d.ts` and `apps/api/src/openapi/paths/files.ts` — stacked, not
  conflicting.
- No migration, no env var, no deploy ordering.
- **No CHANGELOG entry** — matching `fix/issue-1314`, which adds none either; a single
  consolidated entry on the merged branch is cleaner than four conflicting ones. This one
  is worth an `### Security` bullet: it is live in production.
- Overlap with siblings #1335 / #1336: none (neither touches files).
- `apps/web/src/api/schema.d.ts` moved by 2 lines (OpenAPI descriptions only). If a sibling
  also regenerates it, re-run `bun run generate:api` after the merge rather than resolving
  by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
