### PR TITLE
fix(web): commit a previewed persona together with its permissions

### DIFF
--- a/apps/web/src/components/view-as-dialog.tsx
+++ b/apps/web/src/components/view-as-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { VIEW_AS_ORG_ROLES, type ViewAsOrgRole } from "@appstrate/core/permissions";
 import { Button } from "@appstrate/ui/components/button";
 import { Field, FieldGroup } from "@appstrate/ui/components/field";
@@ -16,7 +17,7 @@ import {
 import { Modal } from "./modal";
 import { OrgRoleOptions } from "./org-role-options";
 import { RoleCatalogState } from "./role-catalog-state";
-import { useCurrentOrgId } from "../hooks/use-org";
+import { fetchOrgsAs, useCurrentOrgId } from "../hooks/use-org";
 import { useCurrentSpaceId, useSpaceSwitcher } from "../hooks/use-current-space";
 import { useSpaces } from "../hooks/use-spaces";
 import { useSpaceRoleOptions } from "../hooks/use-roles";
@@ -56,6 +57,7 @@ export function ViewAsDialog({ onClose, spaceId }: ViewAsDialogProps) {
   const [orgRole, setOrgRole] = useState<ViewAsOrgRole>("member");
   const [selectedSpaceId, setSelectedSpaceId] = useState(initialSpaceId);
   const [roleValue, setRoleValue] = useState("");
+  const [entering, setEntering] = useState(false);
 
   const inSpace = selectedSpaceId !== NO_SPACE;
   const {
@@ -73,11 +75,23 @@ export function ViewAsDialog({ onClose, spaceId }: ViewAsDialogProps) {
   const catalogUsable = rolesKnown && !rolesError && options.length > 0;
   const ready = !!orgId && (!inSpace || (!!roleOption && !!space));
 
-  const submit = () => {
-    if (!orgId || !ready) return;
+  const submit = async () => {
+    if (!orgId || !ready || entering) return;
     // Replaces any preview already running: the store commits one persona and
     // resets the cache either way.
-    enterViewAs(toViewAsPersona(orgId, orgRole, space, roleOption));
+    const persona = toViewAsPersona(orgId, orgRole, space, roleOption);
+    setEntering(true);
+    try {
+      // Load the persona's own org row BEFORE committing it: the permissions
+      // and the banner must appear together, and a load that fails must leave
+      // the admin exactly where they were rather than under a persona wearing
+      // their own authority.
+      enterViewAs(persona, await fetchOrgsAs(persona));
+    } catch {
+      setEntering(false);
+      toast.error(t("viewAs.enterFailed"));
+      return;
+    }
     // Land where the persona's role applies. Elsewhere the persona is only its
     // org role — an implicit member of open spaces — and a banner naming
     // "Lecteur dans Default" over a page answered for another space reads as
@@ -96,7 +110,11 @@ export function ViewAsDialog({ onClose, spaceId }: ViewAsDialogProps) {
           <Button variant="ghost" onClick={onClose}>
             {t("btn.cancel", { ns: "common" })}
           </Button>
-          <Button data-testid="view-as-submit" disabled={!ready} onClick={submit}>
+          <Button
+            data-testid="view-as-submit"
+            disabled={!ready || entering}
+            onClick={() => void submit()}
+          >
             {t("viewAs.submit")}
           </Button>
         </>

--- a/apps/web/src/hooks/use-org.ts
+++ b/apps/web/src/hooks/use-org.ts
@@ -6,7 +6,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { client } from "../api/client";
 import { orgStore } from "../stores/org-store";
 import { spaceStore } from "../stores/space-store";
-import { exitViewAs } from "../stores/view-as-store";
+import { exitViewAs, serializeViewAs, type ViewAsPersona } from "../stores/view-as-store";
 import { useAutoSelect } from "./use-auto-select";
 import { orgKeys, removeOrgScopedQueries } from "../lib/query-keys";
 
@@ -15,9 +15,23 @@ export function useCurrentOrgId(): string | null {
   return useStore(orgStore, (s) => s.id);
 }
 
-async function fetchOrgs() {
-  const { data } = await client.GET("/api/orgs");
+async function fetchOrgs(viewAs?: string) {
+  const { data } = await client.GET(
+    "/api/orgs",
+    viewAs ? { params: { header: { "X-View-As": viewAs } } } : {},
+  );
   return data?.data ?? [];
+}
+
+/**
+ * The org listing as it would be answered FOR `persona` — the `permissions`
+ * every `can()` gate reads. The header is passed explicitly because the store
+ * does not hold the persona yet, which is the point: `enterViewAs` commits the
+ * persona and this listing together, so nothing ever renders the previewer's
+ * authority under the persona's banner.
+ */
+export function fetchOrgsAs(persona: ViewAsPersona) {
+  return fetchOrgs(serializeViewAs(persona));
 }
 
 /**

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -1065,5 +1065,6 @@
   "viewAs.spaceRolePlaceholder": "Choose a role",
   "viewAs.rolesEmpty": "No previewable role in this space.",
   "viewAs.submit": "Preview",
+  "viewAs.enterFailed": "Could not start the preview. Try again.",
   "viewAs.trigger": "Preview a role"
 }

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -1065,5 +1065,6 @@
   "viewAs.spaceRolePlaceholder": "Choisir un rôle",
   "viewAs.rolesEmpty": "Aucun rôle prévisualisable dans cet espace.",
   "viewAs.submit": "Prévisualiser",
+  "viewAs.enterFailed": "Impossible de démarrer la prévisualisation. Réessayez.",
   "viewAs.trigger": "Prévisualiser un rôle"
 }

--- a/apps/web/src/stores/test/view-as.test.tsx
+++ b/apps/web/src/stores/test/view-as.test.tsx
@@ -33,6 +33,7 @@ const {
   toViewAsPersona,
   STORAGE_KEY,
 } = await import("../view-as-store.ts");
+const { orgKeys } = await import("../../lib/query-keys.ts");
 const { orgStore } = await import("../org-store.ts");
 const { spaceStore } = await import("../space-store.ts");
 const { queryClient } = await import("../../lib/query-client.ts");
@@ -56,32 +57,48 @@ const PERSONA: ViewAsPersona = {
   },
 };
 
+type Organization = components["schemas"]["Organization"];
+
+/** `GET /api/orgs` as the server answers it FOR the persona — its permissions. */
+const ORGS_AS_PERSONA: Organization[] = [
+  {
+    id: "org_a",
+    name: "Acme",
+    slug: "acme",
+    role: "member",
+    permissions: ["org:read"],
+    createdAt: "2026-01-01T00:00:00Z",
+    deleting_at: null,
+  },
+];
+
 beforeEach(() => {
   fakeStorage.clear();
   viewAsStore.setState({ persona: null, stoppedReason: null });
   orgStore.setState({ id: "org_a" });
+  queryClient.removeQueries({ queryKey: orgKeys.all });
 });
 
 describe("view-as store", () => {
   it("serializes the header in the grammar the server parses", () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     expect(getViewAsHeader()).toBe("org_role=member; space=spc_1; role=preset:viewer");
   });
 
   it("omits the space pair when the persona names no space", () => {
-    enterViewAs({ orgId: "org_a", orgRole: "guest", space: null });
+    enterViewAs({ orgId: "org_a", orgRole: "guest", space: null }, ORGS_AS_PERSONA);
     expect(getViewAsHeader()).toBe("org_role=guest");
   });
 
   it("stays silent in every organization but its own", () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     orgStore.setState({ id: "org_b" });
     expect(getViewAsHeader()).toBeNull();
     expect(buildScopingHeaders()["X-View-As"]).toBeUndefined();
   });
 
   it("rides on the scoping headers for the previewed organization", () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     expect(buildScopingHeaders()).toMatchObject({
       "X-Org-Id": "org_a",
       "X-View-As": "org_role=member; space=spc_1; role=preset:viewer",
@@ -89,7 +106,7 @@ describe("view-as store", () => {
   });
 
   it("persists the persona and drops it on exit", () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     expect(JSON.parse(fakeStorage.getItem(STORAGE_KEY)!)).toEqual(PERSONA);
     exitViewAs();
     expect(fakeStorage.getItem(STORAGE_KEY)).toBeNull();
@@ -117,7 +134,9 @@ describe("cache reset", () => {
   function spyCache() {
     return {
       remove: spyOn(queryClient, "removeQueries").mockImplementation(() => {}),
-      refetch: spyOn(queryClient, "refetchQueries").mockImplementation(() => Promise.resolve()),
+      invalidate: spyOn(queryClient, "invalidateQueries").mockImplementation(() =>
+        Promise.resolve(),
+      ),
     };
   }
 
@@ -130,50 +149,67 @@ describe("cache reset", () => {
     expect(predicate({ queryKey: ["get", "/api/spaces"] })).toBe(true);
   }
 
-  it("empties the scoped cache and refetches the org list on entry", () => {
-    const { remove, refetch } = spyCache();
+  it("empties the scoped cache on entry", () => {
+    const { remove, invalidate } = spyCache();
     try {
-      enterViewAs(PERSONA);
+      enterViewAs(PERSONA, ORGS_AS_PERSONA);
       expect(remove).toHaveBeenCalledTimes(1);
-      expect(refetch).toHaveBeenCalledTimes(1);
-      expect(refetch.mock.calls[0]?.[0]).toEqual({ queryKey: ["orgs"] });
+      // The org list is HANDED to the store, so entering never waits on — nor
+      // gambles on — a refetch of it.
+      expect(invalidate).not.toHaveBeenCalled();
       assertOrgListSpared(remove);
     } finally {
       remove.mockRestore();
-      refetch.mockRestore();
+      invalidate.mockRestore();
     }
   });
 
-  it("does the same on exit", () => {
-    enterViewAs(PERSONA);
-    const { remove, refetch } = spyCache();
+  it("empties it again on exit and re-asks for the caller's own org row", () => {
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
+    const { remove, invalidate } = spyCache();
     try {
       exitViewAs();
       expect(remove).toHaveBeenCalledTimes(1);
-      expect(refetch).toHaveBeenCalledTimes(1);
+      // Invalidated, not just refetched: a refetch that fails would otherwise
+      // leave the persona's reduced row serving the caller for good.
+      expect(invalidate).toHaveBeenCalledTimes(1);
+      expect(invalidate.mock.calls[0]?.[0]).toEqual({ queryKey: ["orgs"] });
       assertOrgListSpared(remove);
     } finally {
       remove.mockRestore();
-      refetch.mockRestore();
+      invalidate.mockRestore();
     }
   });
 
   it("does nothing when there is no preview to leave", () => {
-    const { remove, refetch } = spyCache();
+    const { remove, invalidate } = spyCache();
     try {
       exitViewAs();
       expect(remove).not.toHaveBeenCalled();
-      expect(refetch).not.toHaveBeenCalled();
+      expect(invalidate).not.toHaveBeenCalled();
     } finally {
       remove.mockRestore();
-      refetch.mockRestore();
+      invalidate.mockRestore();
     }
+  });
+
+  it("publishes the persona's own org row in the same tick as the persona", () => {
+    // #1322: the persona used to be committed on its own and `["orgs"]` merely
+    // refetched. React Query serves the previous value for the whole of a
+    // background refetch — and forever if it fails — so `usePermissions` kept
+    // reading the previewer's permissions and every org-level admin entry
+    // stayed in the menu under a "Lecteur" banner.
+    queryClient.setQueryData(orgKeys.all, [
+      { ...ORGS_AS_PERSONA[0]!, role: "owner", permissions: ["org:read", "webhooks:read"] },
+    ]);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
+    expect(queryClient.getQueryData<Organization[]>(orgKeys.all)).toEqual(ORGS_AS_PERSONA);
   });
 });
 
 describe("realtime carrier", () => {
   it("appends `view_as` to the stream URL — those routes refuse the header", () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     expect(withViewAsParam("/api/realtime/runs?orgId=org_a", getViewAsHeader())).toBe(
       "/api/realtime/runs?orgId=org_a&view_as=org_role%3Dmember%3B%20space%3Dspc_1%3B%20role%3Dpreset%3Aviewer",
     );
@@ -199,7 +235,7 @@ const previewedRequest = () => new Headers({ "X-View-As": "org_role=member" });
 
 describe("exit on refusal", () => {
   it("drops the persona and keeps the code when the server refuses it", async () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     await noteViewAsRefusal(previewedRequest(), refusal(404, "view_as_not_found"));
     expect(viewAsStore.getState().persona).toBeNull();
     // Held for the first mounted frame to say: the refusal lands on the boot
@@ -208,19 +244,19 @@ describe("exit on refusal", () => {
   });
 
   it("keeps the preview on a 404 the previewed role earned", async () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     await noteViewAsRefusal(previewedRequest(), refusal(404, "not_found"));
     expect(viewAsStore.getState().persona).toEqual(PERSONA);
   });
 
   it("keeps the preview on an unrelated denial", async () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     await noteViewAsRefusal(previewedRequest(), refusal(403, "forbidden"));
     expect(viewAsStore.getState().persona).toEqual(PERSONA);
   });
 
   it("ignores a failure on a request that carried no persona", async () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     await noteViewAsRefusal(new Headers(), refusal(403, "view_as_forbidden"));
     expect(viewAsStore.getState().persona).toEqual(PERSONA);
   });
@@ -229,13 +265,13 @@ describe("exit on refusal", () => {
   // takes the header-less door. Its answer is what stops the reconnect loop —
   // a refused preview retried forever is an idle tab hammering a wall.
   it("reports a refused persona to the caller that must stop retrying", async () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     expect(await endPreviewIfRefused(refusal(403, "view_as_forbidden"))).toBe(true);
     expect(viewAsStore.getState().persona).toBeNull();
   });
 
   it("reports a transient failure as no refusal, so the caller keeps retrying", async () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     expect(await endPreviewIfRefused(new Response("gateway down", { status: 502 }))).toBe(false);
     expect(viewAsStore.getState().persona).toEqual(PERSONA);
   });
@@ -251,14 +287,14 @@ describe("exit on refusal", () => {
       "view_as_forbidden",
       "view_as_not_found",
     ]) {
-      enterViewAs(PERSONA);
+      enterViewAs(PERSONA, ORGS_AS_PERSONA);
       expect(await endPreviewIfRefused(refusal(403, code))).toBe(true);
       expect(viewAsStore.getState().persona).toBeNull();
     }
   });
 
   it("keeps the preview when the failure carries no code at all", async () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     expect(await endPreviewIfRefused(new Response("{}", { status: 403 }))).toBe(false);
     expect(viewAsStore.getState().persona).toEqual(PERSONA);
   });
@@ -268,8 +304,8 @@ describe("leaving on purpose", () => {
   it("replaces a running preview rather than stacking a second one", () => {
     // The entry dialog stays reachable under a preview, so submitting again is
     // a replacement — no `exitViewAs()` dance at the call site.
-    enterViewAs(PERSONA);
-    enterViewAs(toViewAsPersona("org_a", "guest", undefined, undefined));
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
+    enterViewAs(toViewAsPersona("org_a", "guest", undefined, undefined), ORGS_AS_PERSONA);
     expect(viewAsStore.getState().persona).toEqual({
       orgId: "org_a",
       orgRole: "guest",
@@ -279,7 +315,7 @@ describe("leaving on purpose", () => {
   });
 
   it("leaves no reason behind when the user simply quits", () => {
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     exitViewAs();
     expect(viewAsStore.getState().stoppedReason).toBeNull();
   });
@@ -287,7 +323,7 @@ describe("leaving on purpose", () => {
   it("hands the reason out exactly once", () => {
     // StrictMode runs the effect that shows it twice; the second take must be
     // empty or the user sees the same toast twice.
-    enterViewAs(PERSONA);
+    enterViewAs(PERSONA, ORGS_AS_PERSONA);
     exitViewAs("view_as_forbidden");
     expect(takeViewAsStopped()).toBe("view_as_forbidden");
     expect(takeViewAsStopped()).toBeNull();

--- a/apps/web/src/stores/view-as-store.ts
+++ b/apps/web/src/stores/view-as-store.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { VIEW_AS_ORG_ROLES } from "@appstrate/core/permissions";
 import { useStore } from "zustand";
 import { createStore } from "zustand/vanilla";
+import type { components } from "../api/schema";
 import { queryClient } from "../lib/query-client";
 import { orgKeys, removeOrgScopedQueries } from "../lib/query-keys";
 import { getCurrentOrgId, orgStore } from "./org-store";
@@ -35,6 +36,9 @@ const personaSchema = z.object({
 });
 
 export type ViewAsPersona = z.infer<typeof personaSchema>;
+
+/** A row of `GET /api/orgs` — where `permissions` lives. */
+type Organization = components["schemas"]["Organization"];
 
 interface ViewAsState {
   persona: ViewAsPersona | null;
@@ -126,29 +130,41 @@ export function toViewAsPersona(
   };
 }
 
-export function enterViewAs(persona: ViewAsPersona): void {
+/**
+ * Start — or replace — a preview.
+ *
+ * `orgs` is the org listing ALREADY answered for this persona (`fetchOrgsAs`),
+ * a parameter rather than something this function goes and gets, because the
+ * two have to land in the same tick. Every `can()` gate reads `permissions` off
+ * the current org row (`usePermissions`), `["orgs"]` is the one query the cache
+ * reset spares, and React Query keeps serving the previous value for the whole
+ * of a background refetch — and forever if that refetch fails. A persona
+ * committed on its own therefore presents the previewer's own authority as the
+ * persona's: org-level admin menus under a "Lecteur" banner (#1322). Loading
+ * first also means a load that fails starts no preview at all.
+ */
+export function enterViewAs(persona: ViewAsPersona, orgs: Organization[]): void {
   viewAsStore.getState().commit(persona, null);
-  resetScopedCache();
+  queryClient.setQueryData(orgKeys.all, orgs);
+  removeOrgScopedQueries(queryClient);
 }
 
 /** The ONE exit path — "Quitter", org switch, sign-out and a refused persona. */
 export function exitViewAs(reason?: string): void {
   if (!viewAsStore.getState().persona) return;
   viewAsStore.getState().commit(null, reason ?? null);
-  resetScopedCache();
-}
-
-/**
- * `["orgs"]` is refetched, not dropped: under a persona `GET /api/orgs` answers
- * with the persona's `role`/`permissions`, which every `can()` gate reads.
- */
-function resetScopedCache(): void {
   removeOrgScopedQueries(queryClient);
-  void queryClient.refetchQueries({ queryKey: orgKeys.all });
+  // Not loaded first, unlike entering: leaving RESTORES authority, so the row
+  // left behind under-states what the caller may do rather than over-stating
+  // it, and exit must succeed with no network at all (sign-out, org switch, a
+  // persona the server just refused). Invalidated rather than merely
+  // refetched: a refetch that fails leaves the row marked stale, so the next
+  // observer to mount tries again instead of keeping it forever.
+  void queryClient.invalidateQueries({ queryKey: orgKeys.all });
 }
 
 /** The `X-View-As` grammar the server parses; `; ` separated `key=value` pairs. */
-function serializeViewAs(persona: ViewAsPersona): string {
+export function serializeViewAs(persona: ViewAsPersona): string {
   const fields = [`org_role=${persona.orgRole}`];
   if (persona.space) {
     fields.push(`space=${persona.space.spaceId}`, `role=${persona.space.role}`);


### PR DESCRIPTION
Closes #1322

## Root cause

`apps/web/src/stores/view-as-store.ts:129` committed the persona and then only
*refetched* the org list — `["orgs"]` is deliberately spared by
`removeOrgScopedQueries` (`apps/web/src/lib/query-keys.ts:175`) because `OrgGate`
blocks on it. React Query keeps serving the previous `data` for the whole of a
background refetch **and** on error, and the `void` discarded the promise, so
`currentOrg.permissions` — what `usePermissions().can()` reads
(`apps/web/src/hooks/use-permissions.ts:65`) — stayed the previewer's. The space
half of the cache *is* dropped, which is why space gates closed correctly while
Webhooks / OAuth clients / CLI sessions / billing stayed in the menu under a
"Lecteur" banner. Sub-second normally, permanent when `/api/orgs` fails.

Server-side enforcement was never at fault (the issue's differential test over
`{member, guest} × {admin, builder, operator, runner, viewer}` found no difference).

## Fix

Make the pairing structural instead of hoping a refetch wins the race.

- `enterViewAs(persona, orgs)` now **takes** the org listing already answered for
  that persona and writes it with `setQueryData` in the same synchronous tick as
  the commit. The two can no longer disagree, and the signature makes it
  impossible for a future call site to skip the step.
- `fetchOrgsAs(persona)` (`apps/web/src/hooks/use-org.ts`) asks `GET /api/orgs`
  with an explicit `X-View-As` header — the store does not hold the persona yet,
  which is the point. `fetchOrgs` gained the optional header argument; the
  request middleware only fills headers that are absent, so the explicit one wins.
- `ViewAsDialog.submit` loads first, disables the button while it does, and on
  failure shows `viewAs.enterFailed` and keeps the dialog open. **No persona is
  committed at all**, so a failed load leaves the admin exactly where they were —
  no rollback state to get wrong, no stale persona to strand.
- `exitViewAs` keeps its background refresh (leaving *restores* authority, so a
  stale row under-states rather than over-states, and exit must work with no
  network at all: sign-out, org switch, a refused persona) but now
  `invalidateQueries` instead of `refetchQueries`, so a refresh that fails leaves
  the row marked stale and the next observer retries. With
  `refetchOnWindowFocus: false` and `retry: 1` in the query client, the old form
  could keep the persona's reduced row for good.
- `resetScopedCache()` is gone — the two paths are deliberately no longer the
  same, and each now carries the reason inline.

No change to `OrgGate`, to `removeOrgScopedQueries`, or to `usePermissions`: the
boot-screen flash the sparing rule exists to avoid is still avoided, because the
listing is seeded rather than dropped.

New i18n key `viewAs.enterFailed` (fr + en, `settings` namespace).

## Tests

`apps/web/src/stores/test/view-as.test.tsx` — every `enterViewAs` call site now
passes the listing it commits with; the cache-reset block was rewritten for the
new contract and gained the regression:

- *"publishes the persona's own org row in the same tick as the persona"* — seeds
  `["orgs"]` with an owner row carrying `webhooks:read`, enters, and asserts the
  cached row is the persona's. Fails on `main`.
- *"empties the scoped cache on entry"* — entry no longer refetches/gambles.
- *"empties it again on exit and re-asks for the caller's own org row"* — pins
  `invalidateQueries({ queryKey: ["orgs"] })`.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/web/src/stores/test/view-as.test.tsx
  → 31 pass / 0 fail
set -a && . ./.env && set +a && TEST_TIER=0 bun test \
  apps/web/src/pages/test/view-as-entry-points.test.tsx \
  apps/web/src/lib/test/query-keys.test.ts \
  apps/web/src/stores/test/view-as.test.tsx \
  apps/web/src/hooks/test/assignable-space-roles.test.tsx
  → 49 pass / 0 fail
bunx tsc --noEmit -p apps/web  → clean
bunx eslint <touched files>    → clean
```

## Notes for the orchestrator

- No migration, no env var, no OpenAPI contract change (`X-View-As` is already a
  declared header parameter on `listOrganizations`).
- **Pre-existing flake, not from this branch**: `apps/web/src/locales/test/locale-keys.test.ts`
  → *"declared keys are all still referenced by the source"* times out at its 5 s
  budget under the current parallel-agent load. Verified against a clean
  `origin/main` worktree in the same conditions: it times out there too (5.3 s).
  The guard does an O(keys × namespaces) substring sweep over a multi-MB blob.
- Overlap with #1368 (identity-derived capabilities not previewable): none in
  code. That issue builds on this one — `enterViewAs` now has a second parameter,
  so a branch that adds another previewable dimension should extend the same
  "load it, then commit it with the persona" shape rather than adding a second
  refetch.
- Behaviour worth knowing: submitting a *replacement* persona that the server
  refuses will now end the preview that was running (the response middleware sees
  the refusal on the loading request) **and** show the dialog's failure message.
  End state is correct — no preview, an explicit error — but the user may see two
  toasts. Left unguarded on purpose: the entry catalog is already filtered to
  grantable roles and the trigger only renders for owner/admin, so it needs a
  concurrent permission change to happen at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
