### PR TITLE
feat(db): diff live-database columns, not just indexes, against the snapshot

### DIFF
--- a/apps/api/test/unit/migration-schema-parity.test.ts
+++ b/apps/api/test/unit/migration-schema-parity.test.ts
@@ -29,8 +29,9 @@
  *
  *   - `drizzle-kit generate` compares the schema to the snapshot. Both carry
  *     the 70-byte name, so there is no drift to report.
- *   - `scripts/check-index-drift.ts` compares INDEX NAMES ONLY, against a LIVE
- *     `DATABASE_URL`. It cannot see a constraint, and it cannot run in `check`.
+ *   - `scripts/check-index-drift.ts` compares index names and column
+ *     name/nullability against a LIVE `DATABASE_URL`. It cannot see a
+ *     constraint, and it cannot run in `check`.
  *   - `migration-index-parity.test.ts` compares indexes to the snapshot.
  *   - the whole suite passes, because the FK works perfectly. Only its NAME is
  *     wrong, and nothing addresses a constraint by name until something does.

--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -35,12 +35,12 @@ bun run db:generate   # Generate migration from schema changes
 bun run db:migrate    # Apply pending migrations
 ```
 
-## Index drift
+## Schema drift
 
 `drizzle/0000_init.sql` is a squash, and any database created before it — production — never ran
-it. An index the squash introduced therefore exists in the schema and in every fresh database while
-being absent there (issue #1182 found two). Before any `DROP INDEX`, verify the surviving index
-against the **live** database; the TS schema and `0000_init.sql` are not evidence.
+it. Anything the squash introduced therefore exists in the schema and in every fresh database while
+being absent there (issue #1182 found two indexes). Before any `DROP INDEX`, verify the surviving
+index against the **live** database; the TS schema and `0000_init.sql` are not evidence.
 
 ```sh
 DATABASE_URL=postgres://… bun scripts/check-index-drift.ts
@@ -54,20 +54,38 @@ without it and you would silently check your own dev database.
 
 It reads the database's own migration watermark (`max(created_at)` in
 `drizzle.__drizzle_migrations`) and diffs against the snapshot matching it — not the newest snapshot
-on disk — so a database that has not yet run a pending release is not accused of missing every index
-that release adds. Pending migrations are named in the output. Exit 1 means either a declared index
-is absent, or the check declined to run (unmigrated database, empty tracking table, or a watermark
-matching no journal entry); each of those opens with `Cannot check`, so it can never read as a clean
-result. A connection or authentication failure surfaces the driver error instead.
+on disk — so a database that has not yet run a pending release is not accused of missing everything
+that release adds. Pending migrations are named in the output. Exit 1 means either something
+declared is absent, or the check declined to run (unmigrated database, empty tracking table, or a
+watermark matching no journal entry); each of those opens with `Cannot check`, so it can never read
+as a clean result. A connection or authentication failure surfaces the driver error instead.
 
-It compares index **names only**. An index present under the expected name with a different
+Two populations are compared, and both halves are reported before the exit code is decided — an
+operator missing an index _and_ a column sees both in one run.
+
+**Indexes** are compared by **name only**. An index present under the expected name with a different
 definition — other columns, a lost partial predicate, lost uniqueness — counts as present, and the
 success line says so. A squash can redefine an index while a pre-squash database keeps the old shape
 under the same name; catching that is out of scope here.
 
-Indexes present in the database but absent from the snapshot never fail the run. Those a constraint
-owns (`pg_constraint.conindid`) are counted as expected; the rest are listed by name as possible
-reverse drift — an index a squash may have dropped from the schema without a forward `DROP INDEX`.
+**Columns** are compared by name and by `NOT NULL`; their **types** are not compared, because the
+normalisation that would make a type comparison honest is where the false positives live. A missing
+column is louder than a missing index — a Postgres `42703` on the first statement naming it — and
+nothing else in the repo can see it on a live database (issue #1349). The Better Auth drizzle
+adapter looks like it does and does not: `findDrizzleSchemaProblems` diffs the plugin's expectations
+against the **Drizzle TS object**, never against `information_schema`, so a database missing a
+declared column boots perfectly clean. `apps/api/test/unit/migration-schema-parity.test.ts` covers
+the other link of that chain in CI by replaying the journal into a throwaway PGlite — but a replay
+structurally cannot see a database that never ran the squash.
+
+Indexes and columns present in the database but absent from the snapshot never fail the run. Indexes
+a constraint owns (`pg_constraint.conindid`) are counted as expected; the rest are listed by name as
+possible reverse drift — something a squash may have dropped from the schema without a forward
+`DROP INDEX` / `DROP COLUMN`.
+
+Nothing here runs at boot, deliberately: production is known to predate `0000_init.sql`, so a
+boot-time gate on the same comparison would refuse to start the platform over drift that has been
+live for months. The exit code is a decision a human makes.
 
 ## Dependencies
 

--- a/packages/db/src/schema/oidc.ts
+++ b/packages/db/src/schema/oidc.ts
@@ -26,6 +26,19 @@
  * with no column here raises `SchemaMismatchError` and rejects auth traffic.
  * Adding a plugin means adding its tables here in the same change.
  *
+ * READ THAT CHECK NARROWLY — it says NOTHING about any database (issue #1349).
+ * `findDrizzleSchemaProblems` diffs the plugin's expectations against THIS
+ * TYPESCRIPT OBJECT; all three findings it can emit (`missing-table`,
+ * `missing-column`, `unexpected-required-column`) are computed from TS, it
+ * never reads `information_schema`, and it does not look at indexes at all. A
+ * database missing a column declared below therefore boots perfectly clean and
+ * fails as a Postgres 42703 on the first `/oauth2/token`. The two checks that
+ * do look at a database are `apps/api/test/unit/migration-schema-parity.test.ts`
+ * (CI: replays the journal into a throwaway PGlite and diffs the catalog
+ * against this file) and `scripts/check-index-drift.ts` (operator: diffs a LIVE
+ * database against its own watermark snapshot — the only one that can see a
+ * production database that predates the `0000_init.sql` squash).
+ *
  * Raw-SQL CHECK constraints from the module's migrations are reproduced here
  * via Drizzle `check()` so regen keeps them. The `oauth_clients_level_immutable`
  * BEFORE UPDATE trigger (not expressible in Drizzle) is carried in the

--- a/scripts/check-index-drift.ts
+++ b/scripts/check-index-drift.ts
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Index drift detector — declared indexes vs. what the database actually has.
+ * Schema drift detector — the declared shape vs. what a LIVE database has.
  *
  *   DATABASE_URL=postgres://… bun scripts/check-index-drift.ts
+ *
+ * Two populations are compared, both against the same snapshot: INDEXES (by
+ * name) and COLUMNS (presence and nullability). The filename predates the
+ * column half and is kept because `0044_finish_file_rename.sql` — a shipped,
+ * immutable migration — names this path in operator guidance.
  *
  * `DATABASE_URL` is the ONLY input. It is read straight off `process.env` and
  * opened with Bun's native SQL client, so the script never loads `@appstrate/env`
@@ -23,18 +28,39 @@
  * must be verified against the LIVE database. Neither the TS schema nor
  * `0000_init.sql` is evidence that an index exists in production.
  *
- * Declared set: the `tables[*].indexes` keys of the snapshot matching the
- * DATABASE'S OWN migration watermark — NOT the newest snapshot on disk. A
- * database that has not yet run the release being deployed legitimately lacks
- * every index that release adds; diffing it against the newest snapshot would
- * report all of them as drift and invite a duplicate migration. Resolution is
+ * Declared set: the `tables[*].indexes` and `tables[*].columns` keys of the
+ * snapshot matching the DATABASE'S OWN migration watermark — NOT the newest
+ * snapshot on disk. A database that has not yet run the release being deployed
+ * legitimately lacks everything that release adds; diffing it against the newest
+ * snapshot would report all of it as drift and invite a duplicate migration.
+ * Resolution is
  * `max(created_at)` in `drizzle.__drizzle_migrations` → the journal entry whose
  * `when` equals it → that entry's snapshot.
  *
- * Actual set: every index in `public` EXCEPT those on a table a workspace module owns, read from
- * that module's own drizzle snapshot (`scripts/lib/drizzle-snapshots.ts`), never from a prefix.
+ * Actual set: every index and every column in `public` EXCEPT those on a table a workspace module
+ * owns, read from that module's own drizzle snapshot (`scripts/lib/drizzle-snapshots.ts`), never
+ * from a prefix.
  *
- * SCOPE — this compares index NAMES ONLY. An index that exists under the
+ * ═══ WHY COLUMNS ARE HERE TOO (issue #1349) ═══
+ *
+ * A MISSING COLUMN on a live database is the same squash-shaped hole as a
+ * missing index, and it is louder: the index case degrades a query plan, the
+ * column case is a Postgres 42703 on the first statement that names it. The
+ * Better Auth drizzle adapter looks like it guards this and does not — its
+ * `findDrizzleSchemaProblems` diffs the plugin's expectations against the
+ * DRIZZLE TS OBJECT, and every finding it can emit (`missing-table`,
+ * `missing-column`, `unexpected-required-column`) is computed from TypeScript.
+ * It never reads `information_schema`, so a database missing a column the
+ * schema declares boots perfectly clean and fails on the first `/oauth2/token`.
+ *
+ * `apps/api/test/unit/migration-schema-parity.test.ts` closes the other link of
+ * that chain in CI — it replays the whole journal into a throwaway PGlite and
+ * diffs the catalog against `packages/db/src/schema/`, columns included — so a
+ * migration that misses a declared column cannot reach main. What a replay
+ * structurally cannot see is a database that never ran the squash. That is
+ * PRODUCTION, and this script is the only thing pointed at it.
+ *
+ * SCOPE — indexes are compared by NAME ONLY. An index that exists under the
  * expected name with a different definition (other columns, a lost partial
  * predicate, lost uniqueness) reads as present. That is a real variant of this
  * drift class — a squash can redefine an index while a pre-squash database
@@ -42,8 +68,25 @@
  * scope: rendering snapshot entries into comparable DDL is fiddly and
  * false-positive-prone. Every message the script prints says so.
  *
- * Exit 1 iff an index is declared but absent, or the check could not run at
- * all. Undeclared indexes never fail the run.
+ * Columns are compared by name and by NULLABILITY. Their TYPE is not compared,
+ * for the same reason: `timestamp with time zone` vs. drizzle's rendering, an
+ * `int4` widened to `int8`, a domain — the normalisation needed to make that
+ * comparison honest is where the false positives live. A declared table with no
+ * column row at all is skipped, not reported: `information_schema.columns` is
+ * privilege-filtered, so its silence about a table is not evidence the table is
+ * absent. Whether the journal builds every declared TABLE is the replay test's
+ * question, and it reads a database it built itself.
+ *
+ * Exit 1 iff a declared index is absent, a declared column is absent, a column
+ * disagrees on NOT NULL, or the check could not run at all. Undeclared indexes
+ * and undeclared columns never fail the run — they are reported for an operator
+ * to act on, because pre-squash production legitimately carries some.
+ *
+ * NOTHING HERE RUNS AT BOOT, and that is deliberate: production is known to
+ * predate `0000_init.sql` (issue #1182 found two indexes missing there), so a
+ * boot-time gate on the same comparison would refuse to start the platform over
+ * drift that has been live for months. This is an operator check, run against a
+ * connection string, and its exit code is a decision a human makes.
  */
 
 import {
@@ -65,6 +108,24 @@ const META_DIR = `${REPO_ROOT}/packages/db/drizzle/meta`;
  */
 export const PUBLIC_INDEXES_QUERY =
   "SELECT indexname, tablename FROM pg_indexes WHERE schemaname = 'public'";
+
+/**
+ * Actual columns in the database, with the table each sits on.
+ *
+ * `is_nullable` is a `YES`/`NO` string in `information_schema`; it is folded to
+ * a boolean in SQL so the comparison here is against the same `notNull` the
+ * snapshot writes, with no string convention crossing the boundary. Aliased to
+ * unprefixed names so a row reads like a `pg_indexes` one.
+ *
+ * Not exported, unlike `PUBLIC_INDEXES_QUERY`: no replay test runs this one —
+ * `migration-schema-parity.test.ts` asks `information_schema` its own question,
+ * against the TS schema rather than a snapshot.
+ */
+const PUBLIC_COLUMNS_QUERY = `
+  SELECT table_name AS tablename, column_name AS columnname, (is_nullable = 'NO') AS notnull
+    FROM information_schema.columns
+   WHERE table_schema = 'public'
+`;
 
 /**
  * Does the drizzle tracking table exist at all?
@@ -116,6 +177,13 @@ const CONSTRAINT_BACKED_INDEXES_QUERY = `
 interface ActualIndex {
   indexname: string;
   tablename: string;
+}
+
+/** One row of `PUBLIC_COLUMNS_QUERY`. */
+interface ActualColumn {
+  tablename: string;
+  columnname: string;
+  notnull: boolean;
 }
 
 interface IndexDiff {
@@ -171,6 +239,79 @@ export function declaredIndexes(snapshot: DrizzleSnapshot): Set<string> {
     for (const name of Object.keys(table.indexes ?? {})) names.add(name);
   }
   return names;
+}
+
+/**
+ * Columns DECLARED by a snapshot, `table name → column name → NOT NULL`.
+ *
+ * Same public-schema filter and same tolerance for a missing key as
+ * `declaredIndexes`: a snapshot entry with no `columns` object declares none
+ * rather than throwing. `notNull` is defaulted to false — drizzle writes it on
+ * every column it emits, so the default only decides what a hand-edited
+ * snapshot means, and the lenient reading is the one that cannot invent drift.
+ */
+export function declaredColumns(snapshot: DrizzleSnapshot): Map<string, Map<string, boolean>> {
+  const tables = new Map<string, Map<string, boolean>>();
+  for (const [key, table] of Object.entries(snapshot.tables)) {
+    const schema = table.schema ?? "";
+    if (schema !== "" && schema !== "public") continue;
+    const columns = new Map<string, boolean>();
+    for (const [name, column] of Object.entries(table.columns ?? {})) {
+      columns.set(name, column.notNull ?? false);
+    }
+    tables.set(key.slice(key.indexOf(".") + 1), columns);
+  }
+  return tables;
+}
+
+/**
+ * Three-way difference between the columns a snapshot declares and the ones a
+ * database has, restricted to the tables the snapshot declares.
+ *
+ * A table the snapshot does not declare is skipped outright: it is already
+ * reported as an undeclared table, and listing every one of its columns as
+ * "undeclared" on top of that would bury the signal.
+ *
+ * `absent` is the 42703 case and the reason the column half exists.
+ * `nullability` is the quieter one: a column that IS there while the NOT NULL
+ * the schema declares is not — a pre-squash database that never ran the `SET
+ * NOT NULL`, or an `ALTER … DROP NOT NULL` applied by hand. Every write path
+ * types the column as required, so nothing fails until a row without it exists.
+ * `undeclared` is pre-squash residue, reported and never fatal.
+ */
+export function diffColumns(
+  declared: Map<string, Map<string, boolean>>,
+  actual: Map<string, Map<string, boolean>>,
+): { absent: string[]; nullability: string[]; undeclared: string[] } {
+  const absent: string[] = [];
+  const nullability: string[] = [];
+  const undeclared: string[] = [];
+  for (const [table, columns] of declared) {
+    const found = actual.get(table);
+    // A declared table with NO column row is skipped rather than reported as
+    // forty missing columns — and, deliberately, rather than reported as a
+    // missing table. `information_schema.columns` is PRIVILEGE-FILTERED: a
+    // table the connecting role cannot see returns nothing, which is
+    // indistinguishable from a table that does not exist. Absence here is
+    // therefore not evidence, and the table-level question belongs to
+    // `apps/api/test/unit/migration-schema-parity.test.ts`, which owns a
+    // database it built itself and can read `pg_tables` without that caveat.
+    if (!found) continue;
+    for (const [column, notNull] of columns) {
+      const actualNotNull = found.get(column);
+      if (actualNotNull === undefined) absent.push(`${table}.${column}`);
+      else if (actualNotNull !== notNull) {
+        nullability.push(
+          `${table}.${column}: database says ${actualNotNull ? "NOT NULL" : "nullable"}, ` +
+            `snapshot declares ${notNull ? "NOT NULL" : "nullable"}`,
+        );
+      }
+    }
+    for (const column of found.keys()) {
+      if (!columns.has(column)) undeclared.push(`${table}.${column}`);
+    }
+  }
+  return { absent: absent.sort(), nullability: nullability.sort(), undeclared: undeclared.sort() };
 }
 
 /**
@@ -231,6 +372,7 @@ export async function runCheck(input: {
   /** Null when the tracking table exists but holds no applied migration. */
   watermark: number | null;
   actual: ActualIndex[];
+  actualColumns: ActualColumn[];
   constraintBacked: Set<string>;
   /** Table name → the module package that owns it; its indexes are in no platform snapshot, so
    * subtracting by NAME leaves a platform table the schema stopped declaring in the comparison. */
@@ -290,6 +432,18 @@ export async function runCheck(input: {
   const actual = new Set(considered.map((row) => row.indexname));
   const { missing, undeclared } = diffIndexes(declared, actual);
   const { expected, reverseDrift } = classifyUndeclared(undeclared, input.constraintBacked);
+
+  // Same subtraction as the indexes above, so the two halves never disagree
+  // about which tables belong to this journal.
+  const declaredColumnsByTable = declaredColumns(snapshot);
+  const actualColumnsByTable = new Map<string, Map<string, boolean>>();
+  for (const row of input.actualColumns) {
+    if (!tables.has(row.tablename) && input.moduleTables.has(row.tablename)) continue;
+    let columns = actualColumnsByTable.get(row.tablename);
+    if (!columns) actualColumnsByTable.set(row.tablename, (columns = new Map()));
+    columns.set(row.columnname, row.notnull);
+  }
+  const columnDiff = diffColumns(declaredColumnsByTable, actualColumnsByTable);
   const undeclaredTables = [
     ...new Set(considered.filter((row) => !tables.has(row.tablename)).map((r) => r.tablename)),
   ].sort();
@@ -320,30 +474,77 @@ export async function runCheck(input: {
     lines.push("An index the schema no longer declares and no constraint owns — a squash may have");
     lines.push("dropped it without a forward DROP INDEX. Verify before removing it.");
   }
+  if (columnDiff.undeclared.length > 0) {
+    lines.push(
+      `Columns on a declared table that ${at.snapshotName} does not declare: ` +
+        `${columnDiff.undeclared.length}`,
+    );
+    for (const name of columnDiff.undeclared) lines.push(`  undeclared column  ${name}`);
+    lines.push("A column the schema no longer declares — a squash may have dropped it without a");
+    lines.push("forward DROP COLUMN. Verify before removing it.");
+  }
   if (
     skipped.length > 0 ||
     undeclaredTables.length > 0 ||
     expected.length > 0 ||
-    reverseDrift.length > 0
+    reverseDrift.length > 0 ||
+    columnDiff.undeclared.length > 0
   )
     lines.push("");
 
+  // Both halves are reported before the exit code is decided: an operator who
+  // is missing an index AND a column must see both in one run, not discover the
+  // second only after fixing the first.
+  const declaredColumnCount = [...declaredColumnsByTable.values()].reduce(
+    (total, columns) => total + columns.size,
+    0,
+  );
+
   if (missing.length > 0) {
-    lines.push(`Declared in ${at.snapshotName} but ABSENT from the database: ${missing.length}`);
-    for (const name of missing) lines.push(`  missing  ${name}`);
+    lines.push(
+      `Indexes declared in ${at.snapshotName} but ABSENT from the database: ${missing.length}`,
+    );
+    for (const name of missing) lines.push(`  missing index   ${name}`);
     lines.push("");
-    lines.push("These are declared by a migration the database has already applied, so the squash");
-    lines.push("never reached it. Add a forward migration creating them.");
-    return { exitCode: 1, lines };
+  } else {
+    lines.push(
+      `No missing index: all ${declared.size} indexes declared by ${at.snapshotName} are present ` +
+        `among the ${actual.size} the database carries outside the module-owned tables.`,
+    );
+    lines.push(
+      "Names only — index DEFINITIONS (columns, uniqueness, partial predicates) are not compared.",
+    );
   }
 
-  lines.push(
-    `No missing index: all ${declared.size} indexes declared by ${at.snapshotName} are present ` +
-      `among the ${actual.size} the database carries outside the module-owned tables.`,
-  );
-  lines.push(
-    "Names only — index DEFINITIONS (columns, uniqueness, partial predicates) are not compared.",
-  );
+  if (columnDiff.absent.length > 0) {
+    lines.push(
+      `Columns declared in ${at.snapshotName} but ABSENT from the database: ` +
+        `${columnDiff.absent.length}`,
+    );
+    for (const name of columnDiff.absent) lines.push(`  missing column  ${name}`);
+    lines.push("");
+  }
+  if (columnDiff.nullability.length > 0) {
+    lines.push(
+      `Columns whose NOT NULL disagrees with ${at.snapshotName}: ` +
+        `${columnDiff.nullability.length}`,
+    );
+    for (const name of columnDiff.nullability) lines.push(`  nullability     ${name}`);
+    lines.push("");
+  }
+  if (columnDiff.absent.length === 0 && columnDiff.nullability.length === 0) {
+    lines.push(
+      `No missing column: all ${declaredColumnCount} columns declared by ${at.snapshotName} are ` +
+        `present, with the declared nullability.`,
+    );
+    lines.push("Names and NOT NULL only — column TYPES are not compared.");
+  }
+
+  if (missing.length > 0 || columnDiff.absent.length > 0 || columnDiff.nullability.length > 0) {
+    lines.push("Each of these is declared by a migration the database has already applied, so the");
+    lines.push("squash never reached it. Add a forward migration bringing the database up.");
+    return { exitCode: 1, lines };
+  }
   return { exitCode: 0, lines };
 }
 
@@ -368,6 +569,7 @@ async function main(): Promise<number> {
   let trackingTableExists: boolean;
   let watermark: number | null = null;
   const actual: ActualIndex[] = [];
+  const actualColumns: ActualColumn[] = [];
   const constraintBacked = new Set<string>();
   try {
     // `.unsafe` rather than tagged templates so each query stays a named
@@ -387,6 +589,9 @@ async function main(): Promise<number> {
     for (const row of await sql.unsafe<ActualIndex[]>(PUBLIC_INDEXES_QUERY)) {
       actual.push(row);
     }
+    for (const row of await sql.unsafe<ActualColumn[]>(PUBLIC_COLUMNS_QUERY)) {
+      actualColumns.push(row);
+    }
     for (const row of await sql.unsafe<{ indexname: string }[]>(CONSTRAINT_BACKED_INDEXES_QUERY)) {
       constraintBacked.add(row.indexname);
     }
@@ -405,6 +610,7 @@ async function main(): Promise<number> {
     trackingTableExists,
     watermark,
     actual,
+    actualColumns,
     constraintBacked,
     moduleTables,
     loadSnapshot: (snapshotName) => Bun.file(`${META_DIR}/${snapshotName}`).json(),

--- a/scripts/lib/drizzle-snapshots.ts
+++ b/scripts/lib/drizzle-snapshots.ts
@@ -12,7 +12,15 @@ export interface DrizzleJournal {
 
 /** The subset of `meta/NNNN_snapshot.json` these gates read. */
 export interface DrizzleSnapshot {
-  tables: Record<string, { schema?: string; indexes?: Record<string, unknown> }>;
+  tables: Record<
+    string,
+    {
+      schema?: string;
+      indexes?: Record<string, unknown>;
+      /** Keyed by SQL column name; drizzle writes `notNull` on every entry. */
+      columns?: Record<string, { notNull?: boolean }>;
+    }
+  >;
 }
 
 /** Zero-padded to the 4 digits drizzle-kit uses: `40` → `0040_snapshot.json`. */

--- a/scripts/test/check-index-drift.test.ts
+++ b/scripts/test/check-index-drift.test.ts
@@ -12,7 +12,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { declaredIndexes, runCheck } from "../check-index-drift.ts";
+import { declaredColumns, declaredIndexes, diffColumns, runCheck } from "../check-index-drift.ts";
 import {
   declaredTables,
   latestSnapshotName,
@@ -42,6 +42,33 @@ const snapshot = (tables: Record<string, string[] | null>): DrizzleSnapshot => (
 });
 
 /**
+ * Overlay column declarations onto a snapshot's tables: `table → column → NOT NULL`.
+ *
+ * Kept separate from `snapshot()` so every index case above stays exactly as it
+ * was written — a table with no entry here declares no column, which is what a
+ * snapshot with no `columns` key means.
+ */
+const withColumns = (
+  snap: DrizzleSnapshot,
+  columns: Record<string, Record<string, boolean>>,
+): DrizzleSnapshot => ({
+  tables: Object.fromEntries(
+    Object.entries(snap.tables).map(([key, entry]) => [
+      key,
+      {
+        ...entry,
+        columns: Object.fromEntries(
+          Object.entries(columns[key.slice(key.indexOf(".") + 1)] ?? {}).map(([name, notNull]) => [
+            name,
+            { name, type: "text", primaryKey: false, notNull },
+          ]),
+        ),
+      },
+    ]),
+  ),
+});
+
+/**
  * `when` is what drizzle stores verbatim in `drizzle.__drizzle_migrations.created_at`,
  * so the watermark cases below pass `whenOf(idx)`, never `idx`.
  */
@@ -65,6 +92,8 @@ const check = (over: {
   trackingTableExists?: boolean;
   watermark?: number | null;
   actual?: [string, string][];
+  /** `[table, column, NOT NULL]`, mirroring `PUBLIC_COLUMNS_QUERY`'s rows. */
+  actualColumns?: [string, string, boolean][];
   constraintBacked?: string[];
   moduleTables?: Record<string, string>;
   snapshots?: Record<string, DrizzleSnapshot>;
@@ -74,6 +103,11 @@ const check = (over: {
     trackingTableExists: over.trackingTableExists ?? true,
     watermark: over.watermark === undefined ? whenOf(1) : over.watermark,
     actual: (over.actual ?? []).map(([indexname, tablename]) => ({ indexname, tablename })),
+    actualColumns: (over.actualColumns ?? []).map(([tablename, columnname, notnull]) => ({
+      tablename,
+      columnname,
+      notnull,
+    })),
     constraintBacked: new Set(over.constraintBacked ?? []),
     moduleTables: new Map(Object.entries(over.moduleTables ?? {})),
     loadSnapshot: async (name) => {
@@ -100,8 +134,8 @@ describe("runCheck — drift", () => {
     });
 
     expect(exitCode).toBe(1);
-    expect(lines.join("\n")).toContain("  missing  idx_runs_package_started");
-    expect(lines.join("\n")).toContain("  missing  idx_runs_schedule_id");
+    expect(lines.join("\n")).toContain("  missing index   idx_runs_package_started");
+    expect(lines.join("\n")).toContain("  missing index   idx_runs_schedule_id");
   });
 
   it("exits 0 and says definitions are not compared when nothing is missing", async () => {
@@ -113,7 +147,96 @@ describe("runCheck — drift", () => {
     expect(exitCode).toBe(0);
     expect(lines.join("\n")).toContain("No missing index");
     expect(lines.join("\n")).toContain("DEFINITIONS");
-    expect(lines.join("\n")).not.toContain("missing  ");
+    expect(lines.join("\n")).not.toContain("missing index  ");
+  });
+});
+
+describe("runCheck — column drift (#1349)", () => {
+  it("exits 1 and names a declared column the database lacks", async () => {
+    // The 42703 the Better Auth adapter check cannot see: it diffs the plugin's
+    // expectations against the TS object, never against a database.
+    const { exitCode, lines } = await check({
+      snapshots: {
+        "0001_snapshot.json": withColumns(snapshot({ oauth_clients: [] }), {
+          oauth_clients: { id: true, is_first_party: true },
+        }),
+      },
+      actualColumns: [["oauth_clients", "id", true]],
+    });
+
+    expect(exitCode).toBe(1);
+    expect(lines.join("\n")).toContain("  missing column  oauth_clients.is_first_party");
+    expect(lines.join("\n")).not.toContain("missing column  oauth_clients.id");
+  });
+
+  it("exits 1 when a column exists but disagrees on NOT NULL", async () => {
+    const { exitCode, lines } = await check({
+      snapshots: {
+        "0001_snapshot.json": withColumns(snapshot({ oauth_clients: [] }), {
+          oauth_clients: { id: true, name: true },
+        }),
+      },
+      actualColumns: [
+        ["oauth_clients", "id", true],
+        ["oauth_clients", "name", false],
+      ],
+    });
+
+    expect(exitCode).toBe(1);
+    expect(lines.join("\n")).toContain(
+      "nullability     oauth_clients.name: database says nullable, snapshot declares NOT NULL",
+    );
+  });
+
+  it("reports a missing index AND a missing column in the same run", async () => {
+    // Fixing one and re-running to discover the other is a second deploy window.
+    const { exitCode, lines } = await check({
+      snapshots: {
+        "0001_snapshot.json": withColumns(snapshot({ runs: ["idx_runs_schedule_id"] }), {
+          runs: { id: true, schedule_id: false },
+        }),
+      },
+      actual: [],
+      actualColumns: [["runs", "id", true]],
+    });
+
+    expect(exitCode).toBe(1);
+    expect(lines.join("\n")).toContain("  missing index   idx_runs_schedule_id");
+    expect(lines.join("\n")).toContain("  missing column  runs.schedule_id");
+  });
+
+  it("names an undeclared column without failing the run", async () => {
+    // Pre-squash residue: a column the schema stopped declaring with no forward
+    // DROP COLUMN. An operator decides; the check does not.
+    const { exitCode, lines } = await check({
+      snapshots: {
+        "0001_snapshot.json": withColumns(snapshot({ runs: [] }), { runs: { id: true } }),
+      },
+      actualColumns: [
+        ["runs", "id", true],
+        ["runs", "legacy_flow_id", false],
+      ],
+    });
+
+    expect(exitCode).toBe(0);
+    expect(lines.join("\n")).toContain("  undeclared column  runs.legacy_flow_id");
+    expect(lines.join("\n")).toContain("No missing column");
+  });
+
+  it("ignores columns on a table a MODULE owns", async () => {
+    const { exitCode, lines } = await check({
+      snapshots: {
+        "0001_snapshot.json": withColumns(snapshot({ runs: [] }), { runs: { id: true } }),
+      },
+      actualColumns: [
+        ["runs", "id", true],
+        ["ee_usage_records", "credits", true],
+      ],
+      moduleTables: { ee_usage_records: "packages/module-ee" },
+    });
+
+    expect(exitCode).toBe(0);
+    expect(lines.join("\n")).not.toContain("ee_usage_records");
   });
 });
 
@@ -264,6 +387,38 @@ describe("declaredIndexes", () => {
       },
     });
     expect([...declared]).toEqual(["idx_runs_schedule_id"]);
+  });
+});
+
+describe("declaredColumns", () => {
+  it("keys by table without the schema prefix and tolerates a table with no `columns`", () => {
+    const declared = declaredColumns(
+      withColumns(snapshot({ runs: [], account: null }), { runs: { id: true, note: false } }),
+    );
+    expect([...declared.get("runs")!]).toEqual([
+      ["id", true],
+      ["note", false],
+    ]);
+    expect([...declared.get("account")!]).toEqual([]);
+  });
+
+  it("ignores tables outside the public schema, which the column query never returns", () => {
+    const declared = declaredColumns({
+      tables: {
+        "public.runs": { schema: "", columns: { id: { notNull: true } } },
+        "audit.events": { schema: "audit", columns: { id: { notNull: true } } },
+      },
+    });
+    expect([...declared.keys()]).toEqual(["runs"]);
+  });
+});
+
+describe("diffColumns", () => {
+  it("skips a declared table the database does not have at all", () => {
+    // The index half already names it once; forty "missing column" lines under
+    // it would bury that.
+    const diff = diffColumns(new Map([["runs", new Map([["id", true]])]]), new Map());
+    expect(diff).toEqual({ absent: [], nullability: [], undeclared: [] });
   });
 });
 


### PR DESCRIPTION
Closes #1349

## Root cause

The issue's mechanism is accurate about upstream: `findDrizzleSchemaProblems`
(`@better-auth/drizzle-adapter`) diffs `getExpectedSchema(options)` against
`introspectDrizzleSchema(schema)`, and all three findings `diffSchema` can emit
(`missing-table`, `missing-column`, `unexpected-required-column`) are computed
from the Drizzle **TypeScript object**. It never reads `information_schema`, and
it does not look at indexes at all.

Its conclusion needed narrowing, though. `apps/api/test/unit/migration-schema-parity.test.ts`
— which predates the audit base — already closes the other link of the chain in
CI: it replays the whole journal into a throwaway PGlite and diffs `pg_catalog`
against `packages/db/src/schema/` (columns, nullability, constraints, FK
actions, indexes, enums), and `schema/oidc.ts` is in the barrel, so the Better
Auth tables are covered. A migration that misses a declared column therefore
**cannot reach main** today.

What no check in the repo could see is the case the issue's own "why it matters"
paragraph names: a **live** database that never ran `0000_init.sql`. A replay
structurally cannot model it. `scripts/check-index-drift.ts` is the only tool
pointed at production, and its documented scope was index **names only**
(`scripts/check-index-drift.ts:39` on the base) — so a missing *column* on
production, the exact 42703 the issue describes, was invisible everywhere.

## Fix

`scripts/check-index-drift.ts` now diffs columns as well as indexes, against the
same watermark snapshot, reusing every piece of plumbing already there (watermark
resolution, module-owned-table subtraction, the pure `runCheck` seam, the
`Cannot check` refusals):

- **absent column** → exit 1, named. **NOT NULL disagreement** → exit 1, named.
- **undeclared column** → reported, never fatal (pre-squash residue), matching
  how undeclared indexes are already treated.
- Both halves are reported **before** the exit code is decided, so an operator
  missing an index *and* a column sees both in one run rather than discovering
  the second after a second deploy window.
- Column **types** are not compared, and a declared table with no column row is
  skipped rather than reported as missing — `information_schema.columns` is
  privilege-filtered, so its silence about a table is not evidence. Both
  carve-outs are stated in the header and in the printed output.

**Design decision — this is deliberately NOT a boot gate**, which is the half of
the issue's "Proposed fix" I did not take. Production is known to predate the
squash (#1182 found two indexes missing there), so gating boot on this
comparison would refuse to start the platform over drift that has been live for
months. It stays an operator check run against a connection string, whose exit
code is a decision a human makes. The reasoning is written into the script header
and `packages/db/README.md` so it is not re-litigated by guesswork.

The filename is unchanged even though the script is now broader than "index
drift": `packages/db/drizzle/0044_finish_file_rename.sql` names this path in
operator guidance, and a shipped migration is immutable. The header says so.

Also fixed: the comment at `packages/db/src/schema/oidc.ts:24-27` that the issue
correctly calls "easy to misread as covering the database" now states plainly
what the adapter check does and does not do, and points at the two checks that
actually read a database.

## Tests

`scripts/test/check-index-drift.test.ts` — 5 new `runCheck` cases (missing
column; NOT NULL disagreement; index **and** column reported in one run;
undeclared column non-fatal; module-owned table ignored) plus unit cases for
`declaredColumns` and `diffColumns`.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test scripts/test/check-index-drift.test.ts
  → 24 pass, 0 fail, 53 expect()   (19 before)

set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/unit/migration-schema-parity.test.ts
  → 8 pass, 0 fail
set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/unit/migration-index-parity.test.ts
  → 4 pass, 0 fail

bunx tsc --noEmit -p scripts/tsconfig.json   → clean
bunx tsc --noEmit -p packages/db             → clean
bunx tsc --noEmit -p apps/api                → clean
bunx eslint <touched files>                  → clean
bun run verify:dead-code                     → exit 0
bun run verify:no-migration-dml              → green (69 files, 2 trees)
```

## Notes for the orchestrator

- **No migration, no env var, no OpenAPI change.** Nothing in `bun run check`
  changes behaviour; `verify:dead-code` and `verify:no-migration-dml` were run
  because the diff adds exports and touches `packages/db`.
- **Pre-existing flake, not mine.** Running
  `scripts/test/check-index-drift.test.ts` + both parity tests in **one** bun
  process fails one of them with `a beforeEach/afterEach hook timed out`
  (5 s hook cap, two PGlite journal replays contending). I verified this on a
  control worktree at the unmodified base `origin/fix/issue-1348`: it fails there
  too, on a *different* file of the three. Each file passes alone on both
  branches.
- **Deploy ordering:** none. This is an operator script; nothing runs it
  automatically. Running it against production after the next deploy is likely to
  print real findings — that is the point, and the exit code is advisory to a
  human, not to a pipeline.
- **Overlap:** none with the chain so far. #1347/#1348 touched the better-auth
  façade, the OAuth FK indexes and `packages/db/src/schema/oidc.ts`'s table
  declarations; this PR only appends to that file's header comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
