### PR TITLE
fix(models): pin only what the endpoint published on a discovered model

### DIFF
--- a/apps/web/src/lib/model-form-payload.ts
+++ b/apps/web/src/lib/model-form-payload.ts
@@ -224,24 +224,44 @@ export function buildModelFormPayload(input: ModelFormPayloadInput): ModelFormPa
   };
 }
 
-/**
- * How much of a picked row ships depends on its listing. `catalog`: the id
- * only, the vendored catalog answers for the rest. `discover`: what the
- * listing reported, as explicit overrides; nothing is defaulted. `search`:
- * everything, cost included — the search IS the billing rate.
- */
-function rowToEntry(row: ModelPickRow): ModelFormModelEntry {
-  if (row.origin === "catalog") return { modelId: row.id };
+/** The values a row carries, as explicit overrides. An empty modality list is dropped: the server refuses it. */
+function describedCapabilities(row: ModelPickRow): ModelCapabilityOverrides {
   return {
-    ...(row.label ? { label: row.label } : {}),
-    modelId: row.id,
-    // The server refuses an empty modality list.
     ...(row.input?.length ? { input: row.input } : {}),
     ...(row.contextWindow !== null ? { contextWindow: row.contextWindow } : {}),
     ...(row.maxTokens !== null ? { maxTokens: row.maxTokens } : {}),
     ...(row.reasoning !== null ? { reasoning: row.reasoning } : {}),
-    ...(row.origin === "search" && row.cost ? { cost: row.cost } : {}),
   };
+}
+
+/**
+ * How much of a picked row ships depends on WHO described it, not just on
+ * which listing it came from. `search`: everything, cost included — the search
+ * IS the billing rate. `catalog`: the id only, the vendored catalog answers
+ * for the rest. `discover`: the endpoint's own words only.
+ *
+ * A discovered row the endpoint said nothing about was described by a catalog
+ * entry carrying the same id — the platform scans every vendor's catalog, so
+ * that entry may well belong to a different vendor, and it describes THAT
+ * vendor's hosted deployment, not the operator's. Pinning it would write a
+ * window a self-hosted server may serve at a fraction of, permanently: the
+ * read path only ever re-resolves a provider's OWN catalog, so no refresh can
+ * correct a value picked up from a foreign one. An unknown limit is inert, a
+ * wrong one truncates or breaks every run. The label is catalog-only by
+ * construction (no listing publishes one), so it goes the same way — the
+ * server derives one from the id.
+ */
+function rowToEntry(row: ModelPickRow): ModelFormModelEntry {
+  if (row.origin === "search") {
+    return {
+      ...(row.label ? { label: row.label } : {}),
+      modelId: row.id,
+      ...describedCapabilities(row),
+      ...(row.cost ? { cost: row.cost } : {}),
+    };
+  }
+  if (row.source !== "endpoint") return { modelId: row.id };
+  return { modelId: row.id, ...describedCapabilities(row) };
 }
 
 export function buildModelsBatchPayload(input: {

--- a/apps/web/src/lib/model-source.ts
+++ b/apps/web/src/lib/model-source.ts
@@ -2,8 +2,8 @@
 
 /**
  * Where the model form's pick list comes from, and the one row shape all three
- * sources produce. `origin` travels on the row so the batch payload knows how
- * much of it to put on the wire.
+ * sources produce. `origin` and `source` both travel on the row: together they
+ * tell the batch payload how much of it to put on the wire.
  */
 
 import type { ModelCost } from "@appstrate/core/module";
@@ -42,7 +42,7 @@ export interface ModelPickRow {
   maxTokens: number | null;
   input: string[] | null;
   reasoning: boolean | null;
-  /** Who described the row — rendered as a badge. */
+  /** Who described the row — rendered as a badge, and what the batch may pin. */
   source: "endpoint" | "catalog" | null;
   cost: ModelCost | null;
   /** The listing it came from: what the batch is allowed to send. */

--- a/apps/web/src/lib/test/model-form-payload.test.ts
+++ b/apps/web/src/lib/test/model-form-payload.test.ts
@@ -487,7 +487,7 @@ const DESCRIBED: Partial<ModelPickRow> = {
   cost: { input: 1.25, output: 10 },
 };
 
-describe("buildModelsBatchPayload — what a row ships, per origin", () => {
+describe("buildModelsBatchPayload — what a row ships, per describer", () => {
   it.each([
     [
       "catalog: the id only, so the catalog keeps answering",
@@ -495,10 +495,9 @@ describe("buildModelsBatchPayload — what a row ships, per origin", () => {
       { modelId: "m" },
     ],
     [
-      "discover: what the listing described, never the cost",
+      "discover: what the endpoint published, never its label nor the cost",
       row({ id: "m", origin: "discover", ...DESCRIBED, source: "endpoint" }),
       {
-        label: "Described",
         modelId: "m",
         input: ["text", "image"],
         contextWindow: 32768,
@@ -507,13 +506,18 @@ describe("buildModelsBatchPayload — what a row ships, per origin", () => {
       },
     ],
     [
+      "discover: the id only when a catalog entry, not the endpoint, described it",
+      row({ id: "m", origin: "discover", ...DESCRIBED, source: "catalog" }),
+      { modelId: "m" },
+    ],
+    [
       "discover: nothing but the id for a model nobody described",
       row({ id: "m", origin: "discover" }),
       { modelId: "m" },
     ],
     [
       "discover: a reported false is kept, an empty modality list is dropped",
-      row({ id: "m", origin: "discover", input: [], reasoning: false }),
+      row({ id: "m", origin: "discover", source: "endpoint", input: [], reasoning: false }),
       { modelId: "m", reasoning: false },
     ],
     [


### PR DESCRIPTION
Closes #1354

## Root cause

`describeServedModel` (`apps/api/src/services/model-providers/model-metadata.ts:38-58`) fills a served id's missing fields from **any** vendor's catalog — the provider's own, then any catalog by exact id, then any by the id minus one `<vendor>/` prefix — and reports `source: "catalog"`. `rowToEntry` (`apps/web/src/lib/model-form-payload.ts:233`) branched on `origin` alone, so every `origin === "discover"` row shipped `label`, `contextWindow`, `maxTokens`, `input` and `reasoning` as explicit `org_models` overrides.

Two corrections to the issue's write-up, verified in the code:

- The failure scenario does not need the prefix strip: `deepseek-ai/DeepSeek-V3` is an **exact key** of `apps/api/src/data/pricing/together-ai.json`, so the second fallback (any catalog, exact id) already hits it. The defect is the whole cross-catalog fill, not just the strip.
- "store `null` and let it re-resolve, exactly as a catalog-origin row does" cannot work here: `resolveCatalogDefaults` (`apps/api/src/services/org-models.ts:712-716`) resolves the **provider's own** catalog only, and discovery is offered solely for `openai-compatible`, which has no catalog (`modelSource`, `apps/web/src/lib/model-source.ts:26-35`). A value picked up from a foreign catalog is unreproducible server-side — which is exactly why it is frozen once written.

## Fix

One rule, in `rowToEntry`: **a discovered row pins what the endpoint itself published, and nothing else.**

- `source === "endpoint"` (the listing published at least one field) → the capability values ship, as today.
- `source !== "endpoint"` → the id only. The catalog match still *describes* the row in the pick list, badge and all — it identifies the model, it does not measure the operator's server.
- The label goes the same way for a discovered row: `describeServedModel` never takes a label from a listing (`label: entry?.label ?? null`), so a discovered label is *always* the catalog's. `deriveModelLabel` (`org-models.ts:380`) names the row after its id instead, deduped.
- `search` keeps its own branch (label from OpenRouter's `name`, cost included — the search is the billing rate). The shared capability spread is factored into `describedCapabilities`, so the three branches no longer restate it.

This aligns a batch-added custom model with a hand-typed one, which already stores null capabilities and lets the operator fill them in.

Why not keep the catalog values and mark them refreshable instead: making `resolveCatalogDefaults` scan foreign catalogs would silently hand every custom endpoint another vendor's specs at read time — and that function also returns `cost`, which `model-metadata.ts` deliberately withholds ("a wrong price would corrupt `llm_usage`"). Not a trade to make for this bug.

## Tests

`apps/web/src/lib/test/model-form-payload.test.ts` — the per-row table now keys on the describer: the endpoint-described case asserts the label no longer ships, a **new** case pins `discover` + `source: "catalog"` → `{ modelId }`, and the "a reported false is kept" fixture gained the `source: "endpoint"` it must have (`describeServedModel` sets `endpoint` as soon as any hint exists, so a hinted row with `source: null` was unreachable).

```
cd apps/web && TEST_TIER=0 bun test src/lib/test/model-form-payload.test.ts src/lib/test/model-source.test.ts   → 53 pass / 0 fail
cd apps/web && TEST_TIER=0 bun test src/components/test/model-form-modal.test.tsx \
                                    src/components/model-form/test/model-pick-list.test.tsx → 30 pass / 0 fail
bunx tsc --noEmit -p apps/web  → clean
bunx eslint / prettier on the three touched files → clean
```

`e2e/tests/models/custom-model.ui.spec.ts` was read and needs no change: its catalog-described row (`gpt-4o`) is only asserted visible by text, and `getByText` is a case-insensitive substring match against the now-derived `gpt-4o` label.

## Notes for the orchestrator

- Web-only, 3 files, no migration, no env var, no OpenAPI/contract change — nothing to re-generate.
- Based on `fix/issue-1356`; no overlap with #1355 (web retry / second credential), #1358 (duplicate `org_models` rows) or #1357 (featured model). #1356 touches the same `/discover` route file but not `model-form-payload.ts`.
- Behaviour change worth a release note: adding a *catalog-identified* model from a Custom endpoint no longer pre-fills its context window, so window-based compaction is off for it until the operator sets one on the row. That is already the case for a hand-typed custom model.
- Rows already saved with frozen foreign values are left alone: no data repair can tell which of them happen to be right. They are editable in the model form (the capabilities toggle opens on the stored overrides).
- Residual, not fixed here: when a listing publishes *some* fields, `source` is `"endpoint"` for the whole row, so any field the catalog filled alongside them still ships. Closing that needs per-field provenance on the wire — a `/discover` contract change, and #1356 owns that file this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
