### PR TITLE
feat(web): state the role preview's identity boundary in the banner

### DIFF
--- a/apps/web/src/components/view-as-banner.tsx
+++ b/apps/web/src/components/view-as-banner.tsx
@@ -28,6 +28,14 @@ import { useSpaces } from "../hooks/use-spaces";
  * banner also names the role it holds in the space being looked at — "Lecteur
  * dans Default" over a page answered for Marketing otherwise reads as a preview
  * that does not work.
+ *
+ * It also states the preview's one boundary. A persona is a restriction of the
+ * caller's own session and the caller stays themselves (`apps/api/src/lib/view-as.ts`),
+ * so every capability gated on IDENTITY rather than on role survives it: the
+ * runs the previewer launched (`runs:read` means "mine"), the files they
+ * uploaded, the integration connections they own. Previewing those would take
+ * impersonation, which the design refuses; naming the boundary is what keeps
+ * "see what this role sees" honest.
  */
 export function ViewAsBanner() {
   const { t } = useTranslation(["common", "settings"]);
@@ -88,6 +96,7 @@ export function ViewAsBanner() {
             />
           </>
         )}
+        <span className="block text-xs font-normal opacity-80">{t("viewAs.bannerOwn")}</span>
       </span>
       <Button variant="outline" size="sm" onClick={() => exitViewAs()}>
         {t("viewAs.exit")}

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -111,6 +111,7 @@
   "viewAs.banner": "You are viewing the organization as <b>{{role}}</b>",
   "viewAs.bannerSpace": "You are viewing the organization as <b>{{role}}</b>, <b>{{spaceRole}}</b> in <b>{{space}}</b>",
   "viewAs.bannerHere": "· in <b>{{space}}</b>: <b>{{role}}</b> (open space)",
+  "viewAs.bannerOwn": "What you created stays visible — your runs, your files, your connections. This role sees less.",
   "viewAs.exit": "Exit",
   "viewAs.stopped.invalid_view_as": "Preview stopped: the saved preview can no longer be read.",
   "viewAs.stopped.view_as_unsupported": "Preview stopped: this session cannot preview a role.",

--- a/apps/web/src/locales/fr/common.json
+++ b/apps/web/src/locales/fr/common.json
@@ -111,6 +111,7 @@
   "viewAs.banner": "Vous voyez l'organisation en tant que <b>{{role}}</b>",
   "viewAs.bannerSpace": "Vous voyez l'organisation en tant que <b>{{role}}</b>, <b>{{spaceRole}}</b> dans <b>{{space}}</b>",
   "viewAs.bannerHere": "· dans <b>{{space}}</b> : <b>{{role}}</b> (espace ouvert)",
+  "viewAs.bannerOwn": "Ce que vous avez créé reste visible — vos runs, vos fichiers, vos connexions. Ce rôle en voit moins.",
   "viewAs.exit": "Quitter",
   "viewAs.stopped.invalid_view_as": "Prévisualisation arrêtée : la prévisualisation enregistrée n'est plus lisible.",
   "viewAs.stopped.view_as_unsupported": "Prévisualisation arrêtée : cette session ne peut pas prévisualiser de rôle.",

--- a/apps/web/src/stores/test/view-as.test.tsx
+++ b/apps/web/src/stores/test/view-as.test.tsx
@@ -430,6 +430,17 @@ describe("banner", () => {
     expect(html).not.toContain("Direction");
   });
 
+  // A persona restricts the caller without replacing them, so every capability
+  // gated on identity — own runs, own files, own connections — survives the
+  // preview. The banner is the one place that boundary is stated.
+  it("states that what the previewer created stays visible, whatever the persona", () => {
+    const withSpace = renderBanner(PERSONA, "org_a");
+    expect(withSpace).toContain("Ce que vous avez créé reste visible");
+
+    const orgOnly = renderBanner({ orgId: "org_a", orgRole: "guest", space: null }, "org_a");
+    expect(orgOnly).toContain("Ce que vous avez créé reste visible");
+  });
+
   it("renders nothing outside the previewed organization", () => {
     expect(renderBanner(PERSONA, "org_b")).toBe("");
   });


### PR DESCRIPTION
Closes #1368

## Root cause

`view-as` is a pure restriction of the caller's own session — `c.get("user")` stays real (`apps/api/src/lib/view-as.ts:5-8`) — so every capability gated on **identity** rather than on role survives a persona: runs the previewer launched (`runs:read` = "mine", `apps/api/src/lib/run-visibility.ts:87-93`), files they uploaded (`apps/api/src/services/files.ts:327-339`), integration connections they own (`apps/web/src/pages/integration-detail.tsx`). An owner previewing `viewer` sees a populated Runs list where a real viewer sees an empty one. Verified against this base; the issue's mechanism is accurate.

## Fix

The divergence itself is by design — previewing identity-derived capabilities would require impersonation, which the design explicitly refuses. The defect is that the divergence was **silent**. So: the banner now states the boundary, in one muted line under the role sentence.

New key `viewAs.bannerOwn` (en + fr), rendered outside the `<Trans>` variants so it holds for every persona shape (org-only, space, "open space" suffix). No behaviour change, no API change, no new state. The component doc comment now carries the reasoning with file references, so the next reader does not re-litigate it.

Deliberately **not** done (YAGNI, and a product decision — see Notes): suppressing identity-derived controls client-side while a persona is active.

## Tests

- `apps/web/src/stores/test/view-as.test.tsx` — one test added in the existing `describe("banner")`: the caveat renders for both a space-bearing and an org-only persona.
- `cd apps/web && TEST_TIER=0 bun test src/stores/test/view-as.test.tsx src/locales/test/locale-keys.test.ts` → **41 pass, 0 fail** (locale-keys' source-scan test needs `--timeout 60000` on a cold FS; green with it, 9/9).
- `bunx tsc --noEmit -p apps/web` → clean. `bunx eslint` + `bunx prettier --check` on the four touched files → clean.
- e2e `e2e/tests/rbac/view-as.ui.spec.ts` unaffected: its negative assertion is on `/espace ouvert|open space/`, which the new copy does not contain.

## Notes for the orchestrator

- Based on `fix/issue-1322` (PR base is that branch). No overlap with its diff: it touched `view-as-store.ts` / `use-org.ts` / `view-as-dialog.tsx`; this touches `view-as-banner.tsx` + `common.json` + the banner tests.
- No migration, no env var, no deploy ordering.
- **Open decision for the user** — the issue offered two options and this ships the cheap honest one (label the limit). The other, suppressing identity-derived capabilities while a persona is active (hiding own runs, the Delete control on own files, own connections), is a real product change: it would make the SPA lie about data the server legitimately returned, needs a rule per surface, and cannot be made exact (the client cannot distinguish "returned because I own it" from "returned because the role may read it" without a new server signal). If the user wants it, it should be specced as its own issue, not bolted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
