### PR TITLE
fix(module-ee): repair an org's billing account and its debt in one transaction

### DIFF
--- a/packages/module-ee/src/billing/repair-account.ts
+++ b/packages/module-ee/src/billing/repair-account.ts
@@ -36,6 +36,23 @@
  * reconstruction would be WRONG on an existing account (a Stripe renewal resets
  * `credits_used` to 0 while historical usage records remain), which is why this
  * refuses to touch an org that already has one.
+ *
+ * ALL OR NOTHING. The guard, the provision and the debt run in ONE transaction.
+ * Split across two commits, an interruption between them (Ctrl-C, a pool blip, a
+ * pod eviction) left the account provisioned and the debt unapplied — and the
+ * guard below then reported `already_provisioned` forever, writing the org's
+ * entire debt off silently while refusing to touch it again. The atomic form
+ * makes that state unreachable: a repair either lands whole or leaves no trace,
+ * so re-running it after any failure is always correct.
+ *
+ * WHY THE GUARD STAYS "DOES A ROW EXIST", rather than "does `credits_used`
+ * already cover the records". It cannot tell the two apart: a subscription
+ * cancellation downgrades the account to free with `credits_used = 0`,
+ * `period_end = NULL` and `stripe_subscription_id = NULL` while the historical
+ * usage records survive — byte for byte the signature of "provisioned, debt not
+ * applied". A guard keyed on the shortfall would re-charge that org for
+ * everything it ever spent. Existence is the only safe test, and with the
+ * transaction above it is also a sufficient one.
  */
 
 import { eq, sql } from "drizzle-orm";
@@ -50,44 +67,66 @@ export type RepairOutcome =
   | { status: "repaired"; creditQuota: number; creditsApplied: number };
 
 /**
+ * Optional test seam for {@link repairBillingAccount}. `onBeforeCommit` runs
+ * INSIDE the transaction, after the debt has been applied: throwing from it is
+ * how a test reproduces an interrupted repair and proves nothing is left behind.
+ */
+export interface RepairHooks {
+  onBeforeCommit?: () => Promise<void>;
+}
+
+/**
  * Re-provision a missing billing account and apply the usage recorded while it
- * was missing. Refuses (without writing anything) when the account already
- * exists — there is nothing to repair, and reconstructing `credits_used` from
- * usage records would clobber a legitimate renewal reset.
+ * was missing, in one transaction. Refuses (without writing anything) when the
+ * account already exists — there is nothing to repair, and reconstructing
+ * `credits_used` from usage records would clobber a legitimate renewal reset.
  */
 export async function repairBillingAccount(
   orgId: string,
   ownerEmail: string,
+  hooks?: RepairHooks,
 ): Promise<RepairOutcome> {
   const db = getEeDb();
 
-  const [existing] = await db
-    .select({ orgId: billingAccounts.orgId })
-    .from(billingAccounts)
-    .where(eq(billingAccounts.orgId, orgId));
-  if (existing) return { status: "already_provisioned" };
+  const outcome = await db.transaction(async (tx): Promise<RepairOutcome> => {
+    const [existing] = await tx
+      .select({ orgId: billingAccounts.orgId })
+      .from(billingAccounts)
+      .where(eq(billingAccounts.orgId, orgId));
+    if (existing) return { status: "already_provisioned" };
 
-  const { creditQuota } = await provisionBillingAccount(
-    orgId,
-    normalizeEmail(ownerEmail),
-    ownerEmail,
-  );
+    const { creditQuota } = await provisionBillingAccount(
+      tx,
+      orgId,
+      normalizeEmail(ownerEmail),
+      ownerEmail,
+    );
 
-  // Apply the debt the sweep recorded but could not debit. Computed in SQL from
-  // the org's usage records so no float round-trips through JS.
-  const [applied] = await db
-    .update(billingAccounts)
-    .set({
-      creditsUsed: sql`COALESCE((
-        SELECT SUM(${orgUsageRecords.costCredits}) FROM ${orgUsageRecords}
-        WHERE ${orgUsageRecords.orgId} = ${orgId}
-      ), 0)`,
-      updatedAt: new Date(),
-    })
-    .where(eq(billingAccounts.orgId, orgId))
-    .returning({ creditsUsed: billingAccounts.creditsUsed });
+    // Apply the debt the sweep recorded but could not debit. Computed in SQL from
+    // the org's usage records so no float round-trips through JS.
+    const [applied] = await tx
+      .update(billingAccounts)
+      .set({
+        creditsUsed: sql`COALESCE((
+          SELECT SUM(${orgUsageRecords.costCredits}) FROM ${orgUsageRecords}
+          WHERE ${orgUsageRecords.orgId} = ${orgId}
+        ), 0)`,
+        updatedAt: new Date(),
+      })
+      .where(eq(billingAccounts.orgId, orgId))
+      .returning({ creditsUsed: billingAccounts.creditsUsed });
 
-  const creditsApplied = applied?.creditsUsed ?? 0;
-  logger.info("billing account repaired", { orgId, creditQuota, creditsApplied });
-  return { status: "repaired", creditQuota, creditsApplied };
+    if (hooks?.onBeforeCommit) await hooks.onBeforeCommit();
+
+    return { status: "repaired", creditQuota, creditsApplied: applied?.creditsUsed ?? 0 };
+  });
+
+  if (outcome.status === "repaired") {
+    logger.info("billing account repaired", {
+      orgId,
+      creditQuota: outcome.creditQuota,
+      creditsApplied: outcome.creditsApplied,
+    });
+  }
+  return outcome;
 }

--- a/packages/module-ee/src/onboarding/post-signup.ts
+++ b/packages/module-ee/src/onboarding/post-signup.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: LicenseRef-Appstrate-Commercial
 
-import { getEeDb } from "../db.ts";
+import { getEeDb, type EeTx } from "../db.ts";
 import { billingAccounts, freeTierClaims } from "../../drizzle/schema.ts";
 import { eq } from "drizzle-orm";
 import { getPlans } from "../config.ts";
@@ -39,9 +39,13 @@ export function normalizeEmail(email: string): string {
  * orgs (the ON CONFLICT dedups the claim row, but both accounts were already
  * credited). Deriving the grant from the insert win closes that race.
  *
- * Both writes run in ONE transaction so a claim is never consumed without the
- * matching account being created — otherwise a failure between the two would
- * burn the email's claim and leave every future org for it at 0 credits.
+ * THE CALLER OWNS THE TRANSACTION, and there must be one: a claim must never be
+ * consumed without the matching account being created, or a failure between the
+ * two burns the email's claim and leaves every future org for it at 0 credits.
+ * Taking `tx` rather than opening one lets `repair:account` provision and apply
+ * the recovered debt atomically — a repair that half-commits is worse than one
+ * that never ran, because the account it leaves behind makes the org look
+ * already repaired.
  *
  * `billingEmail` seeds the billing contact and is the address AS TYPED, not
  * `normalizedEmail`: normalization strips plus- and dot-addressing to make the
@@ -49,47 +53,41 @@ export function normalizeEmail(email: string): string {
  * the wrong one for an address a human reads.
  */
 export async function provisionBillingAccount(
+  tx: EeTx,
   orgId: string,
   normalizedEmail: string,
   billingEmail: string,
 ): Promise<{ freeTierGranted: boolean; creditQuota: number }> {
-  const db = getEeDb();
   const freePlan = getPlans().free;
 
-  const claim = await db.transaction(async (tx) => {
-    const [won] = await tx
-      .insert(freeTierClaims)
-      .values({ email: normalizedEmail })
-      .onConflictDoNothing({ target: freeTierClaims.email })
-      .returning({ email: freeTierClaims.email });
+  const [won] = await tx
+    .insert(freeTierClaims)
+    .values({ email: normalizedEmail })
+    .onConflictDoNothing({ target: freeTierClaims.email })
+    .returning({ email: freeTierClaims.email });
 
-    await tx
-      .insert(billingAccounts)
-      .values({
-        orgId,
-        planId: "free",
-        creditsUsed: 0,
-        creditQuota: won ? freePlan.creditQuota : 0,
-        periodEnd: null, // Non-renewable, no reset
-        billingEmail,
-      })
-      .onConflictDoNothing({ target: billingAccounts.orgId });
-
-    return won ?? null;
-  });
+  await tx
+    .insert(billingAccounts)
+    .values({
+      orgId,
+      planId: "free",
+      creditsUsed: 0,
+      creditQuota: won ? freePlan.creditQuota : 0,
+      periodEnd: null, // Non-renewable, no reset
+      billingEmail,
+    })
+    .onConflictDoNothing({ target: billingAccounts.orgId });
 
   return {
-    freeTierGranted: claim !== null,
-    creditQuota: claim ? freePlan.creditQuota : 0,
+    freeTierGranted: won !== undefined,
+    creditQuota: won ? freePlan.creditQuota : 0,
   };
 }
 
 export async function onOrgCreate(orgId: string, userEmail: string): Promise<void> {
   const normalized = normalizeEmail(userEmail);
-  const { freeTierGranted, creditQuota } = await provisionBillingAccount(
-    orgId,
-    normalized,
-    userEmail,
+  const { freeTierGranted, creditQuota } = await getEeDb().transaction((tx) =>
+    provisionBillingAccount(tx, orgId, normalized, userEmail),
   );
 
   if (freeTierGranted) {

--- a/packages/module-ee/test/integration/services/repair-account.test.ts
+++ b/packages/module-ee/test/integration/services/repair-account.test.ts
@@ -97,6 +97,32 @@ describe("repairBillingAccount", () => {
     expect((await account())!.creditsUsed).toBe(42);
   });
 
+  it("leaves no trace when it is interrupted after the provision, so a re-run still repairs", async () => {
+    // The two statements used to commit separately: an interruption between them
+    // (Ctrl-C, a pool blip, a pod eviction) left the account provisioned with the
+    // debt unapplied, and the guard above then refused every re-run — writing the
+    // org's whole debt off while claiming there was nothing to repair.
+    await seedBillingCursor(0);
+    seedLlmUsage({ orgId, costUsd: 0.05, contextId: "run-1" }); // 50 credits
+    await runBillingSweep();
+    expect(await account()).toBeNull();
+
+    await expect(
+      repairBillingAccount(orgId, "owner@example.com", {
+        onBeforeCommit: () => Promise.reject(new Error("interrupted")),
+      }),
+    ).rejects.toThrow("interrupted");
+
+    expect(await account()).toBeNull();
+
+    // A re-run completes the repair, and `creditQuota` proves the rolled-back
+    // attempt did not burn the email's non-renewable free-tier claim either.
+    const outcome = await repairBillingAccount(orgId, "owner@example.com");
+
+    expect(outcome).toMatchObject({ status: "repaired", creditQuota: 5000, creditsApplied: 50 });
+    expect((await account())!.creditsUsed).toBe(50);
+  });
+
   it("leaves the org billable again — the next sweep debits it normally", async () => {
     await seedBillingCursor(0);
     seedLlmUsage({ orgId, costUsd: 0.05, contextId: "run-1" });


### PR DESCRIPTION
Closes #1329

## Root cause

`packages/module-ee/src/billing/repair-account.ts` ran the repair as two
independent commits: `provisionBillingAccount(...)` (which opened its own
transaction) and then an `UPDATE ee_billing_accounts SET credits_used =
SUM(ee_usage_records.cost_credits)`. An interruption between them (Ctrl-C, a
pool blip, a pod eviction) left the account provisioned with the debt
unapplied, and the existence guard at the top of the function then returned
`already_provisioned` on every re-run — the org's whole orphaned debt written
off silently, by the one tool meant to recover it.

## Fix

The guard, the provision and the debt now run in **one** transaction, so a
repair either lands whole or leaves no trace. To compose them,
`provisionBillingAccount` takes the caller's `EeTx` instead of opening a
transaction of its own; `onOrgCreate` opens one, so the free-tier claim and the
account insert still commit together exactly as before. That is the whole
refactor — one signature, two call sites, no duplicated claim logic.

**The guard deliberately stays keyed on the account's existence**, not on a
`credits_used` shortfall as the issue suggested. The two states are
indistinguishable: `customer.subscription.deleted` downgrades an account to
free with `credits_used = 0`, `period_end = NULL` and
`stripe_subscription_id = NULL` (`src/stripe/webhooks.ts:560-580`) while its
historical usage records survive — byte for byte the signature of "provisioned,
debt not applied". A shortfall-keyed guard would re-charge such an org for
everything it ever spent. With the transaction above, existence is not just the
only safe test but a sufficient one: the partial state is unreachable. The
reasoning is written into the module docblock so it is not re-litigated.

## Tests

`packages/module-ee/test/integration/services/repair-account.test.ts` — one new
case: an interrupted repair (a throwing `onBeforeCommit` seam, the same idiom
`sweepLedgerBatch` already uses) leaves **no** account behind, and a re-run
repairs fully. The re-run's `creditQuota` of 5000 also pins that the rolled-back
attempt did not burn the email's non-renewable free-tier claim.

Negative control: reverting only the atomicity (provisioning in a nested
transaction of its own) makes the new case fail with an account at
`credits_used: 0, credit_quota: 5000` — exactly the state the issue describes.

```
bun test packages/module-ee/test                     → 445 pass, 26 skip, 0 fail
bun test .../repair-account.test.ts                  → 6 pass, 0 fail
bunx tsc --noEmit -p packages/module-ee              → clean
bunx eslint + prettier on the 3 touched files        → clean
```

## Notes for the orchestrator

- No migration, no env var, no OpenAPI surface touched. `repair:account`'s CLI
  contract and its `RepairOutcome` union are unchanged.
- Overlap with siblings: none. The EE sweeper chain (#1326/#1328/#1330/#1370)
  never touches `repair-account.ts` or `post-signup.ts`; #1327 is catalog
  re-pricing.
- **Test-environment caveat, not a code caveat**: the Docker daemon is down on
  this host (OrbStack's VM panics — its macOS Group Container directory is
  missing/unwritable), so the shared compose Postgres was unavailable. The
  suites above were run against a locally started PostgreSQL 17.6 on :5433 and
  Redis on :6380 matching `docker-compose.test.yml`, under the fleet's
  `pg-test-lock.sh`. Worth a re-run on the consolidated branch once Docker is
  back.
- Residual, pre-existing and out of scope: a sweep pass committing a usage
  record for the same org in the window between the repair's `SUM` read and its
  commit would still leave that increment un-applied, since the repair's guard
  refuses afterwards. Closing it needs the sweeper to take a lock the repair can
  also take — a change to the sweeper, not to this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
