### PR TITLE
fix(runs): apply run visibility to PATCH /runs/:runId/sink/extend

### DIFF
--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -1766,7 +1766,7 @@ const canonicalRunsPaths = {
       tags: ["Runs"],
       summary: "Extend the sink expiry for a long-running remote run",
       description:
-        "Pushes `sink_expires_at` out to `now() + ttl_seconds`, clamped to `REMOTE_RUN_SINK_MAX_TTL_SECONDS`. Only open sinks (not closed, not already expired) owned by the caller's org can be extended; mismatches return 404 to avoid cross-tenant leaks.",
+        "Pushes `sink_expires_at` out to `now() + ttl_seconds`, clamped to `REMOTE_RUN_SINK_MAX_TTL_SECONDS`, and bumps `last_heartbeat_at` (the column the stall watchdog reads). Extendable sinks are the open ones (not closed, not already expired) on a run in the caller's org and space that the caller may READ: `runs:read` is the runs they launched, `runs:read-all` the whole space. Anything else returns 404 rather than confirming the run exists.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { name: "runId", in: "path", required: true, schema: { type: "string" } },

--- a/apps/api/src/routes/runs-remote.ts
+++ b/apps/api/src/routes/runs-remote.ts
@@ -33,6 +33,7 @@ import { requirePermission } from "../middleware/require-permission.ts";
 import { invalidRequest, notFound, forbidden, ApiError } from "../lib/errors.ts";
 import { readJsonBody } from "@appstrate/core/request-body";
 import { getActor } from "../lib/actor.ts";
+import { runVisibilityFilter } from "../lib/run-visibility.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
 import { getPlatformRunLimits } from "../services/run-limits.ts";
 import { assertPackageDependenciesAccessible } from "../lib/package-access.ts";
@@ -405,8 +406,8 @@ export function createRunsRemoteRouter() {
 
   // PATCH /api/runs/:runId/sink/extend — push out sink_expires_at for a
   // long-running remote run. Same auth as creation: agents:run. Runs are
-  // space-scoped but this route resolves the run by id (not space path) so the
-  // handler checks ownership explicitly.
+  // space-scoped but this route resolves the run by id (not space path), so
+  // tenancy AND run visibility are both predicates on the UPDATE below.
   router.patch(
     "/runs/:runId/sink/extend",
     rateLimit(30),
@@ -421,11 +422,15 @@ export function createRunsRemoteRouter() {
       const ttl = Math.min(body.ttl_seconds, env.REMOTE_RUN_SINK_MAX_TTL_SECONDS);
       const newExpiresAt = new Date(Date.now() + ttl * 1000);
 
-      // Update only open sinks (not closed, not already expired) owned by
-      // the caller's org AND space. Filtering on `spaceId` too
-      // stops a space-A principal from extending a space-B run's sink within
-      // the same org. Mismatched ownership or closed sink → 404, which
-      // avoids leaking whether a run exists across tenancies.
+      // Update only open sinks (not closed, not already expired) inside the
+      // caller's org AND space, and only among the runs the caller may READ.
+      // Tenancy is not visibility: `agents:run` gates the action, the
+      // `runVisibilityFilter` predicate gates WHICH rows, exactly as
+      // `runs:cancel` + `assertRunVisible` do on POST /runs/:id/cancel. Without
+      // it a member who cannot even see a colleague's run could push out its
+      // sink expiry and bump `last_heartbeat_at`, defeating the stall watchdog,
+      // and read the 200-vs-404 as a liveness oracle over the whole space.
+      // A row outside any of these → 404, so nothing leaks about its existence.
       const orgId = c.get("orgId");
       // Bumping `last_heartbeat_at` alongside `sink_expires_at` turns
       // /sink/extend into the canonical keep-alive: runners that are
@@ -441,6 +446,7 @@ export function createRunsRemoteRouter() {
             eq(runs.id, runId),
             eq(runs.orgId, orgId),
             eq(runs.spaceId, c.get("spaceId")),
+            runVisibilityFilter(c),
             sql`sink_closed_at IS NULL`,
             sql`sink_expires_at IS NOT NULL`,
           ),

--- a/apps/api/test/integration/routes/runs-read-isolation.test.ts
+++ b/apps/api/test/integration/routes/runs-read-isolation.test.ts
@@ -22,7 +22,8 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { db } from "../../helpers/db.ts";
-import { files } from "@appstrate/db/schema";
+import { eq } from "drizzle-orm";
+import { files, runs } from "@appstrate/db/schema";
 import {
   authHeaders,
   createTestContext,
@@ -277,6 +278,68 @@ describe("run read isolation between members", () => {
         `${label}: ${JSON.stringify({ detail: 404, logs: 404, cancel: 404 })}`,
       );
     }
+  });
+
+  it("404s a sink extension on a colleague's run, leaving its expiry and heartbeat alone", async () => {
+    // `/sink/extend` is a run MUTATION reached by run id, not by space path:
+    // org + space tenancy is not visibility. Extending a run the caller may not
+    // read would push out `sink_expires_at` AND bump `last_heartbeat_at`, which
+    // is what `services/run-watchdog.ts` reads to finalise a stalled run — so
+    // the 404 has to be a refusal to WRITE, not merely a hidden 200. The
+    // fixture's five rows carry no sink, so the two rows below are the only
+    // ones this route can touch at all.
+    const withOpenSink = async (userId: string) =>
+      (
+        await seedRun({
+          packageId: AGENT_ID,
+          orgId: owner.orgId,
+          spaceId: owner.defaultSpaceId,
+          userId,
+          status: "running",
+          // `runs_open_sink_has_secret` — an open sink must carry the secret
+          // its ingestion verifies against, so the fixture writes one; this
+          // route never reads it.
+          sinkSecretEncrypted: "encrypted-sink-secret",
+          sinkExpiresAt: T0,
+          lastHeartbeatAt: T0,
+        })
+      ).id;
+    const sinkOfA = await withOpenSink(operatorA.user.id);
+    const sinkOfB = await withOpenSink(operatorB.user.id);
+
+    const extend = (ctx: TestContext, runId: string) =>
+      app.request(`/api/runs/${runId}/sink/extend`, {
+        method: "PATCH",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ ttl_seconds: 3600 }),
+      });
+    const sinkRow = async (runId: string) => {
+      const [row] = await db
+        .select({ expiresAt: runs.sinkExpiresAt, heartbeatAt: runs.lastHeartbeatAt })
+        .from(runs)
+        .where(eq(runs.id, runId))
+        .limit(1);
+      return { expiresAt: row!.expiresAt?.getTime(), heartbeatAt: row!.heartbeatAt.getTime() };
+    };
+
+    expect((await extend(operatorA, sinkOfB)).status).toBe(404);
+    // Untouched: both columns still hold the seeded T0, so the refusal happened
+    // in the WHERE and not after the write.
+    expect(await sinkRow(sinkOfB)).toEqual({
+      expiresAt: T0.getTime(),
+      heartbeatAt: T0.getTime(),
+    });
+
+    // The control: the very same call on A's own run succeeds and does move
+    // both columns — the 404 above is about the run, not about the route.
+    expect((await extend(operatorA, sinkOfA)).status).toBe(200);
+    const moved = await sinkRow(sinkOfA);
+    expect(moved.expiresAt).toBeGreaterThan(T0.getTime());
+    expect(moved.heartbeatAt).toBeGreaterThan(T0.getTime());
+
+    // `runs:read-all` is the space, here as everywhere: an admin supervising
+    // the space extends a member's sink, the same rows they may already cancel.
+    expect((await extend(owner, sinkOfB)).status).toBe(200);
   });
 
   it("404s ?wait on a colleague's run without waiting for it", async () => {

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -4077,7 +4077,7 @@ export interface paths {
         head?: never;
         /**
          * Extend the sink expiry for a long-running remote run
-         * @description Pushes `sink_expires_at` out to `now() + ttl_seconds`, clamped to `REMOTE_RUN_SINK_MAX_TTL_SECONDS`. Only open sinks (not closed, not already expired) owned by the caller's org can be extended; mismatches return 404 to avoid cross-tenant leaks.
+         * @description Pushes `sink_expires_at` out to `now() + ttl_seconds`, clamped to `REMOTE_RUN_SINK_MAX_TTL_SECONDS`, and bumps `last_heartbeat_at` (the column the stall watchdog reads). Extendable sinks are the open ones (not closed, not already expired) on a run in the caller's org and space that the caller may READ: `runs:read` is the runs they launched, `runs:read-all` the whole space. Anything else returns 404 rather than confirming the run exists.
          */
         patch: operations["extendRunSink"];
         trace?: never;


### PR DESCRIPTION
Closes #1335

## Root cause

`apps/api/src/routes/runs-remote.ts:441-454` — the sink-extension UPDATE narrowed on `runs.id`, `runs.orgId` and `runs.spaceId` and nothing else. Tenancy is not visibility: since the `runs:read` / `runs:read-all` split (#1307), a member holding `agents:run` could extend the sink of a run they cannot even `GET` (404 on the detail, 200 here). The write pushes out `sink_expires_at` **and** bumps `last_heartbeat_at`, the column `services/run-watchdog.ts` reads, so it stops a stalled colleague's run from being finalised; the 200-vs-404 answer is also a liveness oracle over every run in the space. The route's own comment claimed "the handler checks ownership explicitly" — it checked tenancy.

## Fix

One predicate added to the existing UPDATE: `runVisibilityFilter(c)` from `apps/api/src/lib/run-visibility.ts`, the module that exists so ownership is never re-derived per route. `agents:run` still gates the ACTION; the caller's run-read predicate gates WHICH rows — the shape `runs:cancel` + `assertRunVisible` already use on `POST /runs/:id/cancel`. A row outside the predicate falls into the `updated.length === 0` branch that was already there, so it answers the same 404 a closed sink does and nothing leaks about its existence. `runs:read-all` keeps the whole space, matching every other run surface (and strictly less destructive than the cancel those principals already hold).

No refactor: the fix is one line plus the comments it corrects. **I deliberately did NOT make the optional `visibility` parameter required on the five `services/state/runs.ts` functions** (offered as in-scope by the orchestrator): this route calls none of them, so it would not have prevented this bug, and `listRunsForSchedule` — one of the five — is #1336's territory. Better done once, there.

Also updated the OpenAPI `description` for `extendRunSink`, which documented the old "owned by the caller's org" rule and did not mention the heartbeat bump; `apps/web/src/api/schema.d.ts` regenerated accordingly.

## Tests

`apps/api/test/integration/routes/runs-read-isolation.test.ts` — one case added to the #1307 isolation suite (`404s a sink extension on a colleague's run, leaving its expiry and heartbeat alone`). It asserts the refusal is a refusal to **write**: after the 404, `sink_expires_at` and `last_heartbeat_at` still hold their seeded values; the control is the same call on the caller's own run (200, both columns moved); and an admin holding `runs:read-all` extends a member's sink. The fixture seeds `sink_secret_encrypted` because the `runs_open_sink_has_secret` CHECK requires it on any open sink.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/integration/routes/runs-read-isolation.test.ts
  → 21 pass / 0 fail (93 expect() calls)
set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/integration/routes/runs-remote-registry.test.ts apps/api/test/integration/routes/runs-events-ingestion.test.ts
  → 96 pass / 0 fail (369 expect() calls)
bunx tsc --noEmit -p apps/api   → clean
bunx tsc --noEmit -p apps/web   → clean
bun run verify:openapi          → ALL CHECKS PASSED
bun run verify:api-types        → up to date
bun run detect:breaking         → 0 breaking, 0 non-breaking (description-only change)
bunx eslint / prettier on the touched files → clean
```

Negative control: with the single `runVisibilityFilter(c)` line removed, the new case fails with `Expected: 404 / Received: 200` and the other 20 stay green.

## Notes for the orchestrator

- No migration, no env var, no deploy ordering.
- **Behaviour change, intended:** a principal without `runs:read-all` can no longer extend the sink of a run they did not launch. No first-party client is affected — the CLI/runtime keep-alive is `POST /events/heartbeat`, and a runner authenticates as the principal that created its own run.
- Sibling overlap: **none in code.** #1336 (`GET /api/schedules/:id/runs`) and #1339 (`run_and_wait`) touch different routes; #1341 is a different guard. The only shared file is `apps/api/test/integration/routes/runs-read-isolation.test.ts` if a sibling also extends that suite — my case is inserted before `404s ?wait on a colleague's run`, so a conflict there would be a trivial adjacent-hunk one.
- `apps/api/src/openapi/paths/runs.ts` + `apps/web/src/api/schema.d.ts` are touched (one description string each). If a sibling also regenerates `schema.d.ts`, take both spec edits and re-run `bun run generate:api` rather than merging the generated file by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
