### PR TITLE
test(ee): make the Stripe contract suite catch an SDK bump, and cover Invoice

### DIFF
--- a/.github/workflows/stripe-live.yml
+++ b/.github/workflows/stripe-live.yml
@@ -7,9 +7,20 @@
 # when a fixture claims a field the live API does not have, or when Stripe stops
 # behaving the way the module bets it does.
 #
-# Without `STRIPE_LIVE_SECRET_KEY` the suite skips itself and this job is green
-# — the same opt-in shape as `scripts/conformance/probes.ts`. That covers fork
-# PRs, which never receive secrets.
+# Without `STRIPE_LIVE_SECRET_KEY` the suite skips itself — the same opt-in
+# shape as `scripts/conformance/probes.ts`. On a pull_request that skip is
+# allowed and this job stays green, because two kinds of PR structurally cannot
+# see repository secrets:
+#
+#   * fork PRs, which never receive them; and
+#   * DEPENDABOT PRs, which receive the Dependabot secret store instead. This is
+#     the reason the `pull_request` trigger alone cannot cover an SDK bump: the
+#     variable is empty, `describe.skipIf` skips every test, and the job reports
+#     green having checked nothing.
+#
+# The `push` trigger below is the half that does cover it. On push, schedule and
+# workflow_dispatch the repository secrets ARE available, so a missing key there
+# is a real failure and this job says so rather than skipping quietly.
 name: Stripe live contract
 
 on:
@@ -18,9 +29,16 @@ on:
   schedule:
     - cron: "0 7 * * 1"
   workflow_dispatch:
-  # Anything that touches the billing module or its Stripe dependency. A
-  # Dependabot bump of `stripe` edits packages/module-ee/package.json, so it
-  # lands here without anyone remembering to label it.
+  # The guaranteed run. A Dependabot bump of `stripe` edits
+  # packages/module-ee/package.json, so its MERGE lands here — with repository
+  # secrets — even though its PR run could not see them.
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/module-ee/**"
+      - ".github/workflows/stripe-live.yml"
+  # Best-effort pre-merge signal for human PRs touching the billing module.
   pull_request:
     paths:
       - "packages/module-ee/**"
@@ -61,12 +79,22 @@ jobs:
       - name: Start test infrastructure
         run: docker compose -f test/setup/docker-compose.test.yml up -d --wait
 
+      # A skipped suite reporting green is the exact failure this job exists to
+      # prevent, so the skip is tolerated only where the secret CANNOT reach the
+      # run: a pull_request from a fork or from Dependabot.
       - name: Report coverage state
         run: |
-          if [ -z "${STRIPE_LIVE_SECRET_KEY}" ]; then
-            echo "::notice::STRIPE_LIVE_SECRET_KEY is not set — the live contract suite will skip itself."
+          if [ -n "${STRIPE_LIVE_SECRET_KEY}" ]; then
+            exit 0
           fi
+          if [ "${EVENT_NAME}" = "pull_request" ]; then
+            echo "::warning::STRIPE_LIVE_SECRET_KEY is not visible to this run — the contract suite will skip itself. Expected on a fork PR, and on a Dependabot PR (those read the Dependabot secret store, not repository secrets). The push-to-main run covers the merge."
+            exit 0
+          fi
+          echo "::error::STRIPE_LIVE_SECRET_KEY is empty on a ${EVENT_NAME} run, where repository secrets ARE available — the secret is missing, and the contract suite would skip itself while reporting green."
+          exit 1
         env:
+          EVENT_NAME: ${{ github.event_name }}
           STRIPE_LIVE_SECRET_KEY: ${{ secrets.STRIPE_LIVE_SECRET_KEY }}
 
       - name: Run Stripe live contract suite

--- a/packages/module-ee/README.md
+++ b/packages/module-ee/README.md
@@ -607,17 +607,47 @@ therefore returning `null` in every test that touched it. The confirmation
 e-mail silently fell back to today's date, and no test noticed, because the
 fixture and the assertions were written from the same stale belief.
 
-`test/live/stripe-contract.test.ts` is the other half. It runs against real
-Stripe in **test mode** and checks the two things the mock structurally cannot:
+Two things close that gap, and they are worth separating because only one of
+them needs a Stripe key.
 
-- **Shape** — every key path a fixture claims must exist on the live object.
-  Extra live fields are ignored (the fixtures are deliberately minimal); invented
-  ones fail. This is what turns the next relocation into a red mock rather than a
-  quiet production lie.
+**Without a key — the fixtures are typed.** `test/helpers/stripe.ts` declares
+`Fixture<T>`, a deep-partial of the real SDK type: a fixture may omit any field
+production never reads, but every field it DOES carry must exist on
+`Stripe.Subscription`, `Stripe.Invoice`, … with a compatible type. The module's
+`tsconfig.json` includes `test` for exactly this reason. So a bump of `stripe`
+that RELOCATES a field fails `bunx tsc --noEmit -p packages/module-ee` on the
+fixture, on any machine, with no account involved. That is the check the
+2025-03-31 move of `current_period_end` would have tripped. Note the one hole it
+cannot see: TypeScript exempts spread properties from excess-property checking,
+so fixture fields are written as direct properties (`amount_paid: undefined`)
+rather than `...(cond ? {} : { amount_paid })`.
+
+**With a key — the live contract suite.** `test/live/stripe-contract.test.ts`
+runs against real Stripe in **test mode** and checks the two things neither the
+mock nor the typechecker can:
+
+- **Shape** — every key path a fixture claims must exist on the live object,
+  for Subscription, Customer, Checkout.Session, BillingPortal.Session and
+  Invoice. Extra live fields are ignored (the fixtures are deliberately
+  minimal); invented ones fail. It also asserts that every path production
+  dereferences resolves on the live object AND on the fixture — a path present
+  in only one of the two is a test proving nothing. The invoice set covers
+  `parent.subscription_details.subscription`, the post-basil replacement for the
+  removed top-level `invoice.subscription`, on which budget allocation hangs.
 - **Semantics** — that `subscriptions.update` replaces the priced item, that
   `current_period_end` is a timestamp on the item, that a forged webhook
   signature raises `StripeSignatureVerificationError` and an unknown id raises
-  `StripeInvalidRequestError` (both classes are branched on in `src/routes/`).
+  `StripeInvalidRequestError` (both classes are branched on in `src/routes/`),
+  and that every enabled webhook endpoint on the account renders payloads at the
+  version the module pins. That last one is a separate contract: the SDK pin
+  governs what a `retrieve` returns, while a webhook payload is rendered at the
+  version configured on the ENDPOINT, and `subscriptionPeriodEnd` is applied to
+  `event.data.object` too.
+
+The API version lives in exactly one place, `STRIPE_API_VERSION` in
+`src/stripe/client.ts`, pinned with `satisfies Stripe.LatestApiVersion` — a
+literal type, so an SDK bump makes that line a hard `TS2322`. The live suite
+imports it rather than restating it.
 
 It creates a customer and a subscription and deletes them in `afterAll`, so it
 needs a key that may mutate the account:
@@ -632,8 +662,12 @@ shape as `scripts/conformance/probes.ts`. It is deliberately **not**
 `bun test` start creating objects in an account nobody aimed at. A key that does
 not begin with `sk_test_` is refused outright rather than skipped.
 
-In CI it is `.github/workflows/stripe-live.yml` — weekly, on demand, and on any
-PR touching `packages/module-ee/**` (which includes a Dependabot bump of the
-`stripe` dependency). The repository secret is `STRIPE_LIVE_SECRET_KEY`; until it
-is provisioned the job runs green with the suite skipped, and says so in an
-annotation.
+In CI it is `.github/workflows/stripe-live.yml`: weekly, on demand, on every
+**push to `main`** touching `packages/module-ee/**`, and on any PR touching the
+same paths. The push trigger is not redundant — a Dependabot PR reads the
+_Dependabot_ secret store, not repository secrets, so `STRIPE_LIVE_SECRET_KEY`
+is empty there, every test skips, and the job would otherwise report green on
+the one PR that most needs the check. The merge of that PR is what runs the
+suite for real. Fork PRs skip for the same structural reason and are equally
+tolerated; on `push`, `schedule` and `workflow_dispatch`, where repository
+secrets ARE available, a missing key **fails** the job instead of skipping.

--- a/packages/module-ee/src/stripe/client.ts
+++ b/packages/module-ee/src/stripe/client.ts
@@ -3,12 +3,24 @@
 import Stripe from "stripe";
 import { getEeEnv } from "../env.ts";
 
+/**
+ * The Stripe API version every request in this module is rendered at.
+ *
+ * `satisfies Stripe.LatestApiVersion` is the tripwire: that type is a single
+ * string LITERAL, so a Dependabot bump of `stripe` that ships a newer version
+ * turns this line into a hard TS2322 and drags the pin forward with the SDK.
+ * It is exported so the live contract suite (`test/live`) pins the same version
+ * instead of restating the literal in a file that would keep agreeing with an
+ * API version production no longer speaks.
+ */
+export const STRIPE_API_VERSION = "2026-08-26.dahlia" satisfies Stripe.LatestApiVersion;
+
 let _stripe: Stripe | null = null;
 
 export function getStripe(): Stripe {
   if (!_stripe) {
     _stripe = new Stripe(getEeEnv().STRIPE_SECRET_KEY, {
-      apiVersion: "2026-08-26.dahlia",
+      apiVersion: STRIPE_API_VERSION,
       // Mock-host redirect is a TEST-ONLY hook. Gating on NODE_ENV keeps an
       // operator-set STRIPE_MOCK_HOST from silently rerouting production Stripe
       // traffic to an arbitrary host over plain HTTP.

--- a/packages/module-ee/test/helpers/stripe.ts
+++ b/packages/module-ee/test/helpers/stripe.ts
@@ -8,6 +8,29 @@
  * injection, and request recording for assertions.
  */
 
+import type Stripe from "stripe";
+
+// ─── Typed fixtures ─────────────────────────────────────────────
+
+/**
+ * A minimal stand-in for a live Stripe object.
+ *
+ * Every field a fixture carries must exist on the real SDK type with a
+ * compatible type; the fixture is free to omit the dozens of fields production
+ * never reads. This is the half of the contract check that needs no Stripe key:
+ * when a bump of `stripe` RELOCATES a field — as 2025-03-31 did with
+ * `current_period_end`, and post-basil did with `invoice.subscription` —
+ * `tsc` fails on the fixture instead of letting it keep agreeing with itself.
+ *
+ * `test/live/stripe-contract.test.ts` is the other half: it proves the fields
+ * the fixtures DO carry still exist on a real response.
+ */
+export type Fixture<T> = T extends (infer U)[]
+  ? Fixture<U>[]
+  : T extends object
+    ? { [K in keyof T]?: Fixture<T[K]> }
+    : T;
+
 // ─── Request recording ──────────────────────────────────────────
 
 interface RecordedRequest {
@@ -83,7 +106,7 @@ async function parseBody(req: Request): Promise<Record<string, unknown> | null> 
 
 let customerCounter = 0;
 
-export function defaultCustomerResponse(): Record<string, unknown> {
+export function defaultCustomerResponse(): Fixture<Stripe.Customer> {
   customerCounter++;
   return {
     id: `cus_test_${customerCounter.toString().padStart(3, "0")}`,
@@ -92,7 +115,7 @@ export function defaultCustomerResponse(): Record<string, unknown> {
   };
 }
 
-export function defaultCheckoutResponse(): Record<string, unknown> {
+export function defaultCheckoutResponse(): Fixture<Stripe.Checkout.Session> {
   return {
     id: `cs_test_${Date.now()}`,
     url: "https://checkout.stripe.com/test",
@@ -100,7 +123,7 @@ export function defaultCheckoutResponse(): Record<string, unknown> {
   };
 }
 
-export function defaultPortalResponse(): Record<string, unknown> {
+export function defaultPortalResponse(): Fixture<Stripe.BillingPortal.Session> {
   return {
     id: `bps_test_${Date.now()}`,
     url: "https://billing.stripe.com/test",
@@ -108,7 +131,7 @@ export function defaultPortalResponse(): Record<string, unknown> {
   };
 }
 
-export function defaultSubscriptionResponse(id: string): Record<string, unknown> {
+export function defaultSubscriptionResponse(id: string): Fixture<Stripe.Subscription> {
   return {
     id,
     object: "subscription",
@@ -138,12 +161,128 @@ export function defaultSubscriptionResponse(id: string): Record<string, unknown>
   };
 }
 
+/**
+ * The invoice `packages/module-ee/src/stripe/webhooks.ts` receives on
+ * `invoice.paid` and `invoice.payment_failed`.
+ *
+ * One place writes `parent.subscription_details.subscription` — the post-basil
+ * replacement for the removed top-level `invoice.subscription`, and the single
+ * path that decides whether budget allocation happens at all. Spelling it at
+ * every call site is how the module ended up with a subscription reference no
+ * test could disprove; spelling it once, typed as `Fixture<Stripe.Invoice>`,
+ * makes the next relocation a typecheck failure.
+ */
+export function invoiceEventObject(opts: {
+  id: string;
+  customer: string;
+  /** `null` for the "invoice with no subscription reference" path. */
+  subscription: string | null;
+  billingReason?: Stripe.Invoice.BillingReason;
+  amountPaid?: number;
+  amountDue?: number;
+  attemptCount?: number;
+  hostedInvoiceUrl?: string;
+}): Fixture<Stripe.Invoice> {
+  // Written as direct properties, never conditional spreads: TypeScript exempts
+  // spread properties from excess-property checking, so a field that Stripe has
+  // moved would slip back in unnoticed through `...(cond ? {} : { gone: x })`.
+  // `JSON.stringify` drops the `undefined` ones, so the wire payload still
+  // carries only what the case under test sets.
+  return {
+    id: opts.id,
+    object: "invoice",
+    customer: opts.customer,
+    billing_reason: opts.billingReason ?? "subscription_cycle",
+    parent:
+      opts.subscription === null
+        ? null
+        : { subscription_details: { subscription: opts.subscription } },
+    amount_paid: opts.amountPaid,
+    amount_due: opts.amountDue,
+    attempt_count: opts.attemptCount,
+    hosted_invoice_url: opts.hostedInvoiceUrl,
+  };
+}
+
+/**
+ * The invoice fixture with every optional field set.
+ *
+ * `invoiceEventObject` leaves unset fields out of the wire payload so each
+ * mocked test carries only what it exercises; the contract checks need the
+ * union of all of them, because the question there is whether the SHAPE the
+ * builder can produce still matches Stripe — not what one test happens to send.
+ */
+export function fullInvoiceFixture(): Fixture<Stripe.Invoice> {
+  return invoiceEventObject({
+    id: "in_shape",
+    customer: "cus_shape",
+    subscription: "sub_shape",
+    billingReason: "subscription_cycle",
+    amountPaid: 2900,
+    amountDue: 2900,
+    attemptCount: 1,
+    hostedInvoiceUrl: "https://invoice.stripe.com/i/test",
+  });
+}
+
+// ─── What production reads off each object ──────────────────────
+
+/**
+ * Every path `packages/module-ee/src` dereferences on a retrieved subscription.
+ *
+ * Held here rather than in either test file because BOTH halves need it: the
+ * key-free half (`test/unit/stripe-fixtures.test.ts`) asserts the fixtures carry
+ * these paths, and the live half (`test/live/stripe-contract.test.ts`) asserts
+ * Stripe still does. A path that resolves on only one side is a suite proving
+ * nothing.
+ */
+export const SUBSCRIPTION_READS = [
+  "id",
+  "status",
+  "customer",
+  "metadata",
+  "cancel_at_period_end",
+  "items.data[0].id",
+  "items.data[0].price.id",
+  "items.data[0].current_period_end",
+];
+
+/**
+ * Every path `src/stripe/webhooks.ts` dereferences on an invoice, across
+ * `invoice.paid` and `invoice.payment_failed`.
+ *
+ * `parent.subscription_details.subscription` is the one that matters most: post-
+ * basil it replaced the removed top-level `invoice.subscription`, and when it
+ * reads `undefined` budget allocation is skipped outright rather than failing.
+ */
+export const INVOICE_READS = [
+  "id",
+  "customer",
+  "billing_reason",
+  "amount_paid",
+  "amount_due",
+  "attempt_count",
+  "hosted_invoice_url",
+  "parent.subscription_details.subscription",
+];
+
+/** Value at a dotted path, `[0]` segments included. `undefined` when absent. */
+export function valueAtPath(root: unknown, path: string): unknown {
+  return path
+    .split(".")
+    .flatMap((seg) => seg.split(/\[(\d+)\]/).filter(Boolean))
+    .reduce<unknown>((node, seg) => {
+      if (node === null || typeof node !== "object") return undefined;
+      return (node as Record<string, unknown>)[seg];
+    }, root);
+}
+
 // ─── Mock server ────────────────────────────────────────────────
 
 let server: ReturnType<typeof Bun.serve> | null = null;
 
 export function startStripeMock(): { port: number } {
-  if (server) return { port: server.port };
+  if (server) return { port: server.port! };
 
   server = Bun.serve({
     port: 0,
@@ -220,7 +359,7 @@ export function startStripeMock(): { port: number } {
     },
   });
 
-  return { port: server.port };
+  return { port: server.port! };
 }
 
 // ─── Webhook signature generation ───────────────────────────────

--- a/packages/module-ee/test/integration/services/before-usage-hook.test.ts
+++ b/packages/module-ee/test/integration/services/before-usage-hook.test.ts
@@ -29,7 +29,9 @@ useEeTestSeams();
 
 const orgId = "00000000-0000-4000-a000-000000000900";
 
-function beforeUsage(...args: Parameters<NonNullable<typeof eeModule.hooks>["beforeUsage"]>) {
+function beforeUsage(
+  ...args: Parameters<NonNullable<NonNullable<typeof eeModule.hooks>["beforeUsage"]>>
+) {
   return eeModule.hooks!.beforeUsage!(...args);
 }
 

--- a/packages/module-ee/test/integration/services/migrate.test.ts
+++ b/packages/module-ee/test/integration/services/migrate.test.ts
@@ -104,10 +104,10 @@ describe("migrateEeDb", () => {
     ).resolves.toBeArray();
 
     // Schema is back and usable (table exists, empty).
-    const [{ count }] = await db.execute(
+    const [countRow] = await db.execute<{ count: number }>(
       sql.raw("SELECT count(*)::int AS count FROM ee_billing_accounts"),
     );
-    expect(count).toBe(0);
+    expect(countRow?.count).toBe(0);
   });
 });
 
@@ -154,14 +154,14 @@ describe("migration chain upgrades", () => {
     expect(billedCols.map((c) => c.column_name)).not.toContain("run_id");
 
     // retry queue gone; cursor table present.
-    const [{ pending }] = await db.execute(
+    const [pendingRow] = await db.execute<{ pending: string | null }>(
       sql.raw("SELECT to_regclass('cloud_pending_bills') AS pending"),
     );
-    expect(pending).toBeNull();
-    const [{ cursor }] = await db.execute(
+    expect(pendingRow?.pending).toBeNull();
+    const [cursorRow] = await db.execute<{ cursor: string | null }>(
       sql.raw("SELECT to_regclass('cloud_billing_cursor') AS cursor"),
     );
-    expect(cursor).not.toBeNull();
+    expect(cursorRow?.cursor).not.toBeNull();
   });
 
   it("0001 → 0002 converts cost_usd to numeric without losing a stored value", async () => {
@@ -234,7 +234,7 @@ describe("migration chain upgrades", () => {
         ORDER BY org_id
       `),
     );
-    expect(rows).toEqual([
+    expect([...rows]).toEqual([
       { org_id: canceledOrg, subscription_status: null, credits_used: 0, credit_quota: 0 },
       { org_id: incompleteOrg, subscription_status: null, credits_used: 0, credit_quota: 0 },
       {
@@ -271,10 +271,10 @@ describe("migration chain upgrades", () => {
     await db.execute(sql.raw("DELETE FROM cloud_pending_bills"));
     await applyMigration("0001_cursor_billing");
 
-    const [{ pending }] = await db.execute(
+    const [pendingRow] = await db.execute<{ pending: string | null }>(
       sql.raw("SELECT to_regclass('cloud_pending_bills') AS pending"),
     );
-    expect(pending).toBeNull();
+    expect(pendingRow?.pending).toBeNull();
   });
 
   it("0004 → 0005 renames every table, index and constraint off the cloud_ prefix", async () => {
@@ -310,7 +310,7 @@ describe("migration chain upgrades", () => {
         WHERE connamespace = 'public'::regnamespace AND conname LIKE 'cloud%'
       `),
     );
-    expect(named).toEqual([]);
+    expect([...named]).toEqual([]);
   });
 });
 

--- a/packages/module-ee/test/integration/services/webhook-emails.test.ts
+++ b/packages/module-ee/test/integration/services/webhook-emails.test.ts
@@ -7,6 +7,7 @@ import {
   resetStripeMock,
   generateWebhookEvent,
   setSubscriptionResponse,
+  invoiceEventObject,
 } from "../../helpers/stripe.ts";
 import { handleWebhook } from "../../../src/stripe/webhooks.ts";
 import { initBillingEmail } from "../../../src/emails/send.ts";
@@ -105,18 +106,14 @@ describe("webhook billing emails", () => {
         id: "evt_email_invoice_001",
         type: "invoice.paid",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_email_001",
             customer: "cus_email_inv_001",
-            billing_reason: "subscription_cycle",
-            amount_paid: 2900,
-            hosted_invoice_url: "https://invoice.stripe.com/i/test",
-            parent: {
-              subscription_details: {
-                subscription: "sub_email_inv_001",
-              },
-            },
-          },
+            subscription: "sub_email_inv_001",
+            billingReason: "subscription_cycle",
+            amountPaid: 2900,
+            hostedInvoiceUrl: "https://invoice.stripe.com/i/test",
+          }),
         },
       });
 
@@ -218,13 +215,14 @@ describe("webhook billing emails", () => {
         id: "evt_email_fail_001",
         type: "invoice.payment_failed",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_email_fail_001",
             customer: "cus_email_fail_001",
-            billing_reason: "subscription_cycle",
-            amount_due: 2900,
-            attempt_count: 2,
-          },
+            subscription: null,
+            billingReason: "subscription_cycle",
+            amountDue: 2900,
+            attemptCount: 2,
+          }),
         },
       });
 
@@ -252,14 +250,14 @@ describe("webhook billing emails", () => {
         id: "evt_email_fail_002",
         type: "invoice.payment_failed",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_email_fail_002",
             customer: "cus_email_fail_002",
-            billing_reason: "subscription_cycle",
-            amount_due: 2900,
-            attempt_count: 2,
-            parent: { subscription_details: { subscription: "sub_email_old" } },
-          },
+            subscription: "sub_email_old",
+            billingReason: "subscription_cycle",
+            amountDue: 2900,
+            attemptCount: 2,
+          }),
         },
       });
 
@@ -326,11 +324,12 @@ describe("webhook billing emails", () => {
         id: "evt_email_unknown_001",
         type: "invoice.payment_failed",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_unknown_001",
             customer: "cus_nonexistent",
-            billing_reason: "subscription_cycle",
-          },
+            subscription: null,
+            billingReason: "subscription_cycle",
+          }),
         },
       });
 

--- a/packages/module-ee/test/integration/services/webhooks.test.ts
+++ b/packages/module-ee/test/integration/services/webhooks.test.ts
@@ -8,6 +8,7 @@ import {
   resetStripeMock,
   generateWebhookEvent,
   setSubscriptionResponse,
+  invoiceEventObject,
   requests,
 } from "../../helpers/stripe.ts";
 import { handleWebhook } from "../../../src/stripe/webhooks.ts";
@@ -418,16 +419,12 @@ describe("handleWebhook", () => {
         id: "evt_invoice_cycle_001",
         type: "invoice.paid",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_cycle_001",
             customer: "cus_invoice_001",
-            billing_reason: "subscription_cycle",
-            parent: {
-              subscription_details: {
-                subscription: "sub_invoice_001",
-              },
-            },
-          },
+            subscription: "sub_invoice_001",
+            billingReason: "subscription_cycle",
+          }),
         },
       });
 
@@ -477,16 +474,12 @@ describe("handleWebhook", () => {
         id: "evt_invoice_create_001",
         type: "invoice.paid",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_create_001",
             customer: "cus_invoice_002",
-            billing_reason: "subscription_create",
-            parent: {
-              subscription_details: {
-                subscription: "sub_invoice_002",
-              },
-            },
-          },
+            subscription: "sub_invoice_002",
+            billingReason: "subscription_create",
+          }),
         },
       });
 
@@ -525,12 +518,12 @@ describe("handleWebhook", () => {
         id: "evt_invoice_dead_001",
         type: "invoice.paid",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_dead_001",
             customer: "cus_invoice_dead",
-            billing_reason: "subscription_cycle",
-            parent: { subscription_details: { subscription: "sub_invoice_dead" } },
-          },
+            subscription: "sub_invoice_dead",
+            billingReason: "subscription_cycle",
+          }),
         },
       });
 
@@ -580,12 +573,12 @@ describe("handleWebhook", () => {
         id: "evt_race_invoice_001",
         type: "invoice.paid",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_race_001",
             customer: "cus_race_001",
-            billing_reason: "subscription_create",
-            parent: { subscription_details: { subscription: "sub_race_001" } },
-          },
+            subscription: "sub_race_001",
+            billingReason: "subscription_create",
+          }),
         },
       });
 
@@ -635,12 +628,12 @@ describe("handleWebhook", () => {
         id: "evt_portal_invoice_001",
         type: "invoice.paid",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_portal_001",
             customer: "cus_portal_001",
-            billing_reason: "subscription_update",
-            parent: { subscription_details: { subscription: "sub_portal_001" } },
-          },
+            subscription: "sub_portal_001",
+            billingReason: "subscription_update",
+          }),
         },
       });
 
@@ -857,11 +850,12 @@ describe("handleWebhook", () => {
         id: "evt_payment_failed_001",
         type: "invoice.payment_failed",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_fail_001",
             customer: "cus_fail_001",
-            billing_reason: "subscription_cycle",
-          },
+            subscription: null,
+            billingReason: "subscription_cycle",
+          }),
         },
       });
 
@@ -994,12 +988,12 @@ describe("handleWebhook", () => {
         id: "evt_identity_invoice_old",
         type: "invoice.paid",
         data: {
-          object: {
+          object: invoiceEventObject({
             id: "in_identity_old",
             customer: "cus_identity",
-            billing_reason: "subscription_cycle",
-            parent: { subscription_details: { subscription: "sub_old" } },
-          },
+            subscription: "sub_old",
+            billingReason: "subscription_cycle",
+          }),
         },
       });
 

--- a/packages/module-ee/test/live/stripe-contract.test.ts
+++ b/packages/module-ee/test/live/stripe-contract.test.ts
@@ -19,31 +19,56 @@
  * the fixture and the assertion were written from the same belief.
  *
  * This suite is the missing half. It hits real Stripe in TEST MODE and checks
- * the two things a mock structurally cannot:
+ * the three things a mock structurally cannot:
  *
  *   1. Shape — every key path the mock claims exists must exist on the live
- *      object. Extra live fields are fine (the fixtures are deliberately
- *      minimal); invented ones are not. This is the check that turns the next
- *      drift into a red mock instead of a quiet production lie.
+ *      object, for Subscription, Customer, Checkout.Session,
+ *      BillingPortal.Session and Invoice. Extra live fields are fine (the
+ *      fixtures are deliberately minimal); invented ones are not. This is the
+ *      check that turns the next drift into a red mock instead of a quiet
+ *      production lie.
  *   2. Semantics — the handful of behaviours the module bets on, above all
  *      that `subscriptions.update` REPLACES the priced item instead of adding
  *      one. A mock returns whatever we told it to; only Stripe can say whether
  *      that call double-charges every customer who changes plan.
+ *   3. Account configuration — that every enabled webhook endpoint renders
+ *      payloads at the version this module pins. The SDK pin governs what a
+ *      `retrieve` returns; a webhook payload is rendered at the ENDPOINT's
+ *      configured version, and `subscriptionPeriodEnd` is applied to
+ *      `event.data.object` too.
  *
  * Coverage is opt-in, following `scripts/conformance/probes.ts`: no
  * `STRIPE_LIVE_SECRET_KEY`, no run, no noise. It is deliberately NOT
  * `STRIPE_SECRET_KEY` — a developer `.env` holding a working key must never
  * make `bun test` start creating objects in an account nobody aimed at.
+ *
+ * Because "no key" is the common case, the checks that do NOT need one live
+ * elsewhere and run everywhere: `Fixture<T>` (test/helpers/stripe.ts) types
+ * every fixture against the SDK, so a bump that RELOCATES a field fails `tsc`;
+ * and `test/unit/stripe-fixtures.test.ts` asserts the fixtures carry every path
+ * production reads, which the all-optional `Fixture<T>` cannot.
+ *
+ * Run it with:
+ *
+ *   STRIPE_LIVE_SECRET_KEY=sk_test_… bun test packages/module-ee/test/live
+ *
+ * (`packages/module-ee` declares `postgres: true`, so the harness needs the
+ * test infrastructure up even though this file touches no table.)
  */
 
 import { describe, expect, it, beforeAll, afterAll } from "bun:test";
 import Stripe from "stripe";
 import {
+  INVOICE_READS,
+  SUBSCRIPTION_READS,
   defaultCheckoutResponse,
   defaultCustomerResponse,
   defaultPortalResponse,
   defaultSubscriptionResponse,
+  fullInvoiceFixture,
+  valueAtPath,
 } from "../helpers/stripe.ts";
+import { STRIPE_API_VERSION } from "../../src/stripe/client.ts";
 
 const SECRET_KEY = process.env.STRIPE_LIVE_SECRET_KEY;
 
@@ -86,20 +111,12 @@ function driftedPaths(mock: unknown, live: unknown, prefix = ""): string[] {
 
   return Object.entries(mock as Record<string, unknown>).flatMap(([key, value]) => {
     const path = prefix ? `${prefix}.${key}` : key;
+    // `undefined` is the fixture declining to set the field (the builders spell
+    // every key so the typechecker sees them), not a claim about the live shape.
+    if (value === undefined) return [];
     if (!(key in liveRecord)) return [`${path} (absent from the live object)`];
     return driftedPaths(value, liveRecord[key], path);
   });
-}
-
-/** Value at a dotted path, `[0]` segments included. `undefined` when absent. */
-function at(root: unknown, path: string): unknown {
-  return path
-    .split(".")
-    .flatMap((seg) => seg.split(/\[(\d+)\]/).filter(Boolean))
-    .reduce<unknown>((node, seg) => {
-      if (node === null || typeof node !== "object") return undefined;
-      return (node as Record<string, unknown>)[seg];
-    }, root);
 }
 
 describe.skipIf(!SECRET_KEY)("Stripe live contract", () => {
@@ -111,11 +128,16 @@ describe.skipIf(!SECRET_KEY)("Stripe live contract", () => {
 
   let customer: Stripe.Customer;
   let subscription: Stripe.Subscription;
+  let invoice: Stripe.Invoice;
   let starterPriceId: string;
   let proPriceId: string | null = null;
 
   beforeAll(async () => {
-    stripe = new Stripe(SECRET_KEY!, { apiVersion: "2026-08-26.dahlia" });
+    // The pin comes from production (src/stripe/client.ts), never from a
+    // literal restated here: a second copy in a file `tsc` drags forward on its
+    // own schedule is how a suite ends up validating an API version production
+    // stopped speaking at the previous SDK bump.
+    stripe = new Stripe(SECRET_KEY!, { apiVersion: STRIPE_API_VERSION });
 
     // Prices come from the account rather than from env: `requirements.ts`
     // force-overrides STRIPE_PRICE_ID_* for the mocked suite, so reading those
@@ -142,6 +164,21 @@ describe.skipIf(!SECRET_KEY)("Stripe live contract", () => {
       items: [{ price: starterPriceId }],
       metadata: { orgId: "00000000-0000-4000-a000-00000000c0de", planId: "starter" },
     });
+
+    // The invoice `invoice.paid` / `invoice.payment_failed` carry. Fetched
+    // rather than mocked because the field budget allocation hangs on —
+    // `parent.subscription_details.subscription` — is a post-basil RELOCATION
+    // of the removed top-level `invoice.subscription`, and a relocation is
+    // exactly what a fixture cannot notice about itself.
+    const invoiceRef = subscription.latest_invoice;
+    if (!invoiceRef) {
+      throw new Error(
+        "The subscription came back with no latest_invoice — the account cannot charge the attached card.",
+      );
+    }
+    invoice = await stripe.invoices.retrieve(
+      typeof invoiceRef === "string" ? invoiceRef : invoiceRef.id!,
+    );
   });
 
   afterAll(async () => {
@@ -180,32 +217,30 @@ describe.skipIf(!SECRET_KEY)("Stripe live contract", () => {
       });
       expect(driftedPaths(defaultPortalResponse(), session)).toEqual([]);
     });
+
+    it("invoice", () => {
+      expect(driftedPaths(fullInvoiceFixture(), invoice)).toEqual([]);
+    });
   });
 
-  // ─── 2. Shape: production's reads must land on both sides ─────
+  // ─── 2. Shape: production's reads must land on the LIVE object ─
 
-  // Every path `packages/module-ee/src` dereferences on a retrieved
-  // subscription. Asserted against the LIVE object and the MOCK alike: a path
-  // that exists in only one of them is a test suite proving nothing.
-  const SUBSCRIPTION_READS = [
-    "id",
-    "status",
-    "customer",
-    "metadata",
-    "cancel_at_period_end",
-    "items.data[0].id",
-    "items.data[0].price.id",
-    "items.data[0].current_period_end",
-  ];
+  // The mirror half — that the FIXTURES carry these same paths — is
+  // `test/unit/stripe-fixtures.test.ts`, which needs no key and therefore runs
+  // everywhere. A path resolving on only one of the two sides is a suite
+  // proving nothing, which is why the lists live in `test/helpers/stripe.ts`
+  // and neither file restates them.
 
-  describe("the fields production reads exist", () => {
+  describe("the fields production reads exist on Stripe", () => {
     for (const path of SUBSCRIPTION_READS) {
       it(`live subscription has ${path}`, () => {
-        expect(at(subscription, path)).toBeDefined();
+        expect(valueAtPath(subscription, path)).toBeDefined();
       });
+    }
 
-      it(`mock subscription has ${path}`, () => {
-        expect(at(defaultSubscriptionResponse("sub_shape"), path)).toBeDefined();
+    for (const path of INVOICE_READS) {
+      it(`live invoice has ${path}`, () => {
+        expect(valueAtPath(invoice, path)).toBeDefined();
       });
     }
   });
@@ -258,6 +293,24 @@ describe.skipIf(!SECRET_KEY)("Stripe live contract", () => {
     await expect(
       stripe.webhooks.constructEventAsync(payload, "t=1,v1=deadbeef", secret),
     ).rejects.toBeInstanceOf(Stripe.errors.StripeSignatureVerificationError);
+  });
+
+  it("every webhook endpoint renders payloads at the version the module pins", async () => {
+    // The SDK pin governs what `subscriptions.retrieve` RETURNS. It does not
+    // govern webhook payloads: those are rendered at the version configured on
+    // the endpoint. `subscriptionPeriodEnd` is applied to `event.data.object`
+    // too (src/stripe/webhooks.ts), so an endpoint left at 2025-03-31 reads a
+    // `current_period_end` that has since moved onto the item — and `periodEnd`
+    // silently stops updating on `customer.subscription.updated`.
+    //
+    // `api_version: null` means "the account default", which is not pinned to
+    // anything this repository can see, so it counts as a mismatch.
+    const endpoints = await stripe.webhookEndpoints.list({ limit: 100 });
+    const mismatched = endpoints.data
+      .filter((e) => e.status === "enabled" && e.api_version !== STRIPE_API_VERSION)
+      .map((e) => `${e.url} (${e.api_version ?? "account default"})`);
+
+    expect(mismatched).toEqual([]);
   });
 
   it("raises StripeInvalidRequestError for an unknown subscription", async () => {

--- a/packages/module-ee/test/unit/stripe-fixtures.test.ts
+++ b/packages/module-ee/test/unit/stripe-fixtures.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: LicenseRef-Appstrate-Commercial
+
+/**
+ * The key-free half of the Stripe contract check.
+ *
+ * `test/live/stripe-contract.test.ts` proves the fields the fixtures carry
+ * still exist on a real Stripe response — but it needs `STRIPE_LIVE_SECRET_KEY`
+ * and skips itself everywhere else, which is most places. This file asserts the
+ * complementary direction, which needs nothing: that every path production
+ * dereferences RESOLVES on the fixture the mocked suite serves.
+ *
+ * That direction is the one the typechecker cannot cover. `Fixture<T>` (test/
+ * helpers/stripe.ts) makes every field optional, so it catches a fixture
+ * claiming a field Stripe does not have — it cannot catch a fixture quietly
+ * MISSING one, which is precisely how `current_period_end` read `undefined` in
+ * every test for the life of the 2025-03-31 relocation.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  INVOICE_READS,
+  SUBSCRIPTION_READS,
+  defaultSubscriptionResponse,
+  fullInvoiceFixture,
+  valueAtPath,
+} from "../helpers/stripe.ts";
+
+describe("Stripe fixtures carry the fields production reads", () => {
+  for (const path of SUBSCRIPTION_READS) {
+    it(`subscription fixture has ${path}`, () => {
+      expect(valueAtPath(defaultSubscriptionResponse("sub_shape"), path)).toBeDefined();
+    });
+  }
+
+  for (const path of INVOICE_READS) {
+    it(`invoice fixture has ${path}`, () => {
+      expect(valueAtPath(fullInvoiceFixture(), path)).toBeDefined();
+    });
+  }
+});

--- a/packages/module-ee/tsconfig.json
+++ b/packages/module-ee/tsconfig.json
@@ -3,5 +3,10 @@
   // `drizzle` for the reason `packages/db` lists its own config file: nothing
   // imports `drizzle/drizzle.config.ts`, so without it the config that drives
   // `db:generate` sits in no program and can break silently.
-  "include": ["src", "drizzle"]
+  //
+  // `test` because the Stripe fixtures live there and are typed against the SDK
+  // (`Fixture<T>`, test/helpers/stripe.ts): outside the program a bump of
+  // `stripe` moves a field, `tsc` drags `src` forward, and the fixtures stay
+  // behind describing an API version production no longer speaks.
+  "include": ["src", "drizzle", "test"]
 }


### PR DESCRIPTION
Closes #1332

## Root cause

One mechanism behind all five points: **nothing could tell a fixture from a fiction.**

- `packages/module-ee/tsconfig.json` had `"include": ["src", "drizzle"]` — the module was the only workspace omitting `test`. So the API-version literal restated at `test/live/stripe-contract.test.ts:118` and every fixture in `test/helpers/stripe.ts` (all typed `Record<string, unknown>`) sat outside the typecheck program. An SDK bump drags `src/stripe/client.ts` forward via the `LatestApiVersion` literal type and leaves the test tree behind.
- Invoice had no fixture at all. `parent.subscription_details.subscription` — the post-basil replacement for the removed `invoice.subscription`, the single path `webhooks.ts:461` and `:743` hang budget allocation and dunning on — was hand-spelled at eleven call sites and disprovable at none.
- `.github/workflows/stripe-live.yml` gated the suite on `pull_request` + `secrets.STRIPE_LIVE_SECRET_KEY`. Dependabot-triggered runs read the *Dependabot* secret store, not repository secrets, so on a `stripe` bump the variable is empty, `describe.skipIf` skips all 26 tests, and the job is green. The workflow's own comment claimed the opposite.

## Fix

**One pin, in the program.** `STRIPE_API_VERSION` is exported from `src/stripe/client.ts` with `satisfies Stripe.LatestApiVersion` (a string *literal* type — the next bump is a hard `TS2322`). The live suite imports it instead of restating it.

**Typed fixtures — the half that needs no key.** `Fixture<T>` in `test/helpers/stripe.ts` is a deep-partial of the real SDK type: a fixture may omit any field production never reads, but every field it carries must exist with a compatible type. `test` joins the tsconfig, which required repairing the 9 pre-existing type errors the issue noted (`server.port`, an optional hook inside `Parameters<…>`, postgres.js `RowList` destructuring in the migration-chain tests). Negative control: renaming `current_period_end` → `current_period_endd`, or `subscription_details` → `subscription_detailsX`, both fail `tsc`.

Fixture fields are written as **direct properties**, never conditional spreads — TypeScript exempts spread properties from excess-property checking, which silently reopens the same hole. `JSON.stringify` drops the `undefined` ones, so each mocked test still sends only what it exercises.

**Invoice.** `invoiceEventObject()` is the one place the invoice payload is written; the 11 hand-built payloads in `webhooks.test.ts` and `webhook-emails.test.ts` now go through it. `fullInvoiceFixture()` (every optional field set) is drift-checked against a real invoice fetched from `subscription.latest_invoice`.

**Both halves share their read-path lists.** `SUBSCRIPTION_READS` / `INVOICE_READS` / `valueAtPath` move to the helper. The direction that needs no key — *the fixture carries every path production reads*, which the all-optional `Fixture<T>` structurally cannot catch — becomes `test/unit/stripe-fixtures.test.ts` and runs everywhere. The live suite keeps the direction only Stripe can answer.

**Webhook payload version.** New live assertion: every *enabled* webhook endpoint on the account must pin `STRIPE_API_VERSION`. The SDK pin governs what a `retrieve` returns; a webhook payload is rendered at the endpoint's configured version, and `subscriptionPeriodEnd` is applied to `event.data.object` too (`webhooks.ts:470ff`). `api_version: null` (account default) counts as a mismatch — it is pinned to nothing this repo can see.

**CI.** Added `push: branches: [main]` on the same paths: the *merge* of a Dependabot bump runs the suite with repository secrets. No second job, no new secret store. The `pull_request` trigger stays as a best-effort pre-merge signal, and the skip is now tolerated only where the secret cannot reach the run — on `push` / `schedule` / `workflow_dispatch` a missing key **fails** the job instead of skipping quietly.

### Running the live half

```sh
cd appstrate
docker compose -f test/setup/docker-compose.test.yml up -d --wait   # module-ee declares postgres: true
set -a && . ./.env && set +a
STRIPE_LIVE_SECRET_KEY=sk_test_… bun test packages/module-ee/test/live
```

The account needs two active recurring prices and a chargeable card (`pm_card_visa` is attached by the suite). A non-`sk_test_` key is refused outright. The key-free half needs none of this: `bunx tsc --noEmit -p packages/module-ee` and `bun test packages/module-ee/test/unit/stripe-fixtures.test.ts`.

## Tests

- `bunx tsc --noEmit -p packages/module-ee` → clean, now **including `test/`**.
- `bun test packages/module-ee/test` (full module, under the shared-Postgres lock) → **456 pass, 28 skip, 0 fail** (the 28 are the live suite skipping without a key).
- New `packages/module-ee/test/unit/stripe-fixtures.test.ts` → 16 pass, key-free. Negative control: dropping `attempt_count` from the invoice builder turns it red (1 fail).
- `bunx eslint` on the 8 touched TS files → clean. `bun run verify:workflows` (actionlint) → no findings. `bun run verify:license-boundary` → clean. `bunx knip --workspace packages/module-ee` → exit 0 (the one configuration hint predates this branch).

## Notes for the orchestrator

- **Base** is `fix/issue-1331`, per assignment.
- No migration, no env var, no OpenAPI change, no deploy ordering.
- **Overlap**: `test/integration/services/webhooks.test.ts` and `webhook-emails.test.ts` — 11 invoice payload literals rewritten. Sibling **#1370** may add tests to the first file; conflicts there would be textual, not semantic.
- **Expect the new webhook-endpoint assertion to be the suite's first real finding.** If the Stripe test account's endpoints are left at the account default (or an older pinned version), that test fails on the first keyed run. That is the bug it was written to surface, not a flake — the fix is to pin the endpoint's version in the Stripe dashboard.
- **Ops, optional**: adding `STRIPE_LIVE_SECRET_KEY` to the repository's *Dependabot* secret store would additionally give the pre-merge signal on Dependabot PRs. Not required — the `push` trigger covers the merge either way, which is why it was not made a hard dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
