### PR TITLE
fix(pricing): list which vendored models a catalog refresh re-prices or drops

### DIFF
--- a/.github/workflows/refresh-pricing-catalog.yml
+++ b/.github/workflows/refresh-pricing-catalog.yml
@@ -153,10 +153,11 @@ jobs:
       - name: Refresh catalog (apply)
         env:
           LITELLM_CATALOG_PATH: ${{ runner.temp }}/litellm-source/litellm-catalog.json
-          # Per-provider cache-rate coverage + delta, for the PR body assembled
-          # below. Written to the runner temp dir, NEVER the worktree — see the
+          # Reviewable summary for the PR body assembled below: the price impact
+          # on models already vendored, then per-provider cache-rate coverage +
+          # delta. Written to the runner temp dir, NEVER the worktree — see the
           # body-path rationale in the drift step.
-          PRICING_COVERAGE_SUMMARY_PATH: ${{ runner.temp }}/pricing-coverage.md
+          PRICING_REVIEW_SUMMARY_PATH: ${{ runner.temp }}/pricing-review.md
         run: |
           cp \
             "${RUNNER_TEMP}/litellm-source/litellm-catalog.lock.json" \
@@ -227,24 +228,28 @@ jobs:
 
           if [ "$pricing" = true ]; then
           cat <<'EOF'
-          - Spot-check 1-2 model price changes against
-            https://openai.com/api/pricing / https://www.anthropic.com/pricing.
-          - Confirm no models we rely on were removed (search `model:`
-            in `apps/api/src/services/llm-proxy/` if unsure).
+          - **Check EVERY row of "Price impact on models already vendored" below**
+            against the vendor's own price page
+            (https://openai.com/api/pricing / https://www.anthropic.com/pricing / …).
+            That section is the complete list of models an org can already be
+            billed on whose rate this PR changes or deletes — catalog-backed
+            `org_models` rows resolve their price live, so merging re-prices
+            existing customers, and a dropped model bills at zero. It is not a
+            spot-check: if a row looks wrong, this PR must not merge as-is.
           - Read the cache-rate coverage table below. `cacheRead` coverage is
             inherited from LiteLLM, so it drifts on its own, and a model with no
             `cacheRead` prices its cached input tokens at zero.
           EOF
 
-          # Inlined verbatim so the coverage change is reviewed rather than merged
-          # blind. Written by the refresh step to $RUNNER_TEMP (outside the
-          # worktree, same reason as the body itself).
-          coverage="${RUNNER_TEMP}/pricing-coverage.md"
-          if [ -f "$coverage" ]; then
+          # Inlined verbatim so the price impact and the coverage change are
+          # reviewed rather than merged blind. Written by the refresh step to
+          # $RUNNER_TEMP (outside the worktree, same reason as the body itself).
+          review="${RUNNER_TEMP}/pricing-review.md"
+          if [ -f "$review" ]; then
             printf '\n'
-            cat "$coverage"
+            cat "$review"
           else
-            printf '\n_Coverage summary missing — the refresh step did not write %s._\n' "$coverage"
+            printf '\n_Review summary missing — the refresh step did not write %s._\n' "$review"
           fi
           fi
 

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -363,6 +363,155 @@ function formatCoverageSummary(rows: readonly CoverageRow[]): string {
 }
 
 /**
+ * One ALREADY-VENDORED model whose rates move — or vanish — in this refresh.
+ *
+ * Catalog-backed `org_models` rows store `cost = NULL` on purpose
+ * (`seedOrgModelsForCredential`) and resolve the rate live on every call
+ * (`resolveCatalogDefaults` → `computeCostUsd` → `llm_usage.cost_usd` → the EE
+ * credit debit), so merging a refresh changes what EXISTING customers pay from
+ * the next release on, with no per-org pin and no notification. That is the
+ * intended design — the catalog is meant to track upstream — but it makes the
+ * price half of the diff a money decision, not a data bump, and the raw JSON
+ * diff buries it among metadata churn (`contextWindow`, `capabilities`,
+ * `generation`). {@link formatPriceChangeSummary} is what puts it in front of
+ * the reviewer.
+ *
+ * Newly ADDED ids are deliberately excluded: no row can be tracking a price
+ * that did not exist last week, so they change nobody's bill.
+ */
+interface PriceChange {
+  provider: string;
+  model: string;
+  /** Rates in the vendored file this refresh replaces. */
+  before: CompactEntry["cost"];
+  /** Rates after it — `null` when upstream DROPPED the model entirely. */
+  after: CompactEntry["cost"] | null;
+}
+
+/**
+ * The rate changes `upstream` makes to models `local` already carries. Reads the
+ * same two snapshots the diff and the coverage row read, before `--apply`
+ * overwrites the file. Pure — unit-tested.
+ */
+function priceChanges(
+  provider: string,
+  local: Record<string, CompactEntry>,
+  upstream: Record<string, CompactEntry>,
+): PriceChange[] {
+  const changes: PriceChange[] = [];
+  for (const model of Object.keys(local).sort()) {
+    const before = local[model]!.cost;
+    const next = upstream[model];
+    if (!next) changes.push({ provider, model, before, after: null });
+    else if (JSON.stringify(before) !== JSON.stringify(next.cost))
+      changes.push({ provider, model, before, after: next.cost });
+  }
+  return changes;
+}
+
+/** The four per-million rate buckets of {@link CompactEntry.cost}, in table order. */
+const RATE_BUCKETS = ["input", "output", "cacheRead", "cacheWrite"] as const;
+
+/**
+ * One bucket's move, as a table cell: `5 → 7.5 (+50%)`, `— → 0.1`, `0.1 → —`,
+ * or `·` when the rate is unchanged (including absent on both sides).
+ *
+ * A rate going to `—` is called out with ⚠️ because it does not mean "free": the
+ * bucket's tokens are then priced at exactly zero while still being consumed.
+ * Pure — unit-tested.
+ */
+function formatRateDelta(before: number | undefined, after: number | undefined): string {
+  if (before === after) return "·";
+  if (before === undefined) return `— → ${after}`;
+  if (after === undefined) return `${before} → — ⚠️`;
+  // A percentage off a zero base is undefined, not infinite — state the move only.
+  if (before === 0) return `${before} → ${after}`;
+  return `${before} → ${after} (${after > before ? "+" : ""}${Math.round(((after - before) / before) * 100)}%)`;
+}
+
+/** Rows listed per table before the rest is elided — see {@link formatPriceChangeSummary}. */
+const MAX_LISTED_PRICE_CHANGES = 60;
+
+function priceChangeTable(
+  rows: readonly PriceChange[],
+  cell: (r: PriceChange) => string[],
+): string[] {
+  const lines = [
+    "| Provider | Model | input | output | cacheRead | cacheWrite |",
+    "| --- | --- | ---: | ---: | ---: | ---: |",
+  ];
+  for (const r of rows.slice(0, MAX_LISTED_PRICE_CHANGES)) {
+    lines.push(`| \`${r.provider}\` | \`${r.model}\` | ${cell(r).join(" | ")} |`);
+  }
+  if (rows.length > MAX_LISTED_PRICE_CHANGES) {
+    lines.push("", `_…and ${rows.length - MAX_LISTED_PRICE_CHANGES} more — read the file diff._`);
+  }
+  return lines;
+}
+
+/**
+ * Markdown for the weekly PR body: every model an org can already be billed on
+ * whose price this refresh changes or removes. Pure — unit-tested.
+ */
+function formatPriceChangeSummary(changes: readonly PriceChange[]): string {
+  const dropped = changes.filter((c) => c.after === null);
+  const repriced = changes.filter((c) => c.after !== null);
+
+  const lines = [
+    "### Price impact on models already vendored",
+    "",
+    "Catalog-backed `org_models` rows store `cost = NULL` and resolve the rate LIVE on",
+    "every call, down to the credit debit — so each row below changes what an existing",
+    "customer pays as soon as this merges and ships. Newly added models are omitted:",
+    "nothing can be tracking a price that did not exist last week.",
+    "",
+  ];
+
+  if (changes.length === 0) {
+    lines.push(
+      "No vendored model was re-priced or dropped by this refresh — every pricing change",
+      "here is a model nobody is billed on yet.",
+      "",
+    );
+    return lines.join("\n");
+  }
+
+  lines.push(
+    "**Check every row against the vendor's own price page before merging.** The platform",
+    "cannot list which orgs are affected from CI (no database here); the operator query is",
+    "`SELECT DISTINCT org_id FROM org_models WHERE cost IS NULL AND model_id = …`.",
+    "",
+  );
+
+  if (dropped.length > 0) {
+    lines.push(
+      `#### Dropped by upstream — ${dropped.length} model(s), now billed at ZERO`,
+      "",
+      "A model that leaves the catalog resolves to NO rate: `cost_usd` is 0 and",
+      "`pricing_status` becomes `unpriced`, so an org still pointing at it is served for",
+      "free — the EE sweeper claims the row, charges nothing and logs a revenue fault.",
+      "Rates shown are the ones being deleted.",
+      "",
+      ...priceChangeTable(dropped, (r) => RATE_BUCKETS.map((b) => `${r.before?.[b] ?? "—"}`)),
+      "",
+    );
+  }
+
+  if (repriced.length > 0) {
+    lines.push(
+      `#### Re-priced — ${repriced.length} model(s)`,
+      "",
+      ...priceChangeTable(repriced, (r) =>
+        RATE_BUCKETS.map((b) => formatRateDelta(r.before?.[b], r.after?.[b])),
+      ),
+      "",
+    );
+  }
+
+  return lines.join("\n");
+}
+
+/**
  * Strip the routing namespace prefix LiteLLM uses for some entries
  * (`mistral/codestral-latest`, `azure/gpt-4o`, …). Our pricing lookup
  * keys on the canonical model id only.
@@ -692,12 +841,14 @@ async function main(): Promise<void> {
   const summaries: Summary[] = [];
   const snapshots: Record<string, Record<string, CompactEntry>> = {};
   const coverageRows: CoverageRow[] = [];
+  const priceChangeRows: PriceChange[] = [];
 
   for (const [litellmProvider, ourName] of Object.entries(LITELLM_TO_OURS)) {
     const upstreamSnapshot = buildProviderSnapshot(upstream, litellmProvider);
     snapshots[ourName] = upstreamSnapshot;
     const local = readLocal(ourName);
     coverageRows.push(coverageRow(ourName, local, upstreamSnapshot));
+    priceChangeRows.push(...priceChanges(ourName, local, upstreamSnapshot));
     const diff = diffSnapshots(local, upstreamSnapshot);
     const summary: Summary = {
       provider: ourName,
@@ -806,9 +957,12 @@ async function main(): Promise<void> {
     }
   }
 
-  // Cache-rate coverage — always computed (it is a state report, not a diff),
-  // printed for the local operator and, in CI, written to the path the caller
-  // names.
+  // Review summary — two sections, both always computed, printed for the local
+  // operator and, in CI, written to the path the caller names:
+  //
+  //   1. price impact (a DIFF: what this refresh does to models orgs can
+  //      already be billed on — the money half, so it goes first);
+  //   2. cache-rate coverage (a STATE report on the resulting catalog).
   //
   // File over "parse it back out of stdout": this script's stdout already
   // interleaves per-provider diff lines, `→ wrote …` lines and warnings, so
@@ -818,13 +972,13 @@ async function main(): Promise<void> {
   // (the workflow uses `$RUNNER_TEMP`): `create-pull-request` commits every
   // change it finds, so a summary file in the repo would land in the very PR
   // it describes.
-  const coverageMarkdown = formatCoverageSummary(coverageRows);
-  console.log(`\n${coverageMarkdown}`);
-  const coveragePath = (globalThis as { process?: { env?: Record<string, string | undefined> } })
-    .process?.env?.PRICING_COVERAGE_SUMMARY_PATH;
-  if (coveragePath) {
-    writeFileSync(coveragePath, coverageMarkdown, "utf8");
-    console.log(`→ wrote coverage summary to ${coveragePath}`);
+  const reviewMarkdown = `${formatPriceChangeSummary(priceChangeRows)}\n${formatCoverageSummary(coverageRows)}`;
+  console.log(`\n${reviewMarkdown}`);
+  const reviewPath = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env?.PRICING_REVIEW_SUMMARY_PATH;
+  if (reviewPath) {
+    writeFileSync(reviewPath, reviewMarkdown, "utf8");
+    console.log(`→ wrote review summary to ${reviewPath}`);
   }
 
   const drift = summaries.some((s) => !s.unchanged);
@@ -852,6 +1006,9 @@ export {
   coverageRow,
   projectGenerationCapabilities,
   formatCoverageSummary,
+  formatPriceChangeSummary,
+  formatRateDelta,
+  priceChanges,
   projectEntry,
 };
-export type { CoverageRow };
+export type { CoverageRow, PriceChange };

--- a/scripts/test/refresh-pricing-catalog.test.ts
+++ b/scripts/test/refresh-pricing-catalog.test.ts
@@ -17,9 +17,13 @@ import {
   countCacheRates,
   coverageRow,
   formatCoverageSummary,
+  formatPriceChangeSummary,
+  formatRateDelta,
+  priceChanges,
   projectGenerationCapabilities,
   projectEntry,
   type CoverageRow,
+  type PriceChange,
 } from "../refresh-pricing-catalog.ts";
 
 const ORIG_EXCLUDE = process.env.FEATURED_MODELS_EXCLUDE;
@@ -233,6 +237,118 @@ describe("formatCoverageSummary", () => {
     ]);
     expect(md).toContain("| `new` | 0 | · | — | · | — | · |");
     expect(md).not.toContain("NaN");
+  });
+});
+
+// #1327 — catalog-backed `org_models` rows resolve their price live, so the
+// weekly refresh silently re-prices existing customers and zero-rates any model
+// upstream drops. These three helpers are what turns that into a reviewable
+// list in the PR body instead of a line buried in a JSON diff.
+describe("priceChanges", () => {
+  const named = (costs: Record<string, Record<string, number>>) =>
+    Object.fromEntries(Object.entries(costs).map(([id, c]) => [id, entry(c)]));
+
+  it("reports a rate move on a model both snapshots carry", () => {
+    const local = named({ "magistral-medium-latest": { input: 2, output: 5 } });
+    const upstream = named({ "magistral-medium-latest": { input: 2, output: 7.5 } });
+    expect(priceChanges("mistral", local, upstream)).toEqual([
+      {
+        provider: "mistral",
+        model: "magistral-medium-latest",
+        before: { input: 2, output: 5 },
+        after: { input: 2, output: 7.5 },
+      },
+    ]);
+  });
+
+  it("reports a dropped model with `after: null` — the zero-rating case", () => {
+    const local = named({ "gemini-3.1-flash-live-preview": { input: 0.3, output: 2.5 } });
+    expect(priceChanges("google-ai", local, {})).toEqual([
+      {
+        provider: "google-ai",
+        model: "gemini-3.1-flash-live-preview",
+        before: { input: 0.3, output: 2.5 },
+        after: null,
+      },
+    ]);
+  });
+
+  it("ignores added models — nothing can be billed on a price that did not exist", () => {
+    const upstream = named({ old: { input: 1, output: 2 }, brand: { input: 9, output: 9 } });
+    expect(priceChanges("openai", named({ old: { input: 1, output: 2 } }), upstream)).toEqual([]);
+  });
+
+  it("ignores metadata-only churn — only `cost` is money", () => {
+    const local = { m: entry({ input: 1, output: 2 }) };
+    const upstream = {
+      m: {
+        contextWindow: 999,
+        maxTokens: 4096,
+        capabilities: ["text"],
+        cost: { input: 1, output: 2 },
+      } as never,
+    };
+    expect(priceChanges("openai", local, upstream)).toEqual([]);
+  });
+});
+
+describe("formatRateDelta", () => {
+  it("renders a rise, a drop and an unchanged bucket", () => {
+    expect(formatRateDelta(5, 7.5)).toBe("5 → 7.5 (+50%)");
+    expect(formatRateDelta(1.5, 0.6)).toBe("1.5 → 0.6 (-60%)");
+    expect(formatRateDelta(2, 2)).toBe("·");
+    expect(formatRateDelta(undefined, undefined)).toBe("·");
+  });
+
+  it("flags a LOST rate — those tokens are now priced at zero, not free", () => {
+    expect(formatRateDelta(0.1, undefined)).toBe("0.1 → — ⚠️");
+    expect(formatRateDelta(undefined, 0.1)).toBe("— → 0.1");
+  });
+
+  it("states the move without a percentage when the old rate was zero", () => {
+    expect(formatRateDelta(0, 0.5)).toBe("0 → 0.5");
+    expect(formatRateDelta(0, 0.5)).not.toContain("Infinity");
+  });
+});
+
+describe("formatPriceChangeSummary", () => {
+  const change = (over: Partial<PriceChange>): PriceChange => ({
+    provider: "mistral",
+    model: "magistral-medium-latest",
+    before: { input: 2, output: 5 },
+    after: { input: 2, output: 7.5 },
+    ...over,
+  });
+
+  it("says so plainly when no vendored model moved", () => {
+    const md = formatPriceChangeSummary([]);
+    expect(md).toContain("No vendored model was re-priced or dropped");
+    expect(md).not.toContain("| Provider |");
+  });
+
+  it("tables a re-priced model with its per-bucket delta", () => {
+    const md = formatPriceChangeSummary([change({})]);
+    expect(md).toContain("#### Re-priced — 1 model(s)");
+    expect(md).toContain("| `mistral` | `magistral-medium-latest` | · | 5 → 7.5 (+50%) | · | · |");
+  });
+
+  it("tables a dropped model separately, naming the zero-billing consequence", () => {
+    const md = formatPriceChangeSummary([
+      change({ provider: "google-ai", model: "gemini-3.1-flash-live-preview", after: null }),
+    ]);
+    expect(md).toContain("#### Dropped by upstream — 1 model(s), now billed at ZERO");
+    expect(md).toContain("`pricing_status` becomes `unpriced`");
+    expect(md).toContain("| `google-ai` | `gemini-3.1-flash-live-preview` | 2 | 5 | — | — |");
+    expect(md).not.toContain("#### Re-priced");
+  });
+
+  it("elides past the listing cap rather than blowing the PR body limit", () => {
+    const many = Array.from({ length: 70 }, (_, i) => change({ model: `m${i}` }));
+    const md = formatPriceChangeSummary(many);
+    expect(md).toContain("#### Re-priced — 70 model(s)");
+    expect(md).toContain("`m59`");
+    expect(md).not.toContain("`m60`");
+    expect(md).toContain("_…and 10 more — read the file diff._");
   });
 });
 


### PR DESCRIPTION
Closes #1327

## Root cause

Catalog-backed `org_models` rows store `cost = NULL` deliberately (`apps/api/src/services/org-models.ts:536-540`) and resolve the rate live on every call — `resolveCatalogDefaults` (`org-models.ts:731`) → `computeCostUsd` (`apps/api/src/services/llm-proxy/metering.ts:296`) → `llm_usage.cost_usd` → the EE credit debit. So merging the weekly refresh changes **what existing customers pay**, and a model upstream drops resolves to no rate at all.

Both facts were invisible at review time. `.github/workflows/refresh-pricing-catalog.yml` asked the reviewer to "spot-check 1-2 model price changes" against a raw JSON diff in which the money lines sit among `contextWindow` / `capabilities` / `generation` churn — a check with no teeth and no list. `ba8a38a99` (#1277) merged exactly that way.

## Fix

`scripts/refresh-pricing-catalog.ts` already reads both snapshots — the vendored file and its replacement — to build the cache-rate coverage table. Same seam, one more section:

- `priceChanges()` — the models the catalog **already carries** whose `cost` moves or vanishes. Added ids are excluded on purpose: nothing can be billed on a price that did not exist last week, so listing them would bury the rows that matter.
- `formatRateDelta()` — one bucket as a cell: `5 → 7.5 (+50%)`, `— → 0.1`, `0.1 → — ⚠️`, `·`. A percentage off a zero base is stated as a plain move, never `Infinity`.
- `formatPriceChangeSummary()` — two tables: **dropped** (naming the zero-billing consequence) and **re-priced**, capped at 60 rows each so a large upstream week cannot blow the PR-body limit.

The summary file now carries two sections, so `PRICING_COVERAGE_SUMMARY_PATH` → `PRICING_REVIEW_SUMMARY_PATH` (CI-only variable, both references in the same commit; not a `packages/env` var). The reviewer checklist now asks for **every** row to be checked, not one or two.

Run against the commit the issue cites (`ba8a38a99^..ba8a38a99`, mistral + google-ai) the new section reproduces the issue's findings and surfaces two re-prices its manual diff missed:

```
#### Dropped by upstream — 4 model(s), now billed at ZERO
| `google-ai` | `gemini-3.1-flash-live-preview` | 0.75 | 4.5 | — | — |          (+3 more)

#### Re-priced — 7 model(s)
| `mistral` | `magistral-medium-latest` | 2 → 1.5 (-25%) | 5 → 7.5 (+50%) | — → 0.15 | · |
| `mistral` | `mistral-medium`          | 2.7 → 1.5 (-44%) | 8.1 → 7.5 (-7%) | — → 0.15 | · |
```

### On the issue's other two bullets

**"Treat a removed catalog id as an error state, not as free inference" — already true on `main`, the issue is mistaken here.** It claims `pricingStatus` stays `priced` in both directions; it does not. A dropped id makes `resolveCatalogDefaults` return `{}` → `resolveModelMetadata` falls to `cost: null` (`org-models.ts:63`) → `classifyTokenPricing` returns `unpriced` (`packages/afps-runtime/src/runner/token-cost.ts`), locked by `apps/api/test/unit/llm-proxy-metering.test.ts:724`. `@appstrate/module-ee` then **claims the row and charges nothing** (`packages/module-ee/src/billing/usage-recorder.ts:353`, `PricingFaults`) and `reportPricingFaults` logs one `error` per pass naming the affected `orgIds`. Nothing to change; no code touched there.

**"Pin `cost` per org model at creation with an explicit track-catalog opt-in"** — not implemented, see below.

## Tests

`scripts/test/refresh-pricing-catalog.test.ts` — 13 new cases next to the existing coverage-summary ones: `priceChanges` (re-price / drop / added-ignored / metadata-only churn ignored), `formatRateDelta` (rise, drop, lost rate flagged, zero base), `formatPriceChangeSummary` (both tables, empty case, listing cap).

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test scripts/test/refresh-pricing-catalog.test.ts   → 39 pass, 0 fail
bunx tsc --noEmit -p scripts/tsconfig.json                                                          → clean
bunx eslint <touched .ts> ; bunx prettier --check <touched .ts + .yml>                              → clean
bun run verify:workflows                                                                            → actionlint, no findings
```

## Notes for the orchestrator

- No migration, no `packages/env` variable, no OpenAPI change, no runtime code touched — the whole diff is the refresh script, its test file and the workflow that runs it. Nothing to deploy; it takes effect on the next Monday 06:00 UTC run (or a `workflow_dispatch`).
- No overlap with #1329, #1370 or #1357. `featured-models.json` is untouched.
- **OPEN DECISION (pricing policy, not shipped):** whether a catalog-backed `org_models` row should keep tracking the catalog (today's default, so upstream re-prices flow through automatically) or freeze `cost` at creation with an explicit "track catalog" opt-in. That reverses the default for every existing customer and needs a product call; it is deliberately not in this PR. The two other things CI structurally cannot do — list the affected orgs, and *block* on a delta for a model an org actually uses — need database access the workflow does not have; the operator query is spelled out in the generated section (`SELECT DISTINCT org_id FROM org_models WHERE cost IS NULL AND model_id = …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
