### PR TITLE
fix(auth): renew the distributed lock while the critical section runs

### DIFF
--- a/apps/api/src/lib/deduped-refresh.ts
+++ b/apps/api/src/lib/deduped-refresh.ts
@@ -32,20 +32,31 @@
 
 import { withRedisLock } from "./distributed-lock.ts";
 
-/** Distributed-lock TTL in seconds — sized as `30s network timeout` + slack. */
+/**
+ * Distributed-lock lease in seconds — sized as `30s network timeout` + slack.
+ * A watchdog renews it while the exchange runs, so this is not a cap on the
+ * critical section: it is how long a CRASHED holder's lock lingers before a
+ * peer can reclaim it.
+ */
 const REFRESH_LOCK_TTL_SECONDS = 45;
 /**
- * How long to wait for the distributed lock before proceeding unlocked.
- * Derived from the TTL so the two cannot drift apart: a waiter gives up only
- * once the holder's lock has definitively expired (holder presumed dead),
- * never at the holder's worst-case exchange duration. Trade-off: a sidecar
- * caller queued behind a wedged holder waits up to ~50 s before proceeding,
- * plus the 30 s exchange timeout in `@appstrate/connect`. A forced caller that
- * arrives while a proactive flight is already exchanging pays that once, not
- * once per hop — it adopts that exchange's token rather than queueing a second
- * one behind it (see {@link dedupedRefresh}).
+ * Hard cap on how long the lock watchdog keeps renewing. Two full exchange
+ * timeouts past the lease: a holder still running then is not slow, it is
+ * wedged, and must stop renewing so the credential's refresh is not deadlocked
+ * for every other instance.
+ *
+ * `withRedisLock` derives the waiter's give-up point from this (the waiter
+ * polls until the holder's lease is guaranteed gone), so the two cannot drift
+ * apart. Trade-off: a caller queued behind a wedged holder waits up to
+ * ~2.5 min before proceeding unlocked, plus the 30 s exchange timeout in
+ * `@appstrate/connect`. Waiting is the cheaper failure — proceeding early
+ * double-spends the rotating `refresh_token` and flags a valid credential
+ * `needsReconnection`. A forced caller that arrives while a proactive flight
+ * is already exchanging pays that once, not once per hop — it adopts that
+ * exchange's token rather than queueing a second one behind it (see
+ * {@link dedupedRefresh}).
  */
-const REFRESH_LOCK_ACQUIRE_TIMEOUT_MS = REFRESH_LOCK_TTL_SECONDS * 1_000 + 5_000;
+const REFRESH_LOCK_MAX_HOLD_SECONDS = 90;
 
 interface DedupedRefreshOptions<T> {
   /** Redis lock key (e.g. `oauth-refresh:${id}` / `intg-refresh:${id}`). */
@@ -138,7 +149,7 @@ export function dedupedRefresh<T>(key: string, opts: DedupedRefreshOptions<T>): 
       opts.lockKey,
       {
         ttlSeconds: REFRESH_LOCK_TTL_SECONDS,
-        acquireTimeoutMs: REFRESH_LOCK_ACQUIRE_TIMEOUT_MS,
+        maxHoldSeconds: REFRESH_LOCK_MAX_HOLD_SECONDS,
         label: opts.lockLabel,
       },
       async (): Promise<FlightOutcome<T>> => {

--- a/apps/api/src/lib/distributed-lock.ts
+++ b/apps/api/src/lib/distributed-lock.ts
@@ -35,22 +35,120 @@ else
 end
 `;
 
+/**
+ * Lua for safe renewal: only push the expiry out while the value is still our
+ * lock-id. A holder whose lease already lapsed must NOT resurrect it — the key
+ * may belong to the instance that took over.
+ */
+const RENEW_LOCK_SCRIPT = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+else
+  return 0
+end
+`;
+
+/**
+ * Renewals per lease. Three gives two consecutive failed renewals of headroom
+ * before the lease lapses, which is what makes a Redis hiccup survivable.
+ */
+const RENEWALS_PER_LEASE = 3;
+
+/**
+ * Polling grace past the moment a holder's lease is guaranteed gone
+ * (`maxHoldSeconds + ttlSeconds`), so a waiter ACQUIRES the reclaimed lock
+ * instead of giving up one poll short of it.
+ */
+const ACQUIRE_GRACE_MS = 5_000;
+
 interface RedisLockOptions {
-  /** Lock auto-expiry (safety net if the holder crashes without releasing). */
+  /**
+   * Lease length. Renewed by a watchdog while `fn` runs, so this is not a cap
+   * on the critical section — it is how long a CRASHED holder's lock lingers
+   * before another instance can reclaim it.
+   */
   ttlSeconds: number;
-  /** How long to keep polling for the lock before giving up and proceeding unlocked. */
-  acquireTimeoutMs: number;
-  /** Optional label for the timeout-warning log line. */
+  /**
+   * Hard cap on how long the watchdog keeps renewing. Past it the holder is
+   * not slow, it is wedged: renewal stops and the lease lapses within
+   * `ttlSeconds`, so a hung `fn` can never own the key forever. Sized by the
+   * caller from its critical section's worst legitimate duration.
+   */
+  maxHoldSeconds: number;
+  /** Optional label for the lock's log lines. */
   label?: string;
 }
 
 /**
+ * Keep the lease alive while the critical section runs.
+ *
+ * Without this, a section that outlives `ttlSeconds` — an upstream exchange
+ * plus a DB read under pressure — silently loses its lock to a waiter and the
+ * two run concurrently, which for a rotating `refresh_token` means both spend
+ * it and the loser writes a dead one.
+ *
+ * Renewal is capped (`maxHoldSeconds`) rather than unbounded: a hung holder
+ * renewing forever would deadlock the key for every other instance.
+ *
+ * Returns the stop function; calling it is mandatory (the `finally` below).
+ */
+function startLeaseWatchdog(
+  renew: () => Promise<boolean>,
+  opts: RedisLockOptions & { onLapse: (reason: string) => void },
+): () => void {
+  const intervalMs = Math.max(1, Math.floor((opts.ttlSeconds * 1_000) / RENEWALS_PER_LEASE));
+  const stopRenewingAt = Date.now() + opts.maxHoldSeconds * 1_000;
+  let stopped = false;
+  let timer = setTimeout(runTick, intervalMs);
+
+  /** `setTimeout` wants a void callback; the tick is async and self-scheduling. */
+  function runTick(): void {
+    void tick();
+  }
+
+  async function tick(): Promise<void> {
+    if (stopped) return;
+    if (Date.now() >= stopRenewingAt) {
+      opts.onLapse("max hold reached");
+      return;
+    }
+    let held = true;
+    try {
+      held = await renew();
+    } catch (err) {
+      // Transient Redis failure: keep trying — two more renewals fit inside
+      // the remaining lease.
+      logger.warn("distributed lock renewal failed", {
+        key: opts.label,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    if (!held) {
+      opts.onLapse("lease already lost");
+      return;
+    }
+    if (!stopped) timer = setTimeout(runTick, intervalMs);
+  }
+
+  return () => {
+    stopped = true;
+    clearTimeout(timer);
+  };
+}
+
+/**
  * Run `fn` while holding the Redis lock `key`. When Redis is absent the lock
- * is a no-op and `fn` runs directly. If the lock can't be acquired within
- * `acquireTimeoutMs`, logs a warning and runs `fn` anyway (availability over
- * strict mutual exclusion — the caller's per-key in-process serialization
- * still bounds the blast radius, and the TTL guarantees the lock can't wedge
- * forever).
+ * is a no-op and `fn` runs directly.
+ *
+ * The lease is renewed for as long as `fn` runs, up to `maxHoldSeconds`. A
+ * waiter therefore polls until the holder's lease is guaranteed gone
+ * (`maxHoldSeconds + ttlSeconds`, i.e. the holder stopped renewing AND the
+ * last lease expired) before giving up; giving up any earlier would hand a
+ * live holder's critical section a concurrent peer, which is the very thing
+ * the lock exists to prevent. Past that point the holder is presumed dead and
+ * `fn` runs unlocked with a warning (availability over strict mutual
+ * exclusion — the caller's per-key in-process serialization still bounds the
+ * blast radius).
  */
 export async function withRedisLock<T>(
   key: string,
@@ -61,7 +159,7 @@ export async function withRedisLock<T>(
 
   const redis = getRedisConnection();
   const lockId = randomBytes(16).toString("hex");
-  const deadline = Date.now() + opts.acquireTimeoutMs;
+  const deadline = Date.now() + (opts.maxHoldSeconds + opts.ttlSeconds) * 1_000 + ACQUIRE_GRACE_MS;
   let acquired = false;
 
   while (Date.now() < deadline) {
@@ -81,9 +179,24 @@ export async function withRedisLock<T>(
     return fn();
   }
 
+  const stopWatchdog = startLeaseWatchdog(
+    async () =>
+      (await redis.eval(RENEW_LOCK_SCRIPT, 1, key, lockId, String(opts.ttlSeconds * 1_000))) === 1,
+    {
+      ...opts,
+      label: opts.label ?? key,
+      onLapse: (reason) =>
+        logger.warn("distributed lock lease lapsed while the critical section was running", {
+          key: opts.label ?? key,
+          reason,
+        }),
+    },
+  );
+
   try {
     return await fn();
   } finally {
+    stopWatchdog();
     // Best-effort release. If the EVAL fails (Redis hiccup), the TTL ensures
     // the lock auto-expires within ttlSeconds.
     try {

--- a/apps/api/test/unit/distributed-lock.test.ts
+++ b/apps/api/test/unit/distributed-lock.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression tests for {@link withRedisLock}'s lease watchdog.
+ *
+ * The lock used to be a plain `SET … EX ttl NX` with no renewal: a critical
+ * section slower than the TTL (an OAuth exchange plus a DB read under
+ * pressure) silently lost the lock to a waiter, and the two then spent the
+ * same rotating `refresh_token` — exactly the double-spend the lock exists to
+ * prevent.
+ *
+ * These need a real Redis (the Lua compare-and-PEXPIRE and key expiry are the
+ * behaviour under test), so they skip on tier 0.
+ */
+
+import { it, expect, afterAll } from "bun:test";
+import Redis from "ioredis";
+import { describeRequiresRedis } from "../helpers/tier.ts";
+import { withRedisLock } from "../../src/lib/distributed-lock.ts";
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describeRequiresRedis("withRedisLock lease watchdog", () => {
+  const redis = new Redis(process.env.REDIS_URL as string, { maxRetriesPerRequest: 3 });
+  const keys: string[] = [];
+
+  function uniqueKey(name: string): string {
+    const key = `test-lock:${name}:${Date.now()}`;
+    keys.push(key);
+    return key;
+  }
+
+  afterAll(async () => {
+    if (keys.length > 0) await redis.del(...keys);
+    await redis.quit();
+  });
+
+  it("renews the lease so a critical section outliving the TTL keeps the lock", async () => {
+    const key = uniqueKey("renewed");
+    const opts = { ttlSeconds: 1, maxHoldSeconds: 10, label: "test-renewed" };
+    const events: string[] = [];
+
+    const holder = withRedisLock(key, opts, async () => {
+      events.push("holder:enter");
+      // 2.5x the TTL: without renewal the lease lapses mid-section.
+      await sleep(2_500);
+      events.push("holder:exit");
+    });
+
+    // Let the holder acquire before the waiter starts polling.
+    await sleep(100);
+    const waiter = withRedisLock(key, opts, async () => {
+      events.push("waiter:enter");
+    });
+
+    await Promise.all([holder, waiter]);
+
+    expect(events).toEqual(["holder:enter", "holder:exit", "waiter:enter"]);
+  }, 15_000);
+
+  it("stops renewing past maxHoldSeconds so a wedged holder cannot own the key forever", async () => {
+    const key = uniqueKey("capped");
+    let existsAfterCap = -1;
+
+    await withRedisLock(
+      key,
+      { ttlSeconds: 1, maxHoldSeconds: 1, label: "test-capped" },
+      async () => {
+        // Renewals stop at ~1s and the last lease expires ~1s later.
+        await sleep(2_600);
+        existsAfterCap = await redis.exists(key);
+        await sleep(200);
+      },
+    );
+
+    expect(existsAfterCap).toBe(0);
+  }, 15_000);
+});


### PR DESCRIPTION
Closes #1366

## Root cause

`apps/api/src/lib/distributed-lock.ts` acquired with `SET … EX ttl NX` and never renewed. A critical section slower than the 45 s TTL — the upstream exchange plus `reReadFreshness`'s DB read under pressure — lost its lock mid-flight; the waiter (polling at 100 ms) then acquired and ran `doRefresh()` concurrently. Both spend the rotating `refresh_token`, the loser writes a dead one, and a valid credential is flagged `needsReconnection`.

Renewal alone would not have closed it: the waiter's `acquireTimeoutMs` was derived as `ttl + 5 s` precisely because the holder's lease "definitively expired" at the TTL. With renewal that premise is false — the waiter would have given up at 50 s and run **unlocked**, double-spending anyway.

## Fix

`distributed-lock.ts` (+96/−22):

- `startLeaseWatchdog` renews the lease every `ttl/3` through a compare-and-PEXPIRE Lua script (same `lockId` guard as the release script, so a lapsed holder can never resurrect the new owner's key). A transient Redis error retries on the next tick — two more renewals fit inside the remaining lease; a renewal that returns 0 means the lease is already gone and the watchdog stops with a warning.
- Renewal is **capped** by a new `maxHoldSeconds` option. Past it the holder is not slow, it is wedged: renewal stops, the lease lapses within `ttlSeconds`, and a hung `fn` can never deadlock the key. Redisson-style unbounded renewal was rejected for exactly that reason.
- `acquireTimeoutMs` is **removed from the options** and derived inside the lock as `(maxHoldSeconds + ttlSeconds) * 1000 + 5 s` — the point at which the holder's lease is guaranteed gone. The invariant "a waiter gives up only once the holder is presumed dead" is now structural instead of a formula duplicated in a caller's comment.

`deduped-refresh.ts` (+21/−13, comments and constants only): `REFRESH_LOCK_MAX_HOLD_SECONDS = 90` (two full 30 s exchange timeouts past the 45 s lease) replaces `REFRESH_LOCK_ACQUIRE_TIMEOUT_MS`.

**Behaviour change worth knowing:** a caller queued behind a genuinely wedged holder now waits up to ~2 min 20 s (was ~50 s) before proceeding unlocked. That is the deliberate trade: waiting yields a slow request, proceeding early yields a broken credential the user must reconnect by hand. In the normal case (holder releases in well under a second) nothing changes.

## Tests

`apps/api/test/unit/distributed-lock.test.ts` (new, `describeRequiresRedis` — the Lua and key expiry are the behaviour under test, so it skips on tier 0 and runs in CI tier 3):

- *renews the lease so a critical section outliving the TTL keeps the lock* — `ttl: 1 s`, holder holds 2.5 s; the waiter must enter only after the holder exits.
- *stops renewing past `maxHoldSeconds`* — `ttl: 1 s`, `maxHold: 1 s`; the key is gone while `fn` is still running.

Commands run:

- Real Redis (local `redis-server --port 6399`, run from `apps/api` so the tier-3 preload's Docker Postgres is not needed): `REDIS_URL=redis://127.0.0.1:6399 bun test test/unit/distributed-lock.test.ts` → **2 pass, 0 fail**.
- Negative control: with the watchdog stubbed out, test 1 fails with `["holder:enter", "waiter:enter", "holder:exit"]` — the concurrent critical section the issue describes. Restored and re-run green.
- `set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/unit/deduped-refresh.test.ts apps/api/test/unit/distributed-lock.test.ts` → **9 pass, 3 skip, 0 fail** (the Redis suite skips on tier 0 as designed; #1365's suite unaffected).
- `bunx tsc --noEmit -p apps/api` → clean. `bunx eslint` + `bunx prettier --write` on the three touched files → clean.

## Notes for the orchestrator

- Based on `fix/issue-1365`; the only shared file is `deduped-refresh.ts`, and this PR touches just its two lock constants plus their doc comments — no overlap with #1365's flight-outcome logic.
- No migration, no env var, no OpenAPI change. Nothing to order at deploy: the lock key format and TTL are unchanged, so an old and a new instance interoperate (the old one simply does not renew).
- `withRedisLock` has exactly one caller (`dedupedRefresh`), so dropping `acquireTimeoutMs` from its options breaks nothing else.
- The new test only executes where a real Redis is configured — it runs in CI, and is a no-op in a tier-0 gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
