### PR TITLE
fix(oidc): make the consent screen honest about an instance token's reach, and pin registration-time scope as advisory

### DIFF
--- a/apps/api/src/modules/oidc/README.md
+++ b/apps/api/src/modules/oidc/README.md
@@ -356,6 +356,24 @@ A public client is one whose `token_endpoint_auth_method` is `"none"` — that i
 - **PKCE is mandatory** for them: `isPKCERequired` returns "pkce is required for public clients" whenever `token_endpoint_auth_method` is `"none"`, whatever the client's own `require_pkce` says.
 - **Loopback ports are flexible** (RFC 8252 §7.3): the provider matches the requested redirect against the registered ones through `stripLoopbackRedirectPort`, so a client registered on `http://127.0.0.1/callback` matches `http://127.0.0.1:63785/callback` at runtime. It port-flexes `http:` loopback IP literals and the bare name `localhost`, and nothing else. Our registration gate (`services/redirect-uri.ts`, `isLoopbackHost`) is deliberately wider — it also admits `*.localhost` subdomains — so a `tenant.localhost` redirect registers but is matched port-exactly.
 
+## Self-service client registration (DCR / CIMD)
+
+Generic MCP clients onboard with no operator step, either by posting an RFC 7591 body to `/api/auth/oauth2/register` (DCR) or by identifying with a `client_id` URL that serves a Client ID Metadata Document (CIMD). Both paths land on `auth/plugins.ts` and are bounded by `getSelfServiceScopes()` — identity scopes plus every module scope opted in via `endUserGrantable: true`. A core action scope (`agents:run`, `llm-proxy:call`, …) is refused with `invalid_scope` at registration. Every such client is stamped `level = "instance"`, `self_service = true` by `markClientSelfService`, which is what confines its tokens to exactly one protected-resource audience at mint.
+
+### Registration-time `scope` is advisory
+
+A `scope` declared at registration is **validated** against the ceiling and then **discarded**: `persistOAuthClientRegistration` writes the whole ceiling to the row, so a client that publishes `scope: "openid"` is still able to request `mcp:invoke` at `/authorize`. This is Better Auth's documented contract — the persisted set is an operator-approved _capability_ set that a later user authorization steps up within, and a registration request "is not an authorization grant".
+
+The module keeps that behaviour rather than intersecting the declaration back in, for one reason: the declaration is client-controlled. A registrant that wanted the whole ceiling would simply declare it (DCR re-registers; CIMD edits its own document), so narrowing buys no confinement — while it would break every MCP client that publishes a minimal `scope` and then requests what the protected-resource metadata advertises. What actually bounds a self-service client is the ceiling itself, the single-audience rule at `/oauth2/token`, the consent screen, and the caller's live org role.
+
+Corollary: `markClientSelfService` writes `level` and `self_service` and nothing else. A scope backfill there would hand the client control of the ceiling `/authorize` enforces; it was removed in #1287 and must not come back.
+
+### What the consent screen promises
+
+For `org` and `space` clients the listed scopes are a real ceiling — an `org` token's claim is intersected with the live role, a `space` token gets exactly the claim. For an `instance` client (which is what every self-service registrant is) the token carries `actor_type: "user"`, `scopesToPermissions` returns an empty set and the pipeline writes no `scopeCeiling`: the request is served with whatever the user's live org role allows, inside the one MCP resource the token is bound to. The consent page says so explicitly for that level instead of letting the scope list imply a cap it does not have.
+
+Making that a real ceiling — minting instance tokens with the consented scope claim as `scopeCeiling` — would also change the CLI and the dashboard SPA, which are instance clients too. That is a product decision, not a bug fix, and is deliberately not taken here.
+
 ## Security notes
 
 - **JWKS rotation**: the Better Auth `jwt` plugin auto-rotates the ES256 keypair every 90 days with a 7-day grace window. `services/enduser-token.ts` verifies through `verifyJwsAccessToken`, which trusts a cached keyset for 300 seconds and re-reads it when the token's `kid` is not in that set, so key rotation propagates to verification within one token-verify cycle — no process restart required. External clients that cache the JWKS document directly should stay under a 5-minute ceiling for the same reason.

--- a/apps/api/src/modules/oidc/auth/plugins.ts
+++ b/apps/api/src/modules/oidc/auth/plugins.ts
@@ -259,6 +259,21 @@ export function oidcBetterAuthPlugins(opts: OidcBetterAuthPluginsOptions = {}): 
       // routes.ts. The user-consent screen remains the real authorization gate.
       // Default and ceiling are ONE array, so they cannot drift: the provider
       // unions them, and a default outside the ceiling would widen it silently.
+      //
+      // A registration `scope` is ADVISORY (issue #1351). The provider validates
+      // it against the union above and then persists that union verbatim
+      // (`persistOAuthClientRegistration`), so a client declaring `openid` may
+      // still ask for `mcp:invoke` at `/authorize`. Upstream documents this: the
+      // persisted set is an operator-approved CAPABILITY set a later user
+      // authorization steps up within, and a registration request "is not an
+      // authorization grant". We do not narrow it back down, because the
+      // declaration is CLIENT-CONTROLLED — the same registrant re-registers, or
+      // edits its metadata document, and declares the whole ceiling instead.
+      // Honouring it would buy no confinement and would break every MCP client
+      // that publishes a minimal `scope` and then requests what the protected
+      // resource advertises. The gates that hold are this ceiling, the consent
+      // screen, and the caller's live role. See README § "Self-service client
+      // registration (DCR / CIMD)".
       allowDynamicClientRegistration: true,
       allowUnauthenticatedClientRegistration: true,
       clientRegistrationDefaultScopes: selfServiceScopes,

--- a/apps/api/src/modules/oidc/pages/consent.ts
+++ b/apps/api/src/modules/oidc/pages/consent.ts
@@ -17,6 +17,7 @@
 import { html, type RawHtml } from "./html.ts";
 import { renderLayout } from "./layout.ts";
 import type { ResolvedSpaceBranding } from "../services/branding.ts";
+import type { OAuthClientLevel } from "../services/oauth-admin.ts";
 
 /**
  * Consent-screen descriptions, French (the hosted OAuth pages are FR-only).
@@ -62,6 +63,11 @@ function describeScope(scope: string): string {
 interface ConsentPageProps {
   clientName: string;
   scopes: string[];
+  /**
+   * Level of the client the user is authorizing. Decides whether the scope
+   * list is described as a limit — see `REACH_NOTICE_FR`.
+   */
+  clientLevel: OAuthClientLevel;
   /** Form action — typically `/api/oauth/consent${queryString}`. */
   action: string;
   /** CSRF token injected into the form + paired cookie. */
@@ -72,8 +78,29 @@ interface ConsentPageProps {
   error?: string;
 }
 
+/**
+ * What an `instance`-level authorization actually grants, in the user's words.
+ *
+ * The scope list above it is NOT a permission ceiling for such a client: its
+ * token carries `actor_type: "user"`, `scopesToPermissions` returns an empty
+ * set for that actor (`auth/claims.ts`) and the pipeline writes no
+ * `scopeCeiling` for it (`lib/auth-pipeline.ts`) — the request is served with
+ * whatever the user's live org role allows. Listing `mcp:invoke` and stopping
+ * there would let the user believe the app is capped at what it enumerated.
+ *
+ * `org` and `space` clients need no such notice: their tokens DO carry the
+ * scope claim as a ceiling (`dashboard_user` intersects it with the live role,
+ * `end_user` gets exactly the claim), so the list is the limit it looks like.
+ */
+const REACH_NOTICE_FR =
+  "Cette application se connecte en votre nom : dans l'organisation qu'elle cible, " +
+  "elle agit avec vos propres droits. La liste ci-dessus décrit l'accès demandé, " +
+  "elle ne le restreint pas.";
+
 export function renderConsentPage(props: ConsentPageProps): RawHtml {
   const scopeItems = props.scopes.map((s) => html`<li>${describeScope(s)}</li>`);
+  const reachNotice =
+    props.clientLevel === "instance" ? html`<p class="notice">${REACH_NOTICE_FR}</p>` : "";
   const title = `Autorisation — ${props.branding.name}`;
   const errorBlock = props.error ? html`<div class="error" role="alert">${props.error}</div>` : "";
   const bodyHtml = html`
@@ -87,6 +114,7 @@ export function renderConsentPage(props: ConsentPageProps): RawHtml {
     <ul class="scopes">
       ${scopeItems}
     </ul>
+    ${reachNotice}
     <div class="actions">
       <form method="POST" action="${props.action}">
         <input type="hidden" name="_csrf" value="${props.csrfToken}" />

--- a/apps/api/src/modules/oidc/pages/layout.ts
+++ b/apps/api/src/modules/oidc/pages/layout.ts
@@ -117,6 +117,11 @@ export function renderLayout(props: LayoutProps): RawHtml {
             padding: 10px 0;
             border-bottom: 1px solid #eee;
           }
+          .notice {
+            font-size: 13px;
+            color: #6b7280;
+            margin: -8px 0 0;
+          }
           .actions {
             display: flex;
             gap: 12px;

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -2087,6 +2087,7 @@ export function createOidcRouter() {
     const body = renderConsentPage({
       clientName: ctx.client.name ?? ctx.client.clientId,
       scopes,
+      clientLevel: ctx.client.level,
       action: `/api/oauth/consent${url.search}`,
       branding: ctx.branding,
       csrfToken: ctx.csrfToken,
@@ -2107,6 +2108,7 @@ export function createOidcRouter() {
       const body = renderConsentPage({
         clientName: ctx.client.name ?? ctx.client.clientId,
         scopes: scope.split(/\s+/).filter(Boolean),
+        clientLevel: ctx.client.level,
         action: `/api/oauth/consent${url.search}`,
         branding: ctx.branding,
         csrfToken: ctx.csrfToken,

--- a/apps/api/src/modules/oidc/services/oauth-admin.ts
+++ b/apps/api/src/modules/oidc/services/oauth-admin.ts
@@ -422,6 +422,18 @@ export async function createClient(input: CreateClientInput): Promise<OAuthClien
  * Both are columns, never the `metadata` JSON: the provider owns that JSON and
  * a registration body may set it, so a flag kept there is a flag the client can
  * name. Idempotent — a refreshed CIMD client is re-stamped on every resolution.
+ *
+ * It writes exactly those two columns and NEVER `scopes` (issue #1351). This
+ * function once backfilled the scope set from the CIMD document, to work around
+ * a Better Auth < 1.7.3 bug where the first resolution handed `/authorize` a
+ * client row with `scopes: []` and the request bounced with `invalid_scope`.
+ * That bug is fixed upstream — `persistOAuthClientRegistration` now writes the
+ * self-service ceiling in the same statement that creates the row — and the
+ * backfill was removed in #1287. Do not restore it: it is a path where the
+ * CLIENT decides its own persisted scope set, which is the ceiling `/authorize`
+ * enforces. The recorded symptom "CIMD 1st hit = invalid_scope" is not a reason
+ * to bring it back; `test/integration/services/dcr-cimd.test.ts` pins both the
+ * first-resolution flow and this function leaving `scopes` alone.
  */
 export async function markClientSelfService(clientId: string): Promise<void> {
   await db

--- a/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts
@@ -41,6 +41,7 @@ import { getEnv } from "@appstrate/env";
 import { OIDC_IDENTITY_SCOPES } from "../../../auth/scopes.ts";
 import oidcModule from "../../../index.ts";
 import { APPSTRATE_CLI_CLIENT_ID, ensureCliClient } from "../../../services/ensure-cli-client.ts";
+import { markClientSelfService } from "../../../services/oauth-admin.ts";
 
 const app = getTestApp({ modules: [oidcModule] });
 
@@ -671,6 +672,48 @@ describe("Dynamic Client Registration (RFC 7591)", () => {
       .where(eq(oauthClient.clientId, clientId))
       .limit(1);
     expect(row).toBeDefined();
+    expect(row!.level).toBe("instance");
+    expect(row!.selfService).toBe(true);
+  });
+
+  it("stamps level and self-service WITHOUT rewriting the scope set", async () => {
+    // The stamp once backfilled `scopes` too, to work around a Better Auth
+    // < 1.7.3 bug that handed the first `/authorize` a row with `scopes: []`.
+    // That path let the CLIENT decide the ceiling `/authorize` enforces, and it
+    // was removed in #1287. The recorded symptom ("CIMD 1st hit =
+    // invalid_scope") makes restoring it tempting, so pin the invariant
+    // directly: this function writes two columns and leaves `scopes` alone
+    // (issue #1351).
+    const { status, json } = await register({
+      client_name: "Stamp must not touch scopes",
+      redirect_uris: ["http://localhost:9921/callback"],
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    });
+    expect([200, 201]).toContain(status);
+    const clientId = String(json.client_id);
+
+    // A sentinel the ceiling would never produce: a backfill of ANY shape —
+    // from the ceiling or from the registration body — overwrites it.
+    const sentinel = ["openid", "urn:appstrate:test:sentinel"];
+    await db
+      .update(oauthClient)
+      .set({ scopes: sentinel })
+      .where(eq(oauthClient.clientId, clientId));
+
+    await markClientSelfService(clientId);
+
+    const [row] = await db
+      .select({
+        scopes: oauthClient.scopes,
+        level: oauthClient.level,
+        selfService: oauthClient.selfService,
+      })
+      .from(oauthClient)
+      .where(eq(oauthClient.clientId, clientId))
+      .limit(1);
+    expect(row!.scopes).toEqual(sentinel);
     expect(row!.level).toBe("instance");
     expect(row!.selfService).toBe(true);
   });

--- a/apps/api/src/modules/oidc/test/unit/pages.test.ts
+++ b/apps/api/src/modules/oidc/test/unit/pages.test.ts
@@ -98,6 +98,7 @@ describe("renderConsentPage", () => {
       ...DEFAULT_PROPS,
       clientName: `<img src=x>`,
       scopes: ["openid", "runs:read", `<evil>`],
+      clientLevel: "space",
       action: "/api/oauth/consent?state=x",
     }).value;
     expect(out).not.toContain(`<img src=x>`);
@@ -113,11 +114,40 @@ describe("renderConsentPage", () => {
       ...DEFAULT_PROPS,
       clientName: "Acme",
       scopes: ["openid", "agents:run", "integrations:connect"],
+      clientLevel: "space",
       action: "/x",
     }).value;
     expect(out).toContain("Votre identité");
     expect(out).toContain("Lancer des agents pour vous");
     expect(out).toContain("Ajouter des connexions en votre nom");
+  });
+
+  // An `instance` token carries `actor_type: "user"`: the scope claim grants
+  // nothing on its own (`scopesToPermissions` returns empty) and the pipeline
+  // writes no `scopeCeiling`, so the request runs on the user's live org role.
+  // Listing `mcp:invoke` and stopping there would read as a cap (issue #1351).
+  it("warns that the scope list is not a cap for an instance-level client", () => {
+    const out = renderConsentPage({
+      ...DEFAULT_PROPS,
+      clientName: "Claude Code",
+      scopes: ["mcp:read", "mcp:invoke"],
+      clientLevel: "instance",
+      action: "/x",
+    }).value;
+    expect(out.replace(/\s+/g, " ")).toContain("elle agit avec vos propres droits");
+  });
+
+  // `org` and `space` tokens DO carry the claim as a ceiling — the list is the
+  // limit it looks like, so the notice would be a lie there.
+  it.each(["org", "space"] as const)("omits that warning for a %s-level client", (level) => {
+    const out = renderConsentPage({
+      ...DEFAULT_PROPS,
+      clientName: "Acme",
+      scopes: ["openid", "runs:read"],
+      clientLevel: level,
+      action: "/x",
+    }).value;
+    expect(out).not.toContain("vos propres droits");
   });
 });
 
@@ -159,6 +189,7 @@ describe("page branding + CSRF", () => {
       ...DEFAULT_PROPS,
       clientName: "Acme",
       scopes: ["openid"],
+      clientLevel: "space",
       action: "/api/oauth/consent",
       csrfToken: "tok_consent",
     }).value;
@@ -200,6 +231,7 @@ describe("page branding + CSRF", () => {
     const out = renderConsentPage({
       clientName: "Acme",
       scopes: ["openid"],
+      clientLevel: "space",
       action: "/x",
       branding,
       csrfToken: "tok_test",


### PR DESCRIPTION
Closes #1351

## Root cause

Two separate findings, one decision each.

1. `persistOAuthClientRegistration` (`@better-auth/oauth-provider` 1.7.3, `dist/authorize-9whjxVLJ.mjs:1936`) overwrites the persisted `scope` with `resolveClientRegistrationScopes(opts)` for `dynamic` and `clientMetadataDocument` registrations, so a declared `scope: "openid"` is stored as the whole self-service ceiling and `/authorize` (`:5558`, `client.scopes` is the ceiling) will hand it `mcp:invoke`.
2. The consent screen lists the requested scopes as the grant (`pages/consent.ts`), but for an `instance` client `scopesToPermissions` returns an empty set for `actor_type: "user"` (`auth/claims.ts:60`) and `lib/auth-pipeline.ts:150-163` writes no `scopeCeiling` — the request runs on the user's live org role.

## Fix

**(1) is not a bug — it is upstream's documented contract**, and the fix is to say so. `clientRegistrationAllowedScopes`' own docblock states the registration `scope` "does not narrow the persisted capability set or grant those scopes to a user"; the persisted set is an operator-approved capability set a later user authorization steps up within. Intersecting the declaration back in was rejected because **the declaration is client-controlled**: a registrant that wants the ceiling just declares it (DCR re-registers, CIMD edits its own document), so narrowing buys zero confinement — while it breaks every MCP client that publishes a minimal `scope` and then requests what the protected-resource metadata advertises (the `claude mcp add` path). What bounds a self-service client stays: the ceiling, the single-audience rule at `/oauth2/token`, consent, and the caller's live role.

Documented at the three seams the issue names — `auth/plugins.ts` where the options are set, the module README (new *Self-service client registration (DCR / CIMD)* section), and `markClientSelfService`, whose CIMD scope backfill was removed unexplained in #1287 and whose recorded symptom ("CIMD 1st hit = invalid_scope") invites restoring it. Pinned by a test asserting the stamp writes `level`/`self_service` and leaves `scopes` untouched.

**(2) is a real defect and is fixed.** `renderConsentPage` now takes a required `clientLevel` and, for `instance` only, renders what the token actually reaches. `org`/`space` tokens do carry the scope claim as a ceiling, so the notice would be false there; making it required rather than optional forces a new level to decide.

No behaviour change to any OAuth flow: no route contract, no scope vocabulary, no token shape moved.

## Tests

- `apps/api/src/modules/oidc/test/integration/services/dcr-cimd.test.ts` — new: *"stamps level and self-service WITHOUT rewriting the scope set"*. **Negative control run**: re-adding a `scopes:` write inside `markClientSelfService` turns it red on the sentinel assertion (`0 pass, 1 fail`), so the pin bites.
- `apps/api/src/modules/oidc/test/unit/pages.test.ts` — new: the reach notice renders for `instance`, and `it.each(["org","space"])` that it does not; 4 existing consent call sites updated for the required prop.

```
TEST_TIER=0 bun test .../unit/pages.test.ts .../unit/self-service-scopes.test.ts   → 32 pass / 0 fail
TEST_TIER=0 bun test .../services/dcr-cimd.test.ts                                 → 25 pass / 0 fail
TEST_TIER=0 bun test .../oauth-enduser-pages .../realm-isolation .../oauth-flows .../loopback-redirect
                                                                                   → 75 pass / 0 fail
TEST_TIER=0 bun test apps/api/test/unit/oauth-scope-labels.test.ts                 →  3 pass / 0 fail
bunx tsc --noEmit -p apps/api                                                      → clean
bunx eslint <touched files>                                                        → clean
```

## Notes for the orchestrator

- No migration, no env var, no OpenAPI change (the consent screen is server-rendered HTML, not a documented response body) — nothing to sequence at deploy.
- **Open decision, deliberately not taken**: making the consented scope a real ceiling for instance tokens (minting `scopeCeiling` from the claim) would also constrain the CLI and the dashboard SPA, which are instance clients too. That is a product decision; the PR ships the honest-copy half and records the trade-off in the README.
- **Overlap with #1372** (next in the chain, builds on this branch): it touches the same scope vocabulary area (`auth/scopes.ts`). This PR does not modify `auth/scopes.ts` at all — only `plugins.ts`, `oauth-admin.ts`, `pages/consent.ts`, `pages/layout.ts`, `routes.ts`, the README and two test files — so the surfaces should not collide.
- The `.notice` CSS lives in `pages/layout.ts` alongside the other consent-only classes (`.client`, `ul.scopes`), matching how that file is already organised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
