### PR TITLE
fix(mcp): let a runs:read-all principal use run_and_wait

### DIFF
--- a/apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts
+++ b/apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts
@@ -517,4 +517,17 @@ describe("run_and_wait", () => {
     expect(parseResult(res).error).toContain("runs:read");
     expect(calls.length).toBe(0);
   });
+
+  it("launches for a caller holding only `runs:read-all`", async () => {
+    // `read-all` is a superset of `read`, not a companion to it
+    // (`lib/run-visibility.ts`), and `runs:read-all` is separately grantable to
+    // an API key. A literal `runs:read` test refused this principal before the
+    // launch even though the poll route it gates reads every run in the space.
+    const { tool, calls } = makeRunAndWait({ permissions: ["mcp:invoke", "runs:read-all"] });
+
+    const res = await tool.handler({ kind: "agent", scope: "@a", name: "b" }, noExtra);
+
+    expect(res.isError).toBeFalsy();
+    expect(calls.find((c) => c.method === "POST")).toBeDefined();
+  });
 });

--- a/apps/api/src/modules/mcp/tools.ts
+++ b/apps/api/src/modules/mcp/tools.ts
@@ -46,6 +46,7 @@ import { CONTEXT_FREE_FILENAMES_PHRASE } from "@appstrate/afps-runtime/bundle";
 import type { Actor } from "@appstrate/connect";
 import { getCatalog, collectReferencedSchemas, type CatalogOperation } from "./catalog.ts";
 import { internalDispatchHeader } from "../../lib/internal-dispatch.ts";
+import { canReadRuns } from "../../lib/run-visibility.ts";
 import type { SpaceScope } from "../../lib/scope.ts";
 import {
   getFileForActor,
@@ -955,18 +956,21 @@ function buildRunAndWaitTool(ctx: McpToolContext): AppstrateToolDefinition {
     // `GET /api/runs/{id}` through the same in-process dispatch — and
     // `internal-dispatch.ts` is explicit that the marker "does not
     // authenticate, elevate, or alter identity", so the caller's own scopes
-    // gate the poll. Without this, a credential holding `agents:run` but not
-    // `runs:read` provisions the container, incurs the LLM spend, and only THEN
-    // takes a 403 on the first poll: a billed orphan instead of a refusal. The
-    // description above also tells the model not to fall back to `getRun`, so
-    // there is no recovery path once the run is away.
-    if (!ctx.permissions.has("runs:read")) {
+    // gate the poll. Without this, a credential holding `agents:run` but no
+    // run-read permission provisions the container, incurs the LLM spend, and
+    // only THEN takes a 403 on the first poll: a billed orphan instead of a
+    // refusal. The description above also tells the model not to fall back to
+    // `getRun`, so there is no recovery path once the run is away. The predicate
+    // is `canReadRuns`, never a literal `runs:read` test: `runs:read-all` is a
+    // superset, so a principal holding only the wide permission reads the poll
+    // route fine and must not be refused here.
+    if (!canReadRuns(ctx.permissions)) {
       emit(ctx, { tool: "run_and_wait", durationMs: performance.now() - start, outcome: "denied" });
       return textResult(
         {
           error:
-            "Permission 'runs:read' is required to wait for a run. Launching without it would " +
-            "start the run and then fail to read its status.",
+            "Permission 'runs:read' or 'runs:read-all' is required to wait for a run. Launching " +
+            "without one would start the run and then fail to read its status.",
         },
         true,
       );


### PR DESCRIPTION
Closes #1339

## Root cause

`apps/api/src/modules/mcp/tools.ts:963` gated `run_and_wait` on a literal
`ctx.permissions.has("runs:read")` — the only re-derivation of the run-read
predicate outside `apps/api/src/lib/run-visibility.ts`. That file states the
invariant it broke (`run-visibility.ts:47-55`): `runs:read-all` is a **superset**
of `runs:read`, not a companion to it, so a principal holding only the wide
permission opens every surface `read` opens. An API key scoped
`["mcp:invoke", "agents:run", "runs:read-all"]` — all three separately grantable
(`API_KEY_ALLOWED_SCOPES` carries `runs:read-all`) — was refused before the
launch, even though the `GET /api/runs/{id}` poll that guard exists to protect
would have answered it fine, and even though the same key reaches the same data
through `invoke_operation → runAgent → getRun`.

## Fix

Ask the canonical predicate: `canReadRuns(ctx.permissions)` from
`lib/run-visibility.ts`. The guard keeps its position (before the launch — the
whole point is that the refusal must precede the container provisioning and the
LLM spend) and its comment now records *why* the predicate is the shared one
rather than a literal test, so the next reader does not re-inline it. The
refusal message names both permissions.

No refactor beyond the one-line predicate swap: the helper the issue asks for
already exists and is already the single source of this semantic.

## Tests

`apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts` — one new case,
`launches for a caller holding only \`runs:read-all\``, next to the existing
"refuses a caller that can launch but not read" case it complements.

- `set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts` → **22 pass, 0 fail**
- Negative control: with the predicate reverted to `has("runs:read")` the same
  run is **21 pass, 1 fail** — the new case, and only it.
- `bunx tsc --noEmit -p apps/api` → clean. `bunx eslint` + `bunx prettier --check` on both touched files → clean.

## Notes for the orchestrator

- No migration, no env var, no OpenAPI change (the MCP tool surface is not
  described in `apps/api/openapi/`), no deploy ordering.
- **Sibling #1372** (`runs:read-all` unrequestable by any OAuth client) is
  adjacent but not a dependency: the failure scenario here is reachable today
  through an **API key**, whose allowed-scope set already contains
  `runs:read-all` (`apps/api/test/unit/permissions.test.ts:282`). No file under
  `apps/api/src/modules/oidc/` is touched. When #1372 lands, the same fix
  additionally covers OAuth principals — no further change needed here.
- Overlap with #1335/#1336 (run visibility): none — this PR only *consumes*
  `lib/run-visibility.ts`, it does not modify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
