### PR TITLE
fix(auth): let a forced refresh adopt an in-flight proactive exchange

### DIFF
--- a/apps/api/src/lib/deduped-refresh.ts
+++ b/apps/api/src/lib/deduped-refresh.ts
@@ -39,10 +39,11 @@ const REFRESH_LOCK_TTL_SECONDS = 45;
  * Derived from the TTL so the two cannot drift apart: a waiter gives up only
  * once the holder's lock has definitively expired (holder presumed dead),
  * never at the holder's worst-case exchange duration. Trade-off: a sidecar
- * caller queued behind a wedged holder waits up to ~50 s before proceeding —
- * and a forced flight chained behind a proactive one pays that twice, once per
- * hop (~50 s acquire + the 30 s exchange timeout in `@appstrate/connect`), so
- * the honest worst case is ≈160 s. Bounded, but not one lock wait.
+ * caller queued behind a wedged holder waits up to ~50 s before proceeding,
+ * plus the 30 s exchange timeout in `@appstrate/connect`. A forced caller that
+ * arrives while a proactive flight is already exchanging pays that once, not
+ * once per hop — it adopts that exchange's token rather than queueing a second
+ * one behind it (see {@link dedupedRefresh}).
  */
 const REFRESH_LOCK_ACQUIRE_TIMEOUT_MS = REFRESH_LOCK_TTL_SECONDS * 1_000 + 5_000;
 
@@ -72,8 +73,19 @@ interface DedupedRefreshOptions<T> {
   doRefresh: () => Promise<T>;
 }
 
+/**
+ * A flight's value plus WHICH branch produced it. A forced joiner may adopt an
+ * in-flight proactive result only when it came from the exchange — see
+ * {@link dedupedRefresh}.
+ */
+interface FlightOutcome<T> {
+  value: T;
+  /** `true` when {@link DedupedRefreshOptions.doRefresh} minted this value. */
+  exchanged: boolean;
+}
+
 /** Per-flight-key in-flight singleflight map (`key` / `key:force`). */
-const inflightRefreshes = new Map<string, Promise<unknown>>();
+const inflightRefreshes = new Map<string, Promise<FlightOutcome<unknown>>>();
 /** Tail of the serialization chain per credential `key`, never rejecting. */
 const refreshChains = new Map<string, Promise<unknown>>();
 
@@ -82,18 +94,43 @@ const refreshChains = new Map<string, Promise<unknown>>();
  * cross-instance Redis lock, with a post-acquire freshness short-circuit.
  *
  * `force` IS part of the flight key: a flight applies only its originator's
- * verdict, so a forced caller joining a proactive flight would be handed back
- * the very token that just 401'd it — short-circuited on freshness by that
- * flight's post-acquire re-read, with no upstream exchange at all.
+ * verdict, so a forced caller sharing a proactive flight outright would be
+ * handed back the very token that just 401'd it — short-circuited on freshness
+ * by that flight's post-acquire re-read, with no upstream exchange at all.
  *
- * The resulting forced/proactive pair is chained per `key` (`refreshChains`
- * in-process, the Redis lock across instances), so the split costs one EXTRA
- * exchange when the two overlap, never a concurrent one.
+ * A forced caller does not therefore have to *wait out* an overlapping
+ * proactive flight before starting its own. It awaits that flight and adopts
+ * its result when the flight actually exchanged: a token minted upstream is by
+ * construction not the stored one the caller 401'd on, so it is exactly what
+ * the caller asked for, one lock-wait + exchange hop earlier than queueing.
+ * When the proactive flight instead short-circuits on freshness (or fails),
+ * the forced caller falls through to a flight of its own — the chain tail has
+ * cleared by then, so it starts immediately rather than queueing.
+ *
+ * Flights that DO run concurrently are chained per `key` (`refreshChains`
+ * in-process, the Redis lock across instances): the forced/proactive split
+ * costs at most one EXTRA exchange, never a concurrent one.
  */
 export function dedupedRefresh<T>(key: string, opts: DedupedRefreshOptions<T>): Promise<T> {
-  const flightKey = opts.force === true ? `${key}:force` : key;
-  const cached = inflightRefreshes.get(flightKey) as Promise<T> | undefined;
-  if (cached) return cached;
+  const force = opts.force === true;
+  const flightKey = force ? `${key}:force` : key;
+  const cached = inflightRefreshes.get(flightKey) as Promise<FlightOutcome<T>> | undefined;
+  if (cached) return cached.then((outcome) => outcome.value);
+
+  if (force) {
+    // No forced flight to join, but a proactive one may already be exchanging
+    // for this credential. Adopt its token if it gets one; on anything else
+    // (freshness short-circuit, failure) re-enter with our own flight, which
+    // by then heads the chain. Re-entry cannot storm the upstream: the first
+    // re-entrant publishes a `key:force` flight the rest collapse into.
+    const proactive = inflightRefreshes.get(key) as Promise<FlightOutcome<T>> | undefined;
+    if (proactive) {
+      return proactive.then(
+        (outcome) => (outcome.exchanged ? outcome.value : dedupedRefresh(key, opts)),
+        () => dedupedRefresh(key, opts),
+      );
+    }
+  }
 
   const previous = refreshChains.get(key) ?? Promise.resolve();
   const promise = previous.then(() =>
@@ -104,15 +141,15 @@ export function dedupedRefresh<T>(key: string, opts: DedupedRefreshOptions<T>): 
         acquireTimeoutMs: REFRESH_LOCK_ACQUIRE_TIMEOUT_MS,
         label: opts.lockLabel,
       },
-      async () => {
+      async (): Promise<FlightOutcome<T>> => {
         // A peer instance may have refreshed while we waited for the lock. If
         // the stored token is now comfortably unexpired, return it without
         // burning the (possibly just-rotated) refresh_token — unless the caller
         // forced this refresh, in which case remaining lifetime says nothing
         // about whether the token still works.
-        const fresh = await opts.reReadFreshness({ force: opts.force === true });
-        if (fresh !== null) return fresh;
-        return opts.doRefresh();
+        const fresh = await opts.reReadFreshness({ force });
+        if (fresh !== null) return { value: fresh, exchanged: false };
+        return { value: await opts.doRefresh(), exchanged: true };
       },
     ),
   );
@@ -121,8 +158,10 @@ export function dedupedRefresh<T>(key: string, opts: DedupedRefreshOptions<T>): 
   const tail = promise.catch(() => {});
   inflightRefreshes.set(flightKey, promise);
   refreshChains.set(key, tail);
-  return promise.finally(() => {
-    inflightRefreshes.delete(flightKey);
-    if (refreshChains.get(key) === tail) refreshChains.delete(key);
-  });
+  return promise
+    .finally(() => {
+      inflightRefreshes.delete(flightKey);
+      if (refreshChains.get(key) === tail) refreshChains.delete(key);
+    })
+    .then((outcome) => outcome.value);
 }

--- a/apps/api/test/unit/deduped-refresh.test.ts
+++ b/apps/api/test/unit/deduped-refresh.test.ts
@@ -204,4 +204,119 @@ describe("dedupedRefresh", () => {
     expect(await run(true)).toBe("EXCHANGED");
     expect(exchanges).toBe(1);
   });
+
+  it("lets a forced caller adopt an in-flight proactive EXCHANGE", async () => {
+    const gate = deferred();
+    let exchanges = 0;
+
+    // PROACTIVE flight held inside its exchange: the stored token was stale,
+    // so this flight IS minting a new one.
+    const proactive = dedupedRefresh<string>("cred_adopt", {
+      lockKey: "test:cred_adopt",
+      lockLabel: "test",
+      force: false,
+      reReadFreshness: async () => null,
+      doRefresh: async () => {
+        await gate.promise;
+        exchanges += 1;
+        return "EXCHANGED";
+      },
+    });
+
+    // FORCED caller arriving while that exchange is in flight. Its token was
+    // minted upstream, so it cannot be the one that just 401'd this caller —
+    // adopting it beats paying another lock wait + exchange behind it.
+    const forced = dedupedRefresh<string>("cred_adopt", {
+      lockKey: "test:cred_adopt",
+      lockLabel: "test",
+      force: true,
+      reReadFreshness: async () => null,
+      doRefresh: async () => {
+        exchanges += 1;
+        return "SECOND-EXCHANGE";
+      },
+    });
+
+    gate.resolve();
+
+    expect(await proactive).toBe("EXCHANGED");
+    expect(await forced).toBe("EXCHANGED");
+    // The whole point: no second hop. Queueing behind the proactive flight
+    // would have cost a second lock wait + a second upstream exchange.
+    expect(exchanges).toBe(1);
+  });
+
+  it("makes a forced caller run its own refresh when the proactive flight fails", async () => {
+    const gate = deferred();
+    let exchanges = 0;
+
+    const proactive = dedupedRefresh<string>("cred_adopt_fail", {
+      lockKey: "test:cred_adopt_fail",
+      lockLabel: "test",
+      force: false,
+      reReadFreshness: async () => null,
+      doRefresh: async () => {
+        await gate.promise;
+        throw new Error("upstream 503");
+      },
+    });
+
+    const forced = dedupedRefresh<string>("cred_adopt_fail", {
+      lockKey: "test:cred_adopt_fail",
+      lockLabel: "test",
+      force: true,
+      reReadFreshness: async () => null,
+      doRefresh: async () => {
+        exchanges += 1;
+        return "EXCHANGED";
+      },
+    });
+
+    gate.resolve();
+
+    await expect(proactive).rejects.toThrow("upstream 503");
+    // A failure is not a token: the forced caller must not inherit it.
+    expect(await forced).toBe("EXCHANGED");
+    expect(exchanges).toBe(1);
+  });
+
+  it("collapses forced callers re-entering after a proactive short-circuit", async () => {
+    const gate = deferred();
+    let exchanges = 0;
+
+    const proactive = dedupedRefresh<string>("cred_reentry", {
+      lockKey: "test:cred_reentry",
+      lockLabel: "test",
+      force: false,
+      reReadFreshness: async ({ force }) => {
+        await gate.promise;
+        return force ? null : "STORED";
+      },
+      doRefresh: async () => {
+        exchanges += 1;
+        return "EXCHANGED";
+      },
+    });
+
+    const forced = () =>
+      dedupedRefresh<string>("cred_reentry", {
+        lockKey: "test:cred_reentry",
+        lockLabel: "test",
+        force: true,
+        reReadFreshness: async ({ force }) => (force ? null : "STORED"),
+        doRefresh: async () => {
+          exchanges += 1;
+          return "EXCHANGED";
+        },
+      });
+
+    const all = [forced(), forced(), forced()];
+    gate.resolve();
+
+    expect(await proactive).toBe("STORED");
+    expect(await Promise.all(all)).toEqual(["EXCHANGED", "EXCHANGED", "EXCHANGED"]);
+    // Re-entry after a non-adoptable outcome must not storm the upstream: the
+    // first re-entrant publishes the forced flight, the others collapse in.
+    expect(exchanges).toBe(1);
+  });
 });


### PR DESCRIPTION
Closes #1365

## Root cause

`apps/api/src/lib/deduped-refresh.ts:94` partitions the singleflight on `force`, so a forced (401-recovery) caller can never *share* an overlapping proactive flight — it chains behind it in `refreshChains` (`:98-99`) and then runs a full second flight of its own. Each hop costs up to `REFRESH_LOCK_ACQUIRE_TIMEOUT_MS` (~50 s, `:47`) plus the 30 s exchange timeout in `@appstrate/connect`, so the forced path paid ~160 s — admitted in-code at `:38-46`.

That path is the run inference hot path: `resolveOAuthTokenForSidecar` → `forceRefreshOAuthModelProviderToken` (`apps/api/src/services/model-providers/token-resolver.ts:129,174`), reached from the sidecar's `POST /internal/oauth-token/:credentialId/refresh` (`apps/api/src/routes/internal.ts:457`).

## Fix

The partition itself is correct and stays: a forced caller must not be handed a value the flight produced by *short-circuiting on freshness*, because that is the very token that just 401'd it. But a flight that actually **exchanged** minted a token upstream — by construction not the stored one the caller 401'd on — and that is exactly what the forced caller asked for.

So a flight now resolves to `FlightOutcome<T> = { value, exchanged }`, recording which branch answered it. A forced caller with no `key:force` flight to join awaits the in-flight proactive one and adopts its value when `exchanged` is true, saving a whole lock-wait + exchange hop. A freshness short-circuit or a failure is not adoptable and re-enters with the caller's own flight — by which time the chain tail has cleared, so it starts immediately rather than queueing. Re-entry cannot storm the upstream: the first re-entrant publishes the `key:force` flight the rest collapse into (covered by a test).

Same-kind joins, the chain, the Redis lock and every failure semantic are untouched — all six pre-existing tests pass unmodified.

Considered and rejected: the issue's other suggestion, a separate deadline for the forced path. A deadline that fires can only throw, which turns a slow recovery into a failed run; adoption removes the wasted hop instead of capping it.

## Tests

`apps/api/test/unit/deduped-refresh.test.ts` — three new cases: adoption of an in-flight proactive exchange, no inheritance of a failed proactive flight, and no upstream storm when several forced callers re-enter after a non-adoptable outcome.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/unit/deduped-refresh.test.ts
→ 9 pass, 0 fail (6 pre-existing + 3 new)
bunx tsc --noEmit -p apps/api → clean
bunx eslint / prettier --check on both touched files → clean
```

Negative control: with `apps/api/src/lib/deduped-refresh.ts` reverted to `HEAD` and the new tests in place, the adoption test fails with `Expected: "EXCHANGED" / Received: "SECOND-EXCHANGE"` — i.e. it directly observes the extra exchange this PR removes.

## Notes for the orchestrator

- No migration, no env var, no OpenAPI/route-contract change (the internal refresh endpoint's request and response are untouched), no `@appstrate/core` export change.
- **Both inference paths checked**, per the standing rule that they must behave alike: `/api/llm-proxy` refuses oauth2-subscription models outright (`apps/api/src/services/llm-proxy/core.ts:157`) and the chat path only ever calls the *proactive* `resolveOAuthTokenForSidecar` (`apps/api/src/services/chat-platform-services.ts:95`). The sidecar's `/refresh` route is the only forced caller on a hot path, and every caller — including the background `refresh-worker` and the integration-connection path (`apps/api/src/services/integration-token-refresh.ts:131`) — funnels through this one helper, so the fix covers them all uniformly.
- **Overlap with #1366 (lock renewal): none.** That issue is `apps/api/src/lib/distributed-lock.ts`; this PR touches only `deduped-refresh.ts` and does not change how `withRedisLock` is called (same TTL, same acquire timeout, same label). A renewal fix drops in underneath cleanly.
- Not addressed, deliberately (out of scope, not a regression): the mirror-image hop, where a *proactive* caller queues behind an in-flight forced flight instead of adopting its freshly minted token. Same one-extra-exchange cost, but off the 401-recovery path this issue is about.
- Pre-existing local test noise, identical before and after this change (22 pass / 28 fail on both): the `services/` integration files seed their `test-oauth` provider through a suite-wide preload, so they fail with `Unknown providerId: test-oauth` when run as a subset. Unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
