### PR TITLE
fix(schedules): gate a schedule's run list on the run-read permission

### DIFF
--- a/apps/api/src/openapi/paths/schedules.ts
+++ b/apps/api/src/openapi/paths/schedules.ts
@@ -391,7 +391,8 @@ export const schedulesPaths = {
       operationId: "listScheduleRuns",
       tags: ["Schedules"],
       summary: "List runs for a schedule",
-      description: "List recent runs triggered by a specific schedule.",
+      description:
+        "List recent runs triggered by a specific schedule. Takes `schedules:read` AND a run read permission: the rows are runs, so `runs:read` lists the ones the caller launched — including the runs of the caller's own schedules — and `runs:read-all` the whole space. A credential holding `schedules:read` alone is rejected with 403.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XSpaceId" },

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -43,7 +43,7 @@ import { resolveAgentRunVersion } from "../services/agent-version-resolver.ts";
 import type { LoadedPackage } from "../types/index.ts";
 import { asJSONSchemaObject, schemaHasFileFields } from "@appstrate/core/form";
 import { listScheduleRuns } from "../services/state/runs.ts";
-import { runVisibilityFilter } from "../lib/run-visibility.ts";
+import { requireRunsRead, runVisibilityFilter } from "../lib/run-visibility.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
 import { setOffsetLinkHeader } from "../lib/pagination-link.ts";
 import { listResponse } from "../lib/list-response.ts";
@@ -570,22 +570,32 @@ export function createSchedulesRouter() {
   });
 
   // GET /api/schedules/:id/runs — list runs for a schedule
-  router.get("/schedules/:id/runs", requirePermission("schedules", "read"), async (c) => {
-    const scheduleId = c.req.param("id")!;
-    const scope = getSpaceScope(c);
-    const { limit, offset } = parseListPagination(c, { defaultLimit: 20 });
-    // `schedules:read` is space-wide, so the schedule itself is readable to
-    // every member — but its RUNS are runs, and follow the run predicate:
-    // without `runs:read-all` a colleague's schedule lists nothing.
-    const result = await listScheduleRuns(scope, scheduleId, {
-      limit,
-      offset,
-      actor: getActor(c),
-      visibility: runVisibilityFilter(c),
-    });
-    setOffsetLinkHeader({ c, limit, offset, total: result.total });
-    return c.json(result);
-  });
+  // Two permissions, because the response is two resources: the schedule
+  // names the rows, but every field of them is a run. `schedules:read` alone
+  // is a legal, grantable scope set, so without the run gate a credential with
+  // no run permission at all reads the full enriched run projection — input,
+  // result, checkpoint, error, context snapshot, cost.
+  router.get(
+    "/schedules/:id/runs",
+    requirePermission("schedules", "read"),
+    requireRunsRead,
+    async (c) => {
+      const scheduleId = c.req.param("id")!;
+      const scope = getSpaceScope(c);
+      const { limit, offset } = parseListPagination(c, { defaultLimit: 20 });
+      // `schedules:read` is space-wide, so the schedule itself is readable to
+      // every member — but its RUNS are runs, and follow the run predicate:
+      // without `runs:read-all` a colleague's schedule lists nothing.
+      const result = await listScheduleRuns(scope, scheduleId, {
+        limit,
+        offset,
+        actor: getActor(c),
+        visibility: runVisibilityFilter(c),
+      });
+      setOffsetLinkHeader({ c, limit, offset, total: result.total });
+      return c.json(result);
+    },
+  );
 
   return router;
 }

--- a/apps/api/test/integration/routes/runs-schedules-read-permissions.test.ts
+++ b/apps/api/test/integration/routes/runs-schedules-read-permissions.test.ts
@@ -169,6 +169,31 @@ describe("run + schedule GET routes — read permission", () => {
     }
   });
 
+  it("403s a schedule's run list for a key holding the schedule scope but no run scope", async () => {
+    // The rows this route returns are runs — the full enriched projection
+    // (input, result, checkpoint, error, context snapshot, cost) — so the
+    // credential ceiling that caps `GET /api/runs` caps it too. `schedules:read`
+    // alone is a legal, grantable scope set, and it used to read every run of
+    // every schedule in the space while `GET /api/runs` answered 403 to the
+    // very same key.
+    const key = await seedApiKey({
+      orgId: ctx.orgId,
+      spaceId: ctx.defaultSpaceId,
+      createdBy: ctx.user.id,
+      scopes: ["schedules:read"],
+    });
+    const headers = { Authorization: `Bearer ${key.rawKey}` };
+
+    const runList = await app.request(`/api/schedules/${scheduleId}/runs`, { headers });
+    expect(runList.status).toBe(403);
+    expect((await app.request("/api/runs", { headers })).status).toBe(403);
+
+    // The control: the schedule surfaces the scope actually names stay open —
+    // only the run list moved behind the run gate.
+    expect((await app.request("/api/schedules", { headers })).status).toBe(200);
+    expect((await app.request(`/api/schedules/${scheduleId}`, { headers })).status).toBe(200);
+  });
+
   it("keeps org-role sessions unaffected (every role carries both read scopes)", async () => {
     for (const route of readRoutes()) {
       const res = await app.request(route.path, { headers: authHeaders(ctx) });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -4159,7 +4159,7 @@ export interface paths {
         };
         /**
          * List runs for a schedule
-         * @description List recent runs triggered by a specific schedule.
+         * @description List recent runs triggered by a specific schedule. Takes `schedules:read` AND a run read permission: the rows are runs, so `runs:read` lists the ones the caller launched — including the runs of the caller's own schedules — and `runs:read-all` the whole space. A credential holding `schedules:read` alone is rejected with 403.
          */
         get: operations["listScheduleRuns"];
         put?: never;


### PR DESCRIPTION
Closes #1336

## Root cause

`GET /api/schedules/:id/runs` was guarded on `requirePermission("schedules", "read")` alone (`apps/api/src/routes/schedules.ts:573` on `main`). Every other run-list surface moved to `requireRunsRead` with the `runs:read` / `runs:read-all` split in #1307; this one did not. `schedules:read` is a grantable API-key scope on its own (`apps/api/src/lib/permissions.ts:276`), so a credential holding it and no run scope at all read the full `enrichedRunColumns` projection — `input`, `result`, `checkpoint`, `error`, `metadata`, `context_snapshot`, `resolved_connections`, `cost`, `token_usage` — off this route while `GET /api/runs` answered 403 to the very same key.

Rows were already narrowed by `runVisibilityFilter`, so this is a credential-ceiling bypass, not a cross-principal leak.

## Fix

Stack `requireRunsRead` after the schedule guard on that one route — the same composition the bulk delete already uses for its two permissions (`routes/runs.ts:830-835`), and the disjunction `lib/run-visibility.ts:58` documents as "the guard on every surface `runs:read` opens". The OpenAPI description now states the two-permission contract.

**Why not the `visibility`-required refactor** (`services/state/runs.ts`, left open by #1335): it would not have caught this bug — the route *did* pass `visibility`, and the row narrowing was correct. What was missing is a permission guard, one layer up. The premise that all callers pass `visibility` also does not hold: `getRunFull` is deliberately called without it on three write-path read-backs (`routes/runs.ts:376`, `:649`, `:762` — a run the caller just launched or cancelled), and `getRunningRunsForPackage` on two mutation guards (`middleware/guards.ts:120`, `routes/packages.ts:1134`) where the documented rule is that "is this agent busy" is about the agent, not about who is watching. Making the parameter required would only add `undefined` at those five call sites. Left alone.

Also left alone: `GET /api/schedules` and `GET /api/schedules/:id`. Their run-derived fields are counters only (`running_runs`, `unread_count`, `last_run_number` — `services/scheduler.ts:815`), already scoped by `runVisibilityFilter`, and they are schedule-card metadata rather than the run projection. Gating them on `runs:read` would break a legitimate schedules-only credential.

## Tests

`apps/api/test/integration/routes/runs-schedules-read-permissions.test.ts` — the file that already owns the credential-ceiling matrix for these routes. New case: a key scoped `["schedules:read"]` gets 403 on `/api/schedules/{id}/runs` and on `/api/runs`, while `/api/schedules` and `/api/schedules/{id}` stay 200 — the control that pins the split rather than a blanket denial. Its existing `keyWithReads` (`runs:read` + `schedules:read`) still gets 200 on all eight routes.

Negative control: with `requireRunsRead` removed, the new case fails with `Expected: 403 / Received: 200`.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test \
  apps/api/test/integration/routes/runs-schedules-read-permissions.test.ts \
  apps/api/test/integration/routes/runs-read-isolation.test.ts \
  apps/api/test/integration/routes/schedules.test.ts \
  apps/api/test/integration/routes/schedules-run-stats.test.ts
→ 81 pass, 0 fail (274 expect() calls)

bunx tsc --noEmit -p apps/api   → clean
bun run verify:openapi          → ALL CHECKS PASSED
bun run verify:api-types        → up to date (after `bun run generate:api`)
bun run detect:breaking         → 0 breaking, 0 non-breaking
```

## Notes for the orchestrator

- Based on `fix/issue-1335` (PR targets that branch, not `main`). The one shared file is `apps/api/test/integration/routes/runs-read-isolation.test.ts`, which #1335 edits and this PR leaves untouched — no overlap.
- No migration, no env var.
- `apps/web/src/api/schema.d.ts` is regenerated output (one description line); the OpenAPI baseline is unchanged, so no `openapi:baseline` run.
- Behaviour change for any existing API key minted with `schedules:read` and no run scope: this route now 403s. That is the point of the fix, but it is worth a CHANGELOG line at release time alongside the other #1307 follow-ups.
- Siblings #1339 (MCP `run_and_wait`) and #1341 (`requireAgent` ordering) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
