### PR TITLE
fix(models): rebind a failed single model add to the credential it minted

### DIFF
--- a/apps/web/src/components/model-form-modal.tsx
+++ b/apps/web/src/components/model-form-modal.tsx
@@ -210,7 +210,11 @@ function ModelForm({
   const [picked, setPicked] = useState<ModelPickRow[]>([]);
   /** Ids a batch could not create — re-offered instead of silently dropped. */
   const [failedModelIds, setFailedModelIds] = useState<string[]>([]);
-  /** The credential a partially failed batch already created: a retry binds to it. */
+  /**
+   * The credential a refused submission already minted from the typed key. It
+   * outlives the model step: a retry binds to it instead of minting a second
+   * one against the same secret and orphaning the first.
+   */
   const [createdCredentialId, setCreatedCredentialId] = useState<string | null>(null);
   const [modelMode, setModelMode] = useState<"list" | "manual" | null>(null);
 
@@ -231,7 +235,15 @@ function ModelForm({
   const dropListing = () => {
     setPicked([]);
     setFailedModelIds([]);
+  };
+
+  /**
+   * The endpoint and the typed key are what a credential is minted from:
+   * editing either strands whatever a refused submission already minted.
+   */
+  const dropEndpointBinding = () => {
     setCreatedCredentialId(null);
+    dropListing();
   };
 
   const resetModelStep = () => {
@@ -249,11 +261,12 @@ function ModelForm({
     dropListing();
   };
 
-  /** A typed key never coexists with a saved credential. */
+  /** A typed key never coexists with a saved credential — nor with what it minted. */
   const bindCredential = (id: string) => {
     setValue("credentialId", id);
     setValue("inlineApiKey", "");
     clearErrors("credentialId");
+    setCreatedCredentialId(null);
   };
 
   /**
@@ -266,6 +279,8 @@ function ModelForm({
     clearErrors();
     setValue("credentialId", "");
     if (!keepTypedKey) setValue("inlineApiKey", "");
+    // A minted credential is pinned to the provider it was created for.
+    setCreatedCredentialId(null);
     const provider = getProviderById(id, registry);
     if (provider) {
       setValue("apiShape", provider.apiShape);
@@ -355,7 +370,7 @@ function ModelForm({
       fields: data,
       dirtyFields,
       provider: selectedProvider,
-      selectedCredentialId: selectedCredential?.id ?? null,
+      selectedCredentialId: selectedCredential?.id ?? createdCredentialId,
       capabilities: capabilitiesExplicit ? "explicit" : "auto",
       isEdit: !!model,
       catalogEntry: catalogEntry(data.modelId.trim()),
@@ -367,6 +382,7 @@ function ModelForm({
     // The host closes on success and reports nothing here.
     const outcome = await onSubmit(result.data);
     if (outcome.failedModelIds.length > 0) {
+      if (outcome.credentialId) setCreatedCredentialId(outcome.credentialId);
       setError("modelId", { message: t("models.form.saveFailed") });
     }
   });
@@ -415,14 +431,19 @@ function ModelForm({
         providers={registry.filter((p) => p.baseUrlOverridable)}
         onApiTypeChange={(entry) => switchProvider(entry.providerId, true)}
         providerLocked={!!model}
-        baseUrlProps={register("baseUrl", { validate: baseUrlValidate, onChange: dropListing })}
+        baseUrlProps={register("baseUrl", {
+          validate: baseUrlValidate,
+          onChange: dropEndpointBinding,
+        })}
         // The URL is a property of the credential, not of the model.
         baseUrlLocked={!!selectedCredential}
         baseUrlError={showError("baseUrl") ? errors.baseUrl?.message : undefined}
-        apiKeyProps={register("inlineApiKey", { onChange: dropListing })}
+        apiKeyProps={register("inlineApiKey", { onChange: dropEndpointBinding })}
         apiKeyError={showError("credentialId") ? errors.credentialId?.message : undefined}
+        // Once the typed key HAS been minted, a retry rebinds to it — promising
+        // another automatic create would be a lie.
         apiKeyHint={
-          !selectedCredential && inlineApiKey.trim()
+          !selectedCredential && !createdCredentialId && inlineApiKey.trim()
             ? t("models.form.createCredentialHint")
             : undefined
         }

--- a/apps/web/src/hooks/use-models.ts
+++ b/apps/web/src/hooks/use-models.ts
@@ -8,13 +8,8 @@ import { useCurrentOrgId } from "./use-org";
 import { useCurrentSpaceId } from "./use-current-space";
 import { useOrgOnlyScope } from "./use-org-scope";
 import type { ModelCost } from "@appstrate/core/module";
-import type {
-  ModelFormData,
-  ModelFormMultiData,
-  ModelFormSubmission,
-  ModelFormSubmitOutcome,
-} from "../lib/model-form-payload";
-import { toCreateModelBody } from "../lib/model-form-payload";
+import type { ModelFormSubmission, ModelFormSubmitOutcome } from "../lib/model-form-payload";
+import { submitModelForm } from "../lib/model-form-submit";
 import { useCreateModelProviderCredential } from "./use-model-provider-credentials";
 import { agentModelKeys, packageKeys } from "../lib/query-keys";
 import type { ModelGenerationSettings } from "@appstrate/core/model-generation";
@@ -156,15 +151,6 @@ export function useSetAgentModel(packageId: string) {
   });
 }
 
-/** `label` is omitted: the server derives and dedupes one. */
-function credentialBody(credential: NonNullable<ModelFormData["newCredential"]>) {
-  return {
-    providerId: credential.providerId,
-    apiKey: credential.apiKey,
-    ...(credential.baseUrlOverride ? { baseUrlOverride: credential.baseUrlOverride } : {}),
-  };
-}
-
 /**
  * ModelFormModal submission: the inline key first if any, then one create or
  * update — or, for a batch, one create per entry against that one key.
@@ -182,60 +168,24 @@ export function useModelFormHandler(opts: {
   const isPending =
     submitPending || createModel.isPending || updateModel.isPending || createCredential.isPending;
 
-  /** The credential the model(s) bind to: the picked one, or the typed key created first. */
-  const bindCredential = async (data: ModelFormSubmission): Promise<string> =>
-    data.newCredential
-      ? (await createCredential.mutateAsync({ body: credentialBody(data.newCredential) })).id
-      : data.credentialId;
+  const submit = submitModelForm({
+    writes: {
+      createCredential: (body) => createCredential.mutateAsync({ body }),
+      createModel: (body) => createModel.mutateAsync({ body }),
+      updateModel: (id, body) => updateModel.mutateAsync({ params: { path: { id } }, body }),
+    },
+    editModelId: opts.editModel?.id ?? null,
+    onSuccess: opts.onSuccess,
+  });
 
-  /** No bulk create: one POST per entry, refusals collected rather than aborting. */
-  const submitBatch = async (data: ModelFormMultiData): Promise<ModelFormSubmitOutcome> => {
+  const onSubmit = async (data: ModelFormSubmission): Promise<ModelFormSubmitOutcome> => {
     setSubmitPending(true);
     try {
-      const credentialId = await bindCredential(data);
-      const failedModelIds: string[] = [];
-      for (const entry of data.models) {
-        try {
-          await createModel.mutateAsync({ body: { ...entry, credentialId } });
-        } catch {
-          failedModelIds.push(entry.modelId);
-        }
-      }
-      if (failedModelIds.length === 0) opts.onSuccess();
-      return { failedModelIds, credentialId };
-    } catch {
-      // The key itself was refused.
-      return { failedModelIds: data.models.map((m) => m.modelId) };
+      return await submit(data);
     } finally {
       setSubmitPending(false);
     }
   };
-
-  /** A refusal (of the key or the model) is reported the way a batch reports its own. */
-  const submitOne = async (data: ModelFormData): Promise<ModelFormSubmitOutcome> => {
-    setSubmitPending(true);
-    try {
-      const credentialId = await bindCredential(data);
-      if (opts.editModel) {
-        const { newCredential: _, ...modelData } = data;
-        await updateModel.mutateAsync({
-          params: { path: { id: opts.editModel.id } },
-          body: { ...modelData, credentialId },
-        });
-      } else {
-        await createModel.mutateAsync({ body: toCreateModelBody(data, credentialId) });
-      }
-      opts.onSuccess();
-      return { failedModelIds: [] };
-    } catch {
-      return { failedModelIds: [data.modelId] };
-    } finally {
-      setSubmitPending(false);
-    }
-  };
-
-  const onSubmit = (data: ModelFormSubmission) =>
-    "models" in data ? submitBatch(data) : submitOne(data);
 
   return { onSubmit, isPending };
 }

--- a/apps/web/src/lib/model-form-submit.ts
+++ b/apps/web/src/lib/model-form-submit.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The ModelFormModal submission, minus React: mint the inline key if there is
+ * one, then run the create(s) or the update against it.
+ *
+ * The writes are injected rather than closed over, so the retry contract this
+ * flow exists to hold is assertable without a DOM. That contract: once the
+ * typed key has been minted, every later refusal reports the credential back,
+ * because the modal re-submits with the same `newCredential` still in the form
+ * — nothing to rebind to means a second credential holding the same secret and
+ * a first one referenced by no model.
+ */
+
+import type {
+  ModelFormData,
+  ModelFormModelEntry,
+  ModelFormMultiData,
+  ModelFormSubmission,
+  ModelFormSubmitOutcome,
+} from "./model-form-payload.ts";
+import { toCreateModelBody } from "./model-form-payload.ts";
+
+export type ModelFormCreateBody = ModelFormModelEntry & { credentialId: string };
+type ModelFormUpdateBody = Omit<ModelFormData, "newCredential">;
+
+/** The three writes a submission can make. */
+export interface ModelFormWrites {
+  createCredential: (body: {
+    providerId: string;
+    apiKey: string;
+    baseUrlOverride?: string;
+  }) => Promise<{ id: string }>;
+  createModel: (body: ModelFormCreateBody) => Promise<unknown>;
+  updateModel: (id: string, body: ModelFormUpdateBody) => Promise<unknown>;
+}
+
+/** `label` is omitted: the server derives and dedupes one. */
+function credentialBody(credential: NonNullable<ModelFormData["newCredential"]>) {
+  return {
+    providerId: credential.providerId,
+    apiKey: credential.apiKey,
+    ...(credential.baseUrlOverride ? { baseUrlOverride: credential.baseUrlOverride } : {}),
+  };
+}
+
+/**
+ * The credential the model(s) bind to: the picked one, or the typed key created
+ * first — or `null` when minting that key was itself refused, which is the one
+ * case where a retry has nothing to rebind to.
+ */
+async function bindCredential(
+  writes: ModelFormWrites,
+  data: ModelFormSubmission,
+): Promise<string | null> {
+  if (!data.newCredential) return data.credentialId;
+  try {
+    return (await writes.createCredential(credentialBody(data.newCredential))).id;
+  } catch {
+    return null;
+  }
+}
+
+/** No bulk create: one POST per entry, refusals collected rather than aborting. */
+async function submitBatch(
+  writes: ModelFormWrites,
+  data: ModelFormMultiData,
+  onSuccess: () => void,
+): Promise<ModelFormSubmitOutcome> {
+  const credentialId = await bindCredential(writes, data);
+  if (!credentialId) return { failedModelIds: data.models.map((m) => m.modelId) };
+
+  const failedModelIds: string[] = [];
+  for (const entry of data.models) {
+    try {
+      await writes.createModel({ ...entry, credentialId });
+    } catch {
+      failedModelIds.push(entry.modelId);
+    }
+  }
+  if (failedModelIds.length === 0) onSuccess();
+  return { failedModelIds, credentialId };
+}
+
+/** A refusal (of the key or the model) is reported the way a batch reports its own. */
+async function submitOne(
+  writes: ModelFormWrites,
+  data: ModelFormData,
+  editModelId: string | null,
+  onSuccess: () => void,
+): Promise<ModelFormSubmitOutcome> {
+  const credentialId = await bindCredential(writes, data);
+  if (!credentialId) return { failedModelIds: [data.modelId] };
+
+  try {
+    if (editModelId) {
+      const { newCredential: _, ...modelData } = data;
+      await writes.updateModel(editModelId, { ...modelData, credentialId });
+    } else {
+      await writes.createModel(toCreateModelBody(data, credentialId));
+    }
+  } catch {
+    return { failedModelIds: [data.modelId], credentialId };
+  }
+  onSuccess();
+  return { failedModelIds: [] };
+}
+
+/** One submission handler over `writes` — a batch when the payload carries `models`. */
+export function submitModelForm(opts: {
+  writes: ModelFormWrites;
+  editModelId: string | null;
+  onSuccess: () => void;
+}) {
+  return (data: ModelFormSubmission): Promise<ModelFormSubmitOutcome> =>
+    "models" in data
+      ? submitBatch(opts.writes, data, opts.onSuccess)
+      : submitOne(opts.writes, data, opts.editModelId, opts.onSuccess);
+}

--- a/apps/web/src/lib/test/model-form-submit.test.ts
+++ b/apps/web/src/lib/test/model-form-submit.test.ts
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `submitModelForm` — what a refused submission reports back.
+ *
+ * The modal re-submits the SAME form on a retry, inline key included. So every
+ * refusal that happens after the key was minted has to name the credential it
+ * minted; the modal binds the retry to it. Without that the retry mints a
+ * second credential holding the same secret and leaves the first referenced by
+ * no model.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { ModelFormData, ModelFormMultiData } from "../model-form-payload.ts";
+import {
+  submitModelForm,
+  type ModelFormCreateBody,
+  type ModelFormWrites,
+} from "../model-form-submit.ts";
+
+const NEW_CREDENTIAL = { apiKey: "sk-abc", providerId: "openai" };
+
+/** Records every write; `refuse` names the step that throws. */
+function harness(refuse?: "credential" | "model") {
+  const created: ModelFormCreateBody[] = [];
+  const updated: { id: string; credentialId: string }[] = [];
+  const credentials: { providerId: string; apiKey: string }[] = [];
+  let successes = 0;
+
+  const writes: ModelFormWrites = {
+    createCredential: async (body) => {
+      if (refuse === "credential") throw new Error("key refused");
+      credentials.push({ providerId: body.providerId, apiKey: body.apiKey });
+      return { id: `cred_${credentials.length}` };
+    },
+    createModel: async (body) => {
+      if (refuse === "model") throw new Error("model refused");
+      created.push(body);
+    },
+    updateModel: async (id, body) => {
+      if (refuse === "model") throw new Error("model refused");
+      updated.push({ id, credentialId: body.credentialId });
+    },
+  };
+
+  return {
+    writes,
+    created,
+    updated,
+    credentials,
+    onSuccess: () => {
+      successes += 1;
+    },
+    get successes() {
+      return successes;
+    },
+  };
+}
+
+const oneWithTypedKey: ModelFormData = {
+  modelId: "gpt-6",
+  credentialId: "",
+  newCredential: NEW_CREDENTIAL,
+};
+
+const batchWithTypedKey: ModelFormMultiData = {
+  credentialId: "",
+  newCredential: NEW_CREDENTIAL,
+  models: [{ modelId: "gpt-6" }, { modelId: "gpt-6-mini" }],
+};
+
+describe("submitModelForm — single model", () => {
+  it("reports the minted credential when the model is refused, so a retry rebinds to it", async () => {
+    const h = harness("model");
+    const outcome = await submitModelForm({
+      writes: h.writes,
+      editModelId: null,
+      onSuccess: h.onSuccess,
+    })(oneWithTypedKey);
+
+    expect(outcome.failedModelIds).toEqual(["gpt-6"]);
+    expect(outcome.credentialId).toBe("cred_1");
+    expect(h.credentials).toHaveLength(1);
+    expect(h.successes).toBe(0);
+
+    // The retry the modal builds from that outcome: the picked credential, no
+    // inline key — so nothing new is minted.
+    const retry = harness();
+    const second = await submitModelForm({
+      writes: retry.writes,
+      editModelId: null,
+      onSuccess: retry.onSuccess,
+    })({ modelId: "gpt-6", credentialId: outcome.credentialId! });
+
+    expect(second.failedModelIds).toEqual([]);
+    expect(retry.credentials).toEqual([]);
+    expect(retry.created[0]?.credentialId).toBe("cred_1");
+    expect(retry.successes).toBe(1);
+  });
+
+  it("names no credential when the key itself was refused, and never tries the model", async () => {
+    const h = harness("credential");
+    const outcome = await submitModelForm({
+      writes: h.writes,
+      editModelId: null,
+      onSuccess: h.onSuccess,
+    })(oneWithTypedKey);
+
+    expect(outcome).toEqual({ failedModelIds: ["gpt-6"] });
+    expect(h.created).toEqual([]);
+  });
+
+  it("binds a successful create to the credential it minted", async () => {
+    const h = harness();
+    const outcome = await submitModelForm({
+      writes: h.writes,
+      editModelId: null,
+      onSuccess: h.onSuccess,
+    })(oneWithTypedKey);
+
+    expect(outcome).toEqual({ failedModelIds: [] });
+    expect(h.created).toEqual([{ modelId: "gpt-6", credentialId: "cred_1" }]);
+    expect(h.successes).toBe(1);
+  });
+
+  it("routes an edit to the update write, bound to the minted credential", async () => {
+    const h = harness();
+    await submitModelForm({ writes: h.writes, editModelId: "mdl_1", onSuccess: h.onSuccess })(
+      oneWithTypedKey,
+    );
+
+    expect(h.updated).toEqual([{ id: "mdl_1", credentialId: "cred_1" }]);
+    expect(h.created).toEqual([]);
+  });
+
+  it("reports the minted credential when an edit is refused", async () => {
+    const h = harness("model");
+    const outcome = await submitModelForm({
+      writes: h.writes,
+      editModelId: "mdl_1",
+      onSuccess: h.onSuccess,
+    })(oneWithTypedKey);
+
+    expect(outcome).toEqual({ failedModelIds: ["gpt-6"], credentialId: "cred_1" });
+  });
+});
+
+describe("submitModelForm — batch", () => {
+  it("reports the shared credential alongside the ids it could not create", async () => {
+    const h = harness("model");
+    const outcome = await submitModelForm({
+      writes: h.writes,
+      editModelId: null,
+      onSuccess: h.onSuccess,
+    })(batchWithTypedKey);
+
+    expect(outcome).toEqual({ failedModelIds: ["gpt-6", "gpt-6-mini"], credentialId: "cred_1" });
+    expect(h.credentials).toHaveLength(1);
+    expect(h.successes).toBe(0);
+  });
+
+  it("names no credential when the key itself was refused", async () => {
+    const h = harness("credential");
+    const outcome = await submitModelForm({
+      writes: h.writes,
+      editModelId: null,
+      onSuccess: h.onSuccess,
+    })(batchWithTypedKey);
+
+    expect(outcome).toEqual({ failedModelIds: ["gpt-6", "gpt-6-mini"] });
+    expect(h.created).toEqual([]);
+  });
+
+  it("creates every entry against one credential and reports it", async () => {
+    const h = harness();
+    const outcome = await submitModelForm({
+      writes: h.writes,
+      editModelId: null,
+      onSuccess: h.onSuccess,
+    })(batchWithTypedKey);
+
+    expect(outcome).toEqual({ failedModelIds: [], credentialId: "cred_1" });
+    expect(h.created.map((m) => m.credentialId)).toEqual(["cred_1", "cred_1"]);
+    expect(h.successes).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #1355

## Root cause

`submitOne` (`apps/web/src/hooks/use-models.ts:215-235` before this change) returned `{ failedModelIds: [data.modelId] }` with no `credentialId`, while `submitBatch` returned `{ failedModelIds, credentialId }` (line 205). The modal only stores what it is given (`model-form-modal.tsx:348`, batch path only), and the single path built its payload with `selectedCredentialId: selectedCredential?.id ?? null` (line 307).

So after "inline key minted → model refused", the re-submit still carried `newCredential` and `credentialId: ""`. `resolveCredentialBinding` (`lib/model-form-payload.ts:148`) therefore minted again: a second credential holding the same secret, the first referenced by no model. `POST /api/model-provider-credentials` always inserts — there is no dedupe by key.

## Fix

The retry contract is now the same on both paths: **every refusal that happens after the key was minted names the credential it minted**, and only a refusal *of the key itself* names none.

That contract was not assertable while the flow lived inside the hook, closed over three `mutateAsync` calls — `apps/web` has no DOM in tests (`renderToStaticMarkup` only), so an async submit cannot be driven there. It moves to `apps/web/src/lib/model-form-submit.ts` with the writes injected (`ModelFormWrites`), which is also what `apps/web/CLAUDE.md` asks for: "any code that builds a request body the SPA sends is a pure function under `lib/` with a test that pins the emitted payload". The hook keeps the pending flag and the three adapters (~20 lines). Behaviour of the batch path is unchanged — `bindCredential` returning `null` replaces the outer try/catch that used to swallow the key refusal.

Modal side:
- the single path builds its payload with `selectedCredential?.id ?? createdCredentialId` and stores `outcome.credentialId` on failure, exactly as the batch path does;
- `createdCredentialId` no longer dies with the model step. `dropListing()` cleared it, and `dropListing` is wired to `resetModelStep` — so switching between the list and the manual field (same provider, same key) stranded the minted credential and the next submit minted a second one, the reported bug by another route. It is now dropped only when the key material changes: the typed key or base URL (`dropEndpointBinding`, which is what those two `register` `onChange`s used to reach `dropListing` for), the provider (`switchProvider`), or picking/clearing a saved credential (`bindCredential`);
- the "a key will be created automatically" hint hides once a key has been minted — after that a retry rebinds, it does not create.

## Tests

`apps/web/src/lib/test/model-form-submit.test.ts` (new, 8 cases): the minted credential is reported on a refused create and on a refused edit; the retry built from that outcome creates **no** second credential and binds to the first; a refused key names none and never attempts the model; batch partial/total failure and success pin the existing behaviour.

```
cd apps/web && bun test src/lib/test/model-form-submit.test.ts   → 8 pass, 0 fail
cd apps/web && bun test                                          → 886 pass, 0 fail (87 files)
bunx tsc --noEmit -p apps/web                                    → clean
bunx eslint <4 touched files>                                    → clean
bunx knip --workspace apps/web                                   → clean
```

Negative control: reverting only `return { failedModelIds: [data.modelId], credentialId }` to the old shape turns 2 of the 8 red.

## Notes for the orchestrator

- Based on `fix/issue-1354`; PR targets that branch. No overlap with its diff (`lib/model-form-payload.ts`, `lib/model-source.ts`) — this touches `hooks/use-models.ts`, `components/model-form-modal.tsx` and a new `lib/model-form-submit.ts`.
- No migration, no env var, no OpenAPI change (frontend only) — so `verify:openapi` / `verify:api-types` were not needed.
- Sibling #1358 (duplicate `org_models` rows) is untouched.
- **Open decision, deliberately not implemented**: the issue also suggests cleaning up a credential that ends up referenced by no model. Not done — deleting a stored API key on the user's behalf is destructive and the credential is a legitimate saved key visible in the credentials list. This PR removes the mechanism that *created* the orphans; reaping pre-existing ones is a separate product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
