### PR TITLE
fix(connect): keep the connect link burned once a refusal cost an upstream registration

### DIFF
--- a/apps/api/src/openapi/paths/integrations.ts
+++ b/apps/api/src/openapi/paths/integrations.ts
@@ -1011,13 +1011,14 @@ export const integrationsPaths = {
         "302": { description: "Redirect to the provider OAuth screen or the hosted form." },
         "400": {
           description:
-            "Missing token, or the oauth2 auth declares neither an issuer nor explicit endpoints (HTML error page). The link stays reusable.",
+            "Missing token, or the oauth2 auth declares neither an issuer nor explicit endpoints (HTML error page). The link stays reusable — except on an auth that auto-provisions its client (DCR/CIMD), where every refusal burns it.",
         },
         "403": {
           description:
-            "The space has no OAuth client registered for this auth and none could be auto-provisioned; the page says the failure is permanent and to ask an administrator, while the operator-facing detail naming the exact remedy stays on the server log — this route carries no session (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint.",
+            "The space has no OAuth client registered for this auth and none could be auto-provisioned; the page says the failure is permanent and to ask an administrator, while the operator-facing detail naming the exact remedy stays on the server log — this route carries no session (HTML error page). For an auth whose client is pre-registered the link stays reusable, so a retry after the administrator registers one needs no re-mint. For an auth that auto-provisions its client at the authorization server (DCR/CIMD) the link is burned: reaching this refusal means a registration was already attempted upstream, and a reusable link would replay it on every click.",
         },
         "410": { description: "Invalid, expired, or already-used token (HTML error page)." },
+        "429": { $ref: "#/components/responses/RateLimited" },
         "500": {
           description: "Integration cannot be connected / unexpected failure (HTML error page).",
         },

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -68,6 +68,7 @@ import { setOffsetLinkHeader } from "../lib/pagination-link.ts";
 import { popupHtmlClose, popupHtmlError } from "../lib/oauth-popup-html.ts";
 import { normalizeOAuthErrorCode, oauthDiagnosticSuffix } from "../lib/oauth-error-diagnostic.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
+import { rateLimitByIp } from "../middleware/rate-limit.ts";
 import { getActor, type Actor } from "../lib/actor.ts";
 import { getSpaceScope } from "../lib/scope.ts";
 import { recordAuditFromContext } from "./../services/audit.ts";
@@ -922,7 +923,16 @@ export function createIntegrationsRouter() {
   // GET /connect/start?token=… — the single dispatch entry point. Verifies the
   // capability token, consumes its jti (single-use), pins a page cookie, then
   // redirects: oauth2 → provider screen; else → the hosted SPA form at /connect.
-  router.get("/connect/start", async (c) => {
+  //
+  // Rate-limited per IP because the route carries no session: the signed token
+  // is its only credential, and every refusal that hands the jti back (below)
+  // leaves the link replayable for its whole 10-minute TTL. One click is a
+  // manifest load plus client lookups, so an unlimited public entry point turns
+  // a single link into an unbounded amplifier (issue #1344). 60/min is far
+  // above what a human clicking a popup ever needs. A 429 is the platform's
+  // standard problem+json — this limit answers abuse, not a flow failure, so it
+  // deliberately does not spend a popup page on it.
+  router.get("/connect/start", rateLimitByIp(60), async (c) => {
     // The single-use capability token rides this request's query string. Strip
     // the Referer entirely so the token can never leak to the provider (oauth2
     // redirect) or any downstream navigation — defence in depth on top of the
@@ -950,8 +960,9 @@ export function createIntegrationsRouter() {
     // exists, the capability token stays unburned so the caller can retry once
     // the integration is back, rather than being forced to re-mint.
     let auth: Awaited<ReturnType<typeof readIntegrationAuth>>["auth"];
+    let manifest: Awaited<ReturnType<typeof readIntegrationAuth>>["manifest"];
     try {
-      ({ auth } = await readIntegrationAuth(scope, claims.package_id, claims.auth_key));
+      ({ auth, manifest } = await readIntegrationAuth(scope, claims.package_id, claims.auth_key));
     } catch {
       return c.html(
         popupHtmlError("This integration is no longer available.", completionDetail),
@@ -1027,10 +1038,8 @@ export function createIntegrationsRouter() {
       //     terms — a client row id, `CONNECTION_ENCRYPTION_KEY`, an upstream
       //     AS's own prose. That half stays on the log line above, exactly as
       //     the callback keeps a provider's `error_description` there
-      //     (`oauth-error-diagnostic.ts`). Hand the jti back either way:
-      //     nothing was minted on the strength of this click, so a retry once
-      //     the admin has registered the client can reuse the very same link
-      //     instead of re-minting.
+      //     (`oauth-error-diagnostic.ts`). Whether the jti comes back depends
+      //     on what the refusal cost upstream — see the guard in the handler.
       //  2. Anything else (provider discovery error, network, an unexpected
       //     throw): transient or unknown. Keep the generic wording, keep the
       //     502, keep the jti burned — an unknown failure may have gone half
@@ -1057,7 +1066,29 @@ export function createIntegrationsRouter() {
             packageId: claims.package_id,
             authKey: claims.auth_key,
           });
-          await releaseJti(claims.jti);
+          // Hand the jti back only when the refusal PROVABLY precedes any
+          // egress — the same criterion the scope-resolution guard above
+          // applies to itself.
+          //
+          // For a classic auth that holds: `begin` resolves its client from
+          // OUR database (`ensureIntegrationOAuthClient` early-returns a plain
+          // row lookup) and every 4xx it can raise is thrown before
+          // `initiateIntegrationOAuth`, the first line that talks to anyone.
+          // Nothing left the process, so the very same link works once an
+          // administrator registers the client — no re-mint.
+          //
+          // An auto-provisioned (DCR/CIMD) auth is the exact opposite. Its
+          // client is acquired AT the third-party authorization server:
+          // discovery probes, then an RFC 7591 registration POST — and the
+          // refusal that lands here is raised precisely when that registration
+          // came back unusable, leaving an orphan client behind ("The upstream
+          // registration is abandoned unused", `ensureIntegrationOAuthClient`).
+          // Releasing the jti would let one 10-minute link replay that
+          // registration on every click of an unauthenticated route: a client
+          // spam amplifier attributable to this deployment (issue #1344). Burn
+          // it. The refusal is permanent anyway, so the retry this forbids was
+          // never going to succeed.
+          if (!usesAutoProvisionedClient(manifest, auth)) await releaseJti(claims.jti);
           return c.html(
             popupHtmlError(
               "This integration is not ready to be connected. Ask an administrator to finish setting it up, then open this link again.",

--- a/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
+++ b/apps/api/test/integration/routes/integrations-hosted-connect.test.ts
@@ -429,6 +429,22 @@ describe("hosted connect portal — oauth2 dispatch without a client (issues #12
     expect(html).not.toContain("dynamic client registration");
   });
 
+  it("burns a remote MCP link: its refusal follows a registration attempt (issue #1344)", async () => {
+    // The mirror image of the reusable classic 403 above. Client acquisition
+    // for this auth happens AT the authorization server — discovery, then an
+    // RFC 7591 registration POST — so by the time the refusal lands, the click
+    // has already spent outbound calls and may have left an orphan client
+    // registered upstream. A link that survived its own refusal would replay
+    // that on every click, for its whole TTL, on a route with no session.
+    await seedIntegration(ctx.orgId, remoteMcpManifest("@myorg/remote-mcp"));
+    const token = await mintSession(ctx, "@myorg/remote-mcp", "oauth");
+    expect((await startConnect(token)).status).toBe(403);
+
+    const again = await startConnect(token);
+    expect(again.status).toBe(410);
+    expect(await again.text()).toContain("already been used");
+  });
+
   it("never names the row or the env var when a client_secret cannot be decrypted", async () => {
     // The ciphertext no longer opens (key rotated without re-encrypt, or
     // corruption): `has_client_secret` still reads true from the column while

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -10996,14 +10996,14 @@ export interface operations {
                 };
                 content?: never;
             };
-            /** @description Missing token, or the oauth2 auth declares neither an issuer nor explicit endpoints (HTML error page). The link stays reusable. */
+            /** @description Missing token, or the oauth2 auth declares neither an issuer nor explicit endpoints (HTML error page). The link stays reusable — except on an auth that auto-provisions its client (DCR/CIMD), where every refusal burns it. */
             400: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content?: never;
             };
-            /** @description The space has no OAuth client registered for this auth and none could be auto-provisioned; the page says the failure is permanent and to ask an administrator, while the operator-facing detail naming the exact remedy stays on the server log — this route carries no session (HTML error page). The link stays reusable so a retry after the administrator registers a client needs no re-mint. */
+            /** @description The space has no OAuth client registered for this auth and none could be auto-provisioned; the page says the failure is permanent and to ask an administrator, while the operator-facing detail naming the exact remedy stays on the server log — this route carries no session (HTML error page). For an auth whose client is pre-registered the link stays reusable, so a retry after the administrator registers one needs no re-mint. For an auth that auto-provisions its client at the authorization server (DCR/CIMD) the link is burned: reaching this refusal means a registration was already attempted upstream, and a reusable link would replay it on every click. */
             403: {
                 headers: {
                     [name: string]: unknown;
@@ -11017,6 +11017,7 @@ export interface operations {
                 };
                 content?: never;
             };
+            429: components["responses"]["RateLimited"];
             /** @description Integration cannot be connected / unexpected failure (HTML error page). */
             500: {
                 headers: {


### PR DESCRIPTION
Closes #1344

## Root cause

`apps/api/src/routes/integrations.ts` — the `begin` catch on `GET /connect/start` released the single-use jti for the whole 4xx class, on the premise stated in its own comment: *"nothing was minted on the strength of this click"*.

That premise holds only for an auth whose OAuth client is pre-registered. For an **auto-provisioned** (DCR/CIMD) auth, `OAuth2Strategy.begin` → `ensureIntegrationOAuthClient` (`apps/api/src/services/integration-connections.ts:1625`) discovers the authorization server and POSTs an RFC 7591 **registration** to it — and the 403 that lands in this catch is raised precisely when that registration came back unusable (a confidential client where a public one was asked for), leaving an orphan client upstream: *"The upstream registration is abandoned unused"* (`:1651`). Releasing the jti let one 10-minute `connect_url` replay discovery + registration on **every** click of an unauthenticated, unlimited route.

## Fix

Two changes, both in the route.

1. **Release only when the refusal provably precedes any egress** — the same criterion #1352's new `releaseJti` site uses, so the two are consistent. The discriminator is the auth's kind, not the error's identity, because the auto-provisioned path is the *only* egress-before-refusal path in `begin`: on a classic auth `ensureIntegrationOAuthClient` early-returns a plain row lookup, and every `ApiError` 4xx `begin` can raise is thrown before `initiateIntegrationOAuth` — the first line that talks to anyone (everything past it throws `OAuthCallbackError`, which takes the 502 branch and keeps the burn). So `if (!usesAutoProvisionedClient(manifest, auth)) await releaseJti(claims.jti)` is exact, and it reuses the helper the route already imports rather than adding an error-code whitelist that could only approximate the same predicate.

   The end-user UX the release exists for is preserved where it was real: a classic "administrator must register a client" 403 still leaves the link reusable, so a retry after the admin acts needs no re-mint (existing test, unchanged).

2. **Rate-limit the route per IP** (`rateLimitByIp(60)`), as the issue asks. It carries no session, and every refusal that hands the jti back leaves the link replayable for its whole TTL — one click is a manifest load plus client lookups, so an unlimited public entry point is an amplifier on its own. 60/min is far above what a human clicking a popup needs. A 429 renders the platform's standard problem+json, not a popup page: this limit answers abuse, not a flow failure.

OpenAPI: the 400 and 403 descriptions asserted "The link stays reusable" unconditionally — amended to state the auto-provisioned exception; `429` added. `apps/web/src/api/schema.d.ts` regenerated.

## Tests

`apps/api/test/integration/routes/integrations-hosted-connect.test.ts` — one new case, the mirror of the existing "keeps the link reusable" one: a remote MCP (auto-DCR) refusal must answer 410 "already been used" on the second click.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test \
  apps/api/test/integration/routes/integrations-hosted-connect.test.ts \
  apps/api/test/integration/routes/integrations-connect-scope-catalog.test.ts
→ 30 pass, 0 fail (156 expect() calls)

bunx tsc --noEmit -p apps/api   → clean
bunx tsc --noEmit -p apps/web   → clean
bun run verify:openapi          → ALL CHECKS PASSED
bun run verify:api-types        → up to date
bun run detect:breaking         → 0 breaking, 1 non-breaking (new 429)
```

Negative control: with the guard reverted to the unconditional `releaseJti`, the new test fails `Expected: 410, Received: 403`.

## Notes for the orchestrator

- Based on `fix/issue-1352`; no overlap with the earlier links in the chain beyond the same handler. The comment #1263 left on case 1 ("Hand the jti back either way…") is the claim this issue falsifies, so it was rewritten rather than left contradicting the code.
- No migration, no env var, no deploy ordering constraint.
- Behaviour change worth naming: the undecryptable-`client_secret` 403 and the malformed-oauth2-auth 400 now also burn the link **on an auto-provisioned auth only** (classic auths are unchanged). Both are operator misconfigurations with no upstream cost on the classic path, which is why the classic path keeps its reusability.
- The rate limiter shares the process-global limiter cache in tests; the API suite issues ~20 `/connect/start` requests total, well under the 60/min bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
