### PR TITLE
fix(roles): answer a delete/assign race with 409 role_in_use, not a 500

### DIFF
--- a/apps/api/src/lib/db-helpers.ts
+++ b/apps/api/src/lib/db-helpers.ts
@@ -117,6 +117,24 @@ export function isInvalidTextRepresentation(err: unknown): boolean {
 }
 
 /**
+ * True when a DB error is a referential-integrity violation on write:
+ * PostgreSQL raises `23503` (foreign_key_violation), while PGlite (tier 0)
+ * surfaces an `ON DELETE RESTRICT` as `23001` (restrict_violation). Both mean
+ * "rows still reference this one". Walks the `cause` chain for the same reason
+ * {@link isUniqueViolation} does.
+ */
+export function isForeignKeyViolation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    if (typeof current !== "object") break;
+    const code = (current as { code?: unknown }).code;
+    if (code === "23503" || code === "23001") return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
  * True when a DB error is Postgres `23505` (unique_violation). Walks the
  * `cause` chain for the same reason {@link isInvalidTextRepresentation} does:
  * Drizzle wraps the driver error in a `DrizzleQueryError` whose own `code` is

--- a/apps/api/src/routes/model-provider-credentials.ts
+++ b/apps/api/src/routes/model-provider-credentials.ts
@@ -35,6 +35,7 @@ import type { ProviderRegistryEntry, ProviderRegistryModelEntry } from "@appstra
 import type { ModelProviderDefinition } from "@appstrate/core/module";
 import { testModelConfig } from "../services/org-models.ts";
 import { logger } from "../lib/logger.ts";
+import { isForeignKeyViolation } from "../lib/db-helpers.ts";
 import {
   ApiError,
   conflict,
@@ -74,27 +75,6 @@ export const updateSchema = z
     apiKey: z.string().min(1).optional(),
   })
   .strict();
-
-/** PG referential-integrity violation on delete. PostgreSQL raises
- * `foreign_key_violation` (23503); PGlite (tier 0) surfaces `ON DELETE
- * RESTRICT` as `restrict_violation` (23001). Both mean "rows still
- * reference this credential". */
-function isForeignKeyViolation(err: unknown): boolean {
-  const code = pgErrorCode(err);
-  return code === "23503" || code === "23001";
-}
-
-/** Walk the `cause` chain for a SQLSTATE `code` — Drizzle (and the PGlite
- * driver) wrap the underlying driver error one or more levels deep. */
-function pgErrorCode(err: unknown): string | undefined {
-  let cur: unknown = err;
-  for (let depth = 0; depth < 5 && typeof cur === "object" && cur !== null; depth++) {
-    const code = (cur as { code?: unknown }).code;
-    if (typeof code === "string") return code;
-    cur = (cur as { cause?: unknown }).cause;
-  }
-  return undefined;
-}
 
 /** Exactly one of `credential_id` or inline `provider_id` + `api_key`; the route enforces which. */
 export const discoverSchema = z

--- a/apps/api/src/services/space-roles.ts
+++ b/apps/api/src/services/space-roles.ts
@@ -12,7 +12,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { orgInvitations, spaceMembers, spaceRoles } from "@appstrate/db/schema";
 import { SPACE_ROLE_PRESETS, type SpaceRolePreset } from "@appstrate/core/permissions";
-import { isUniqueViolation } from "../lib/db-helpers.ts";
+import { isForeignKeyViolation, isUniqueViolation } from "../lib/db-helpers.ts";
 import { getAppConfig } from "../lib/app-config.ts";
 import { ApiError, conflict, invalidRequest, notFound } from "../lib/errors.ts";
 import { prefixedId } from "../lib/ids.ts";
@@ -284,18 +284,11 @@ export async function updateSpaceRole(params: {
  * Two things hold a bundle: a `space_members` row, and a PENDING invitation
  * whose JSONB `space_assignments` name it. The second has no FK, so deleting
  * under it would strand the invitee with an assignment that never applies.
- *
- * Counted here rather than left to `ON DELETE RESTRICT`, whose error names
- * neither the role nor how many people would lose access.
  */
-export async function deleteSpaceRole(orgId: string, id: string): Promise<SpaceRoleWire> {
-  const [row] = await db
-    .select()
-    .from(spaceRoles)
-    .where(and(eq(spaceRoles.id, id), eq(spaceRoles.orgId, orgId)))
-    .limit(1);
-  if (!row) throw notFound(`Role '${id}' not found in this organization`);
-
+async function countRoleHolders(
+  orgId: string,
+  id: string,
+): Promise<{ memberCount: number; pendingInvitationCount: number }> {
   const [assigned, invited] = await Promise.all([
     db
       .select({ count: sql<number>`count(*)::int` })
@@ -314,17 +307,59 @@ export async function deleteSpaceRole(orgId: string, id: string): Promise<SpaceR
         ),
       ),
   ]);
-  const memberCount = assigned[0]?.count ?? 0;
-  const pendingInvitationCount = invited[0]?.count ?? 0;
-  if (memberCount > 0 || pendingInvitationCount > 0) {
-    throw conflict(
-      "role_in_use",
-      `Role '${row.key}' is still held by ${memberCount} space member(s) and ` +
-        `${pendingInvitationCount} pending invitation(s). Reassign them before deleting it.`,
-      { member_count: memberCount, pending_invitation_count: pendingInvitationCount },
-    );
-  }
+  return {
+    memberCount: assigned[0]?.count ?? 0,
+    pendingInvitationCount: invited[0]?.count ?? 0,
+  };
+}
 
-  await db.delete(spaceRoles).where(and(eq(spaceRoles.id, id), eq(spaceRoles.orgId, orgId)));
+function roleInUse(
+  key: string,
+  counts: { memberCount: number; pendingInvitationCount: number },
+): never {
+  throw conflict(
+    "role_in_use",
+    `Role '${key}' is still held by ${counts.memberCount} space member(s) and ` +
+      `${counts.pendingInvitationCount} pending invitation(s). Reassign them before deleting it.`,
+    {
+      member_count: counts.memberCount,
+      pending_invitation_count: counts.pendingInvitationCount,
+    },
+  );
+}
+
+/**
+ * The loser of a delete/assign race gets the same 409 as the pre-count, not a
+ * 500 naming a constraint — the same shape {@link asKeyConflict} gives the
+ * create/update races. `space_members.custom_role_id` is ON DELETE RESTRICT,
+ * so an assignment landing between the count and the delete fires the
+ * referential-integrity violation; recount to name who now holds the role.
+ */
+async function asRoleInUse(err: unknown, orgId: string, id: string, key: string): Promise<never> {
+  if (!isForeignKeyViolation(err)) throw err;
+  roleInUse(key, await countRoleHolders(orgId, id));
+}
+
+/**
+ * Holders are counted rather than left to `ON DELETE RESTRICT`, whose error
+ * names neither the role nor how many people would lose access. The count is
+ * lock-free on purpose: {@link asRoleInUse} turns the race it leaves open into
+ * the very same 409, so the delete never has to hold a lock to be honest.
+ */
+export async function deleteSpaceRole(orgId: string, id: string): Promise<SpaceRoleWire> {
+  const [row] = await db
+    .select()
+    .from(spaceRoles)
+    .where(and(eq(spaceRoles.id, id), eq(spaceRoles.orgId, orgId)))
+    .limit(1);
+  if (!row) throw notFound(`Role '${id}' not found in this organization`);
+
+  const counts = await countRoleHolders(orgId, id);
+  if (counts.memberCount > 0 || counts.pendingInvitationCount > 0) roleInUse(row.key, counts);
+
+  await db
+    .delete(spaceRoles)
+    .where(and(eq(spaceRoles.id, id), eq(spaceRoles.orgId, orgId)))
+    .catch((err: unknown) => asRoleInUse(err, orgId, id, row.key));
   return toWire(row);
 }

--- a/apps/api/test/unit/lib/db-helpers.test.ts
+++ b/apps/api/test/unit/lib/db-helpers.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `isForeignKeyViolation` is what turns a referential-integrity failure into a
+ * readable 409 (`role_in_use`, `credential_in_use`) instead of a 500. It has to
+ * see through the wrapper Drizzle puts around the driver error, and it has to
+ * accept the code PGlite raises for `ON DELETE RESTRICT` as well as the one a
+ * real Postgres raises — the tier-0 suite runs on the former.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isForeignKeyViolation } from "../../../src/lib/db-helpers.ts";
+
+/** How Drizzle surfaces a driver failure: a wrapper with no code of its own. */
+function drizzleWrapped(code: string): Error {
+  const driver = Object.assign(new Error("driver error"), { code });
+  return Object.assign(new Error("Failed query"), { cause: driver });
+}
+
+describe("isForeignKeyViolation", () => {
+  it("matches 23503 (postgres) and 23001 (PGlite ON DELETE RESTRICT)", () => {
+    expect(isForeignKeyViolation({ code: "23503" })).toBe(true);
+    expect(isForeignKeyViolation({ code: "23001" })).toBe(true);
+  });
+
+  it("sees the code through the Drizzle wrapper", () => {
+    expect(isForeignKeyViolation(drizzleWrapped("23503"))).toBe(true);
+    expect(isForeignKeyViolation(drizzleWrapped("23001"))).toBe(true);
+  });
+
+  it("rejects neighbouring integrity codes and non-DB errors", () => {
+    expect(isForeignKeyViolation(drizzleWrapped("23505"))).toBe(false);
+    expect(isForeignKeyViolation({ code: "22P02" })).toBe(false);
+    expect(isForeignKeyViolation(new Error("boom"))).toBe(false);
+    expect(isForeignKeyViolation(null)).toBe(false);
+    expect(isForeignKeyViolation("23503")).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #1371

## Root cause

`apps/api/src/services/space-roles.ts` — `deleteSpaceRole()` counted the role's
holders (`space_members` rows + PENDING invitations naming it) with a lock-free
read, then issued `db.delete(spaceRoles)` with no `.catch`. `space_members.custom_role_id`
is `ON DELETE RESTRICT` (`packages/db/src/schema/spaces.ts:118`), so a
`POST /api/spaces/:id/members {custom_role_id}` landing between the count and the
delete makes Postgres raise a referential-integrity violation that nothing
handles — the intended 409 `role_in_use` becomes a 500.

## Fix

Guard the delete the way `createSpaceRole`/`updateSpaceRole` already guard their
key races (`asKeyConflict`): map the violation back to the *same* 409. The
counting and the throwing are split into `countRoleHolders()` / `roleInUse()` so
the racing path recounts and the problem body still carries `member_count` and
`pending_invitation_count` — the two fields the OpenAPI description promises and
`apps/web/src/pages/org-settings/roles.tsx:77` reads. No contract change: same
status, same code, same details shape.

Chosen over "count and delete in one transaction with `SELECT … FOR UPDATE`":
that lock does serialise the two writers, but it makes the *delete* win, so the
concurrent assignment is the side that dies on the FK. Refusing the delete is
the semantics the pre-count already states ("in use → 409"), and catching the
violation gets there without holding a lock.

The predicate for that violation already existed — privately, with its own
cause-chain walk, in `apps/api/src/routes/model-provider-credentials.ts`. First
commit promotes it to `apps/api/src/lib/db-helpers.ts` beside `isUniqueViolation`
rather than writing a third copy of the walk. It keeps covering both SQLSTATEs
(`23503` on a real Postgres, `23001` on PGlite for tier 0).

## Tests

- New `apps/api/test/unit/lib/db-helpers.test.ts` (3 `it`s) pins the promoted
  predicate: both SQLSTATEs, seen through the Drizzle wrapper, and rejecting
  neighbouring codes (`23505`, `22P02`) and non-DB values.
- `set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/unit/lib/db-helpers.test.ts apps/api/test/integration/routes/roles.test.ts` → **27 pass, 0 fail**
- `… bun test apps/api/test/integration/routes/model-provider-credentials.test.ts` → **27 pass, 0 fail** (its `credential_in_use` case is the regression guard for the helper move)
- `bunx tsc --noEmit -p apps/api` → clean. eslint + prettier clean on all four files.

The race itself is not reproduced end-to-end: tier-0 PGlite is a single
connection, so there is no second writer to interleave with.

## Notes for the orchestrator

- Stacked on `fix/issue-1334`; no overlap with #1333 (`space-members` removal).
- No migration, no env var, no OpenAPI change — nothing to order at deploy.
- The pending-invitation half of the pre-count has no FK behind it, so an
  invitation created concurrently with a delete still strands its assignment.
  That is a different mechanism from the 500 this issue reports and is left
  alone deliberately.
- An outside contributor opened #1374 against this issue; this PR does not use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
