### PR TITLE
docs(migration): fix the 0057 pre-flight under-count and the fold it blames

### DIFF
--- a/packages/db/drizzle/0057_oauth_provider_1_7_3.sql
+++ b/packages/db/drizzle/0057_oauth_provider_1_7_3.sql
@@ -176,18 +176,21 @@ CREATE UNIQUE INDEX IF NOT EXISTS "uq_oauth_client_resources_pair" ON "oauth_cli
 --   repo already writes `token_endpoint_auth_method`, so on most databases this
 --   rewrites nothing.
 --
--- OPERATOR PRE-FLIGHT, to run BEFORE this migration. 1.7.3 reads a stored NULL
--- `token_endpoint_auth_method` as `client_secret_basic` and then enforces it
--- strictly, so a confidential client that sends its secret in the POST body is
--- answered `invalid_client` the moment the fold below writes that value in.
--- Count those rows first:
+-- OPERATOR PRE-FLIGHT, to run BEFORE the 1.7.3 image is deployed — which is
+-- earlier than this file, since migrations apply at boot under that image.
+-- 1.7.3 reads a stored NULL `token_endpoint_auth_method` as
+-- `client_secret_basic` and then refuses every other method, so a confidential
+-- client that sends its secret in the POST body is answered `invalid_client`
+-- the moment the new code serves. The fold below neither causes that break nor
+-- widens it — it writes the value the runtime was already assuming — but it is
+-- what leaves those rows unfindable afterwards: a written `client_secret_basic`
+-- is indistinguishable from a registered one.
 --
---     SELECT count(*) FROM oauth_clients
---     WHERE token_endpoint_auth_method IS NULL AND "public" = false;
---
--- A non-zero count is a decision to take, not a detail: fold those rows to
--- `client_secret_post` by hand instead, or notify their owners that they must
--- move to `client_secret_basic`.
+-- The query, and what to do with a non-zero result, live in
+-- `scripts/migration/README.md` under "OAuth-provider 1.7.3 rollout", step 1.
+-- It carries no `public` predicate: `public` is nullable, so the rows this fold
+-- skips (`public IS NULL`) keep a NULL method and break in exactly the same
+-- way.
 UPDATE oauth_clients SET application_type = "type" WHERE application_type IS NULL AND "type" IS NOT NULL;--> statement-breakpoint
 UPDATE oauth_clients SET token_endpoint_auth_method = CASE WHEN "public" THEN 'none' ELSE 'client_secret_basic' END WHERE token_endpoint_auth_method IS NULL AND "public" IS NOT NULL;--> statement-breakpoint
 ALTER TABLE "oauth_clients" DROP COLUMN IF EXISTS "public";--> statement-breakpoint

--- a/scripts/migration/README.md
+++ b/scripts/migration/README.md
@@ -92,19 +92,36 @@ Deleted spaces/custom roles in OAuth signup assignments require updating the cli
 
 ## OAuth-provider 1.7.3 rollout (drizzle `0057`, script `0011`)
 
-1. **Pre-flight, before any drizzle migration.** `0057` fills a NULL
-   `token_endpoint_auth_method` with `client_secret_basic`, which 1.7.3 then
-   enforces strictly. Count the confidential clients that have no method stored
-   — each one authenticates by putting its secret in the POST body and will be
-   answered `invalid_client`:
+1. **Pre-flight, before the 1.7.3 image is deployed.** 1.7.3 reads a stored
+   NULL `token_endpoint_auth_method` as `client_secret_basic` and then refuses
+   every other method, so a client that authenticates by putting its secret in
+   the POST body is answered `invalid_client` the moment the new code serves —
+   before `0057` runs, not because of it, since migrations apply at boot under
+   that same image. `0057` is why the count cannot wait: its fold writes
+   `client_secret_basic` into exactly these rows, and a written value is
+   indistinguishable from a registered one, so afterwards nothing enumerates
+   them. Run this while the old image is still up and **keep the rows**, not
+   just the count:
 
    ```sql
-   SELECT count(*) FROM oauth_clients
-   WHERE token_endpoint_auth_method IS NULL AND "public" = false;
+   SELECT id, client_id, "public", created_at
+   FROM oauth_clients
+   WHERE token_endpoint_auth_method IS NULL
+   ORDER BY created_at;
    ```
 
-   Non-zero → decide per client before applying: store `client_secret_post` by
-   hand, or tell the owner to move to `client_secret_basic`.
+   No `public` predicate: the column is nullable and the runtime default is read
+   from the method alone, so a row with `public` NULL breaks exactly like a
+   `public = false` one. It is also the single case the fold skips
+   (`… AND "public" IS NOT NULL`), which is why a count written against the
+   fold's own predicate misses it. Save the result with the release's rehearsal
+   notes; `0057` drops `public`, so nothing reconstructs the list.
+
+   Any row → decide per client before that image ships: store
+   `client_secret_post` by hand, or tell the owner to move to
+   `client_secret_basic`. The fail direction is safe either way — a NULL
+   resolves to `client_secret_basic`, never to `none`, so no confidential client
+   is downgraded to a public one.
 
 2. Apply pending Drizzle migrations, including `0057_oauth_provider_1_7_3.sql`.
    Its section D drops `oauth_clients.public` and `type`; an older build still


### PR DESCRIPTION
Closes #1350

Documentation-only. `packages/db/drizzle/0057_oauth_provider_1_7_3.sql` has **zero non-comment changes** — its DDL is byte-identical, and `meta/_journal.json` carries no content hash (the watermark is `when`), so a database that already applied `0057` is unaffected.

## Root cause

Two independent defects in the operator pre-flight for the 1.7.3 bump:

1. **Under-count.** `scripts/migration/README.md:101-104` (and the same query copied into `0057:185-186`) filtered `token_endpoint_auth_method IS NULL AND "public" = false`. `public` was nullable (`649277242^:packages/db/src/schema/oidc.ts:104` — `boolean("public")`, no `.notNull()`), so a client with **both** columns NULL was counted by neither the pre-flight nor the fold at `0057:192` (`… AND "public" IS NOT NULL`). It breaks identically: `utils-oOcdCCVw.mjs:640` resolves `client.tokenEndpointAuthMethod ?? "client_secret_basic"` and `:641` then refuses any other method, so a POST-body secret gets `invalid_client`.
2. **Wrong causal claim.** `0057:179-182` said such a client is refused *"the moment the fold below writes that value in"*. It is refused by the code alone: a stored NULL already reads as `client_secret_basic` under 1.7.3. Confirmed against the pin this release replaces — `1.7.0-beta.4` has no `registeredAuthMethod` mismatch check at all; `1.7.2`/`1.7.3` do. Since migrations apply at boot, "before this migration" is the same instant as "after the break", and by then the fold has made the affected rows indistinguishable from clients that really registered `client_secret_basic`.

## Fix

- **README step 1** — query becomes `WHERE token_endpoint_auth_method IS NULL` with no `public` predicate; it now `SELECT`s `id, client_id, "public", created_at` instead of `count(*)`, because the operator has to act per client and the list is unrecoverable once `0057` runs. Timing moves from "before any drizzle migration" to "before the 1.7.3 image is deployed", with the reason stated. The result is to be saved with the release's rehearsal notes. Records the safe fail direction (NULL → `client_secret_basic`, never `none`).
- **0057 comment** — corrected to say the break arrives with the code and that the fold's contribution is losing the evidence, not causing the failure. It now *points at* the README step rather than restating the query: the duplicated copy is what drifted, and a file that drops its own input should not own the count.

I did not add a regression test: nothing in the codebase reads either text (`rg` over `apps/api/test`, `packages/db` finds no assertion on the pre-flight string), so a test here would only pin prose.

## Tests

- `bun run verify:no-migration-dml` → `✅ … 68 file(s) scanned across 2 migration tree(s), 10 grandfathered.`
- `bunx prettier --check scripts/migration/README.md` → `All matched files use Prettier code style!` (`.sql` has no prettier parser, as before)
- `git diff -U0 packages/db/drizzle/0057_… | grep -vc '^[-+]--'` → `0` non-comment changed lines
- No TypeScript touched → no `tsc` run needed; no OpenAPI, no env var, no migration index consumed.

## Notes for the orchestrator

- **Base is `fix/issue-1317`**, not `main`. That sibling added `assertSelfServiceFoldApplied()` and rewrote README step 3 of this same section plus the `0011` header; my edits are confined to step 1 and the `0057` section-D comment, so the two do not overlap textually.
- **No overlap** with #1351, #1319, #1318.
- **Migration/env**: none. `0057`'s DDL is untouched by design — per the reserved-index rule, an edited migration is silently skipped by any database that already applied it.
- **Deploy ordering, operator-facing**: the corrected instruction is that the pre-flight must run *while the pre-1.7.3 image is still serving*. If the 1.7.3 image has already been deployed anywhere, that window is closed for the rows the fold rewrote; the rows the fold *skipped* (`public IS NULL`) keep a NULL method and remain enumerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
