### PR TITLE
fix(db): bound NOTIFY payload text in bytes, not characters

### DIFF
--- a/apps/api/test/integration/services/notify-triggers.test.ts
+++ b/apps/api/test/integration/services/notify-triggers.test.ts
@@ -250,6 +250,73 @@ describe("NOTIFY triggers (regression)", () => {
     expect(received[1]).toMatchObject({ message: "large data", data: "[payload too large]" });
   });
 
+  // `left()` counts CHARACTERS while pg_notify's ceiling is BYTES: a 2 000-
+  // character emoji log line is 8 000 bytes on its own. The trigger used to cap
+  // with `LEFT(NEW.message, 2000)`, so such a line made pg_notify raise INSIDE
+  // the trigger and the agent lost the run_logs ROW, not just the live frame.
+  it("notify_run_log_insert keeps a multibyte log line and trims it by bytes", async () => {
+    const run = await seedRun({
+      packageId: "@notifyorg/trigger-agent",
+      orgId: ctx.orgId,
+      spaceId: ctx.defaultSpaceId,
+      userId: ctx.user.id,
+      status: "running",
+    });
+
+    const received: Array<Record<string, unknown>> = [];
+    await listenClient.listen("run_log_insert", (raw) => {
+      try {
+        const payload = JSON.parse(raw) as Record<string, unknown>;
+        if (payload.run_id === run.id) received.push(payload);
+      } catch {
+        /* ignore */
+      }
+    });
+
+    // 400 × 3 bytes = 1 200 bytes — inside the 2 000-byte message budget.
+    const fits = "漢".repeat(400);
+    // 2 000 × 4 bytes = 8 000 bytes — over the whole NOTIFY ceiling by itself.
+    const overflows = "😀".repeat(2_000);
+
+    // Both `seedRunLog` calls RETURNING the row is half the assertion: a
+    // trigger that raises aborts the INSERT, so the second one used to throw
+    // `payload string too long` here.
+    await seedRunLog({ runId: run.id, orgId: ctx.orgId, event: "fits", message: fits });
+    await seedRunLog({ runId: run.id, orgId: ctx.orgId, event: "overflows", message: overflows });
+    for (let i = 0; i < 40 && received.length < 2; i++) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+
+    expect(received).toHaveLength(2);
+    // Under budget → delivered verbatim; the budget is bytes, not a blanket
+    // character cap that would mangle CJK that comfortably fits.
+    expect(received[0]).toMatchObject({ event: "fits", message: fits });
+
+    // Over budget → trimmed on whole code points, never mid-character.
+    const trimmed = received[1]!.message as string;
+    const bytes = new TextEncoder().encode(trimmed).length;
+    expect(bytes).toBeLessThanOrEqual(2_000);
+    expect(bytes).toBeGreaterThan(1_900);
+    expect(trimmed).toBe("😀".repeat(bytes / 4));
+  });
+
+  // Same defect, worse blast radius: `notify_run_change` interpolates
+  // `runs.error`, and it fires on the finalize UPDATE. A raise there rolls the
+  // finalize back and leaves the run stuck in 'running' forever.
+  it("notify_run_change survives a multibyte run error", async () => {
+    const run = await seedRun({
+      packageId: "@notifyorg/trigger-agent",
+      orgId: ctx.orgId,
+      spaceId: ctx.defaultSpaceId,
+      userId: ctx.user.id,
+      status: "running",
+    });
+
+    await db.execute(
+      sql`UPDATE runs SET status = 'failed', error = ${"😀".repeat(2_000)}, completed_at = now() WHERE id = ${run.id}`,
+    );
+  });
+
   // Drives the live "Reconnection required" badge end-to-end: trigger →
   // pg_notify → LISTEN → SSE event. The actor filter on the realtime
   // subscriber is exercised separately in services/realtime tests; here we

--- a/packages/db/src/notify.ts
+++ b/packages/db/src/notify.ts
@@ -74,6 +74,36 @@ export async function notifyRunMetric(db: Db, payload: RunMetricNotifyPayload): 
  * Safe to call multiple times (uses CREATE OR REPLACE).
  */
 export async function createNotifyTriggers(db: Db): Promise<void> {
+  // Byte budget for one free-form value inside a NOTIFY payload.
+  //
+  // `pg_notify` raises above 8 000 BYTES; `left()` counts CHARACTERS, so a cap
+  // written with it bounds nothing — 2 000 emoji are 8 000 bytes. And the raw
+  // byte length is not the spend either: the value is interpolated into JSON,
+  // where a control character becomes a six-byte `\u0001`. So measure what the
+  // value actually costs — its JSON encoding — and scale the character count
+  // down by the bytes-per-character that measurement reveals.
+  //
+  // The loop is strictly decreasing (the ratio is < 1 whenever it runs) and
+  // therefore terminates; in practice one or two passes.
+  await db.execute(drizzleSql`
+    CREATE OR REPLACE FUNCTION notify_text_budget(_value text, _max_bytes int)
+    RETURNS text AS $$
+    DECLARE
+      _bytes int;
+    BEGIN
+      IF _value IS NULL THEN
+        RETURN NULL;
+      END IF;
+      LOOP
+        _bytes := octet_length(to_json(_value)::text);
+        EXIT WHEN _bytes <= _max_bytes OR _value = '';
+        _value := left(_value, (length(_value) * _max_bytes) / _bytes);
+      END LOOP;
+      RETURN _value;
+    END;
+    $$ LANGUAGE plpgsql STABLE
+  `);
+
   // Trigger function for run changes
   await db.execute(drizzleSql`
     CREATE OR REPLACE FUNCTION notify_run_change()
@@ -90,10 +120,11 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
         'space_id', NEW.space_id,
         'schedule_id', NEW.schedule_id,
         -- Bound the error text: the whole NOTIFY payload must stay under
-        -- Postgres' 8 KB limit, else pg_notify raises and aborts the
-        -- finalize transaction — orphaning the run in 'running'. 2 KB is
-        -- ample for a surfaced error message; the full text lives in run_logs.
-        'error', LEFT(NEW.error, 2000),
+        -- Postgres' 8 000-BYTE limit, else pg_notify raises and aborts the
+        -- finalize transaction — orphaning the run in 'running'. 2 000 bytes
+        -- is ample for a surfaced error message; the full text lives in
+        -- run_logs. Every other value here is an id, an enum or a timestamp.
+        'error', notify_text_budget(NEW.error, 2000),
         'started_at', to_char(NEW.started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
         'completed_at', to_char(NEW.completed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
         'duration', NEW.duration
@@ -125,15 +156,17 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
         'space_id', _space_id,
         'user_id', _user_id,
         'end_user_id', _end_user_id,
-        'type', NEW.type,
-        'level', NEW.level,
-        'event', NEW.event,
-        -- Payload budget: pg_notify raises above 8 000 bytes, and it raises
+        -- Payload budget: pg_notify raises above 8 000 BYTES, and it raises
         -- INSIDE this trigger, so an over-long frame aborts the run_logs INSERT
-        -- rather than merely losing a frame. The two caps below (2 000 for the
-        -- message, 5 000 for the data) plus the fixed keys, the two ids and the
-        -- two actor columns stay under that ceiling with room to spare.
-        'message', LEFT(NEW.message, 2000),
+        -- rather than merely losing a frame. Every free-form column is bounded
+        -- in bytes: message carries agent output, and type / event are
+        -- open-ended by design (modules invent their own progress kinds).
+        -- 100 + 400 + 2 000 plus the 5 000-byte data cap, the fixed keys, the
+        -- ids, the two actor columns and the timestamp stay under the ceiling.
+        'type', notify_text_budget(NEW.type, 100),
+        'level', NEW.level,
+        'event', notify_text_budget(NEW.event, 400),
+        'message', notify_text_budget(NEW.message, 2000),
         'data', CASE
           WHEN NEW.data IS NULL THEN NULL
           WHEN octet_length(NEW.data::text) <= 5000 THEN NEW.data
@@ -169,7 +202,7 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
   // one the previous write already delivered — the fan-out is unchanged for
   // every payload-visible transition (status, error, timestamps, duration,
   // ownership, scheduling). `error` is compared in full even though the
-  // payload truncates it to 2 000 chars: comparing the untruncated value can
+  // payload truncates it to 2 000 bytes: comparing the untruncated value can
   // only make the guard fire MORE often, never less.
   //
   // Columns deliberately NOT in the list (a write touching only these no


### PR DESCRIPTION
Closes #1340

## Root cause

`packages/db/src/notify.ts` capped the two free-form strings it interpolates into
NOTIFY payloads with `LEFT(..., 2000)` — `run_logs.message` (old line 137) and
`runs.error` (old line 93). `LEFT()` counts **characters**; `pg_notify`'s ceiling
is 8 000 **bytes**, so 2 000 emoji are 8 000 bytes and the cap bounded nothing.

The raise happens *inside* the trigger, so the consequence is not a lost frame:
an emoji- or CJK-heavy agent log line aborted the `run_logs` INSERT (the row is
gone), and the identical cap on `runs.error` rolls back the finalize UPDATE and
leaves the run orphaned in `running`.

Two columns the budget comment claimed to account for were never bounded at all:
`run_logs.type` and `run_logs.event` are free-form by design (`schema/runs.ts:432`
— "progress/event kinds modules invent freely").

## Fix

A new SQL function `notify_text_budget(_value text, _max_bytes int)`, installed
by `createNotifyTriggers()` alongside the trigger functions, trims a value until
its **JSON encoding** fits the byte budget, then rescales by the measured
bytes-per-character and re-checks. Measuring the encoding rather than
`octet_length(_value)` is deliberate: one control character costs six bytes once
escaped (`\u0001`), which the raw byte length does not see. `left()` cuts on
code points, so a multibyte value is never sliced mid-character.

The loop is strictly decreasing whenever it runs (the ratio is < 1), and exits on
`''`, so it terminates for every input including NULL and a non-positive budget —
all four exercised below.

Applied to `runs.error` (2 000 B), `run_logs.message` (2 000 B), `run_logs.event`
(400 B) and `run_logs.type` (100 B). The `data` cap was already byte-based and is
unchanged, so the existing 4 900-under / 6 000-over test still pins it.

**No migration.** These function bodies are a boot-time artifact — `CREATE OR
REPLACE` from `bootBackground()` (`apps/api/src/lib/boot.ts:248`) is the only
installer, and `0053_applications_to_spaces.sql` documents at length why the
drizzle chain must not own them. Copying the bodies into 0061 would create a
second, divergent source of truth. The reserved platform index **0061 is
therefore unused and free for another agent.**

## Tests

`apps/api/test/integration/services/notify-triggers.test.ts` — two new cases:
a 2 000-emoji `message` must keep its INSERT and arrive trimmed on whole code
points (with a 400-char CJK message alongside proving an in-budget multibyte
value is still delivered verbatim), and a 2 000-emoji `runs.error` must not roll
back the finalize UPDATE.

Commands run:

- `bunx tsc --noEmit -p packages/db` -> clean
- `bunx tsc --noEmit -p apps/api` -> clean
- `bunx eslint` + `bunx prettier --check` on both touched files -> clean
- `bun run verify:no-migration-dml` -> green (68 files, 2 trees)
- **The integration suite could not be executed here: the Docker daemon
  (OrbStack) is down on this machine and would not start, so the shared
  Postgres the suite needs is unavailable.** Instead the SQL was validated
  end-to-end on PGlite in a scratch harness that installs the helper plus the
  real `notify_run_log_insert` body verbatim:
  - negative control — the pre-fix expression
    `LEFT(repeat('emoji', 4000), 2000)` raises `payload string too long`;
  - helper termination and output on 8 inputs: 2 000 emoji -> 499 chars /
    1 996 B, 2 000 CJK -> 666 chars / 1 998 B, 5 000 ASCII -> 1 998 B,
    3 000 control chars -> 333 chars / 2 000 B *encoded*, 400 CJK -> untouched,
    `''`, `NULL`, and budget `0`;
  - worst case through a real trigger + `LISTEN`: multibyte `type`, `event` and
    `message` with `data` at the cap -> INSERT survives, payload **7 663 bytes**
    (ceiling 7 999), `message` 1 996 B and all whole emoji;
  - a 400-char CJK message round-trips byte-identical.

  The new bun:test assertions are the same predicates against the same inputs, so
  they should be green once the suite runs on the consolidated branch.

## Notes for the orchestrator

- **Reserved migration 0061 was not used** — reassign it.
- Overlap with siblings: none. The INFO-tier rolling-deploy asymmetry on this
  trigger was left alone as instructed; it is unchanged by this PR (a pod running
  the old body simply keeps the old caps until the new boot replaces them, which
  is the pre-existing behaviour).
- Scope note: the issue names only `run_log_insert`, but `notify_run_change`'s
  `LEFT(NEW.error, 2000)` is the same defect with a worse blast radius, and the
  same helper covers it in one line. Bounding `type` / `event` is what makes the
  budget comment true rather than aspirational.
- No env var, no OpenAPI change, no deploy ordering constraint: the helper is
  created before the trigger functions in the same `createNotifyTriggers()` call,
  so it always exists before a new body can reference it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
