### PR TITLE
fix(api): bound the profile batch lookup by members:read

### DIFF
--- a/apps/api/src/openapi/paths/profile.ts
+++ b/apps/api/src/openapi/paths/profile.ts
@@ -151,7 +151,8 @@ export const profilePaths = {
       operationId: "batchGetProfiles",
       tags: ["Profile"],
       summary: "Batch lookup profiles",
-      description: "Retrieve display names for a list of user IDs.",
+      description:
+        "Retrieve display names for a list of user IDs. Reads the organization directory, so it requires `members:read`.",
       parameters: [{ $ref: "#/components/parameters/XOrgId" }],
       requestBody: {
         required: true,
@@ -199,6 +200,7 @@ export const profilePaths = {
         },
         "400": { $ref: "#/components/responses/ValidationError" },
         "401": { $ref: "#/components/responses/Unauthorized" },
+        "403": { $ref: "#/components/responses/Forbidden" },
       },
     },
   },

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -14,6 +14,7 @@ import { readJsonBody } from "@appstrate/core/request-body";
 import { listResponse } from "../lib/list-response.ts";
 import { scopedWhere } from "../lib/db-helpers.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
+import { requirePermission } from "../middleware/require-permission.ts";
 import { setDisplayName } from "../services/profile.ts";
 
 export const profileUpdateSchema = z
@@ -162,8 +163,13 @@ profileRouter.post("/profile/password", async (c) => {
   return c.json({ status: true });
 });
 
-// POST /api/profiles/batch — batch lookup display names by user IDs (scoped to org members)
-profileRouter.post("/profiles/batch", async (c) => {
+// POST /api/profiles/batch — batch lookup display names by user IDs (scoped to
+// org members). Resolving ids to names IS the org directory, read one page at a
+// time, so it carries the directory permission (`members:read`, RBAC spec §3.2)
+// — the same one `buildOrgDetail` gates the member list on. Without it a
+// `guest`, the org role defined as "member reads minus `members:read`", put
+// names on ids and learned membership from which ids came back empty.
+profileRouter.post("/profiles/batch", requirePermission("members", "read"), async (c) => {
   const orgId = c.get("orgId");
   const data = await readJsonBody(c, batchLookupSchema);
   const ids = data.ids.filter(Boolean);

--- a/apps/api/test/integration/routes/profile.test.ts
+++ b/apps/api/test/integration/routes/profile.test.ts
@@ -4,7 +4,13 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { and, eq } from "drizzle-orm";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll, db } from "../../helpers/db.ts";
-import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import {
+  createTestContext,
+  authHeaders,
+  memberContext,
+  orgOnlyHeaders,
+  type TestContext,
+} from "../../helpers/auth.ts";
 import { seedApiKey } from "../../helpers/seed.ts";
 import { flushRedis } from "../../helpers/redis.ts";
 import { user as userTable, account as accountTable } from "@appstrate/db/schema";
@@ -164,6 +170,40 @@ describe("Profile API", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.data).toHaveLength(0);
+    });
+
+    // Putting names on ids IS reading the org directory, so the route is
+    // bounded by `members:read` (RBAC spec §3.2). A `guest` is exactly the
+    // org role defined as member reads MINUS that permission, and must be
+    // refused — otherwise the omissions alone answer "is this id in my org?".
+    // Org-only headers: a guest has no implicit space, and the refusal under
+    // test is the permission one, not a space-context one.
+    it("refuses a guest, who does not hold members:read", async () => {
+      const guest = await memberContext(ctx, "guest");
+
+      const res = await app.request("/api/profiles/batch", {
+        method: "POST",
+        headers: orgOnlyHeaders(guest, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ ids: [ctx.user.id] }),
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    // Positive control for the bound above: an ordinary `member` holds
+    // `members:read` and still resolves colleague names.
+    it("allows an org member, who holds members:read", async () => {
+      const member = await memberContext(ctx, "member");
+
+      const res = await app.request("/api/profiles/batch", {
+        method: "POST",
+        headers: orgOnlyHeaders(member, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ ids: [ctx.user.id] }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.data).toHaveLength(1);
     });
   });
 

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -3561,7 +3561,7 @@ export interface paths {
         put?: never;
         /**
          * Batch lookup profiles
-         * @description Retrieve display names for a list of user IDs.
+         * @description Retrieve display names for a list of user IDs. Reads the organization directory, so it requires `members:read`.
          */
         post: operations["batchGetProfiles"];
         delete?: never;
@@ -18172,6 +18172,7 @@ export interface operations {
             };
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
         };
     };
     listProxies: {


### PR DESCRIPTION
Closes #1369

## Root cause

`apps/api/src/routes/profile.ts:166` (before this PR) registered `POST /api/profiles/batch` with no permission guard. Org context runs (the route is not in `skipOrgContext`), so the query is org-scoped — but membership is not permission. `apps/api/src/lib/permissions.ts:117-127` defines `guest` as the member read set **minus** `members:read`, "no enumerating the org directory". A guest could therefore POST `{ ids: [...] }`, get display names back for org members, and read membership off the ids the response omitted — an oracle for "is this user in my org?".

## Fix

One guard: `requirePermission("members", "read")` on the route. Resolving ids to display names *is* the org directory read one page at a time, so the route now carries the same permission `buildOrgDetail` gates its `members` array on (RBAC spec §3.2 / §6.5). No response narrowing: the resource is the directory itself, there is no subset a guest legitimately needs (the spec is explicit that even a guest holding preset `admin` in a space "enumerates nothing else" — `docs/architecture/RBAC_PERMISSIONS_SPEC.md:337`), and there is no in-repo consumer to narrow for (`rg 'profiles/batch'` finds only the API route, its OpenAPI path, and tests — the SPA never calls it).

Deliberate side effect: `members:read` is not in `API_KEY_ALLOWED_SCOPES`, so API keys now get 403 here. That matches the rest of this file — `/api/profile`, `PATCH /api/profile` and `/api/profile/password` already refuse `authMethod === "api_key"` outright, because the dashboard user's identity record is session-only.

OpenAPI: `403` documented on the now-guarded route and the description states the permission (`apps/api/src/openapi/paths/profile.ts`). `apps/web/src/api/schema.d.ts` regenerated via `bun run generate:api`. `detect:breaking` classifies the added 403 as non-breaking, so `baseline.json` is untouched.

## Tests

`apps/api/test/integration/routes/profile.test.ts` — two cases added to the existing `POST /api/profiles/batch` describe:
- a `guest` is refused with 403 (the regression),
- an ordinary `member` still gets 200 with one row (positive control, so the bound is not silently over-tightened).

Both use `orgOnlyHeaders` rather than `authHeaders`: a guest has no implicit space membership, and the refusal under test must be the permission one, not a space-context one.

Commands run (from the worktree root):

- `set -a && . ./.env && set +a && TEST_TIER=0 bun test apps/api/test/integration/routes/profile.test.ts` → **22 pass, 0 fail** (53 expect calls)
- `... bun test apps/api/test/integration/multi-tenancy.test.ts` → **14 pass, 0 fail** (it also exercises this route's cross-org isolation)
- Negative control: with the guard temporarily removed, the new guest case fails `Expected: 403 / Received: 200`. Guard restored, suite re-run.
- `bunx tsc --noEmit -p apps/api` → clean (exit 0)
- `bun run verify:openapi` → ALL CHECKS PASSED; `bun run verify:api-types` → up to date; `bun run detect:breaking` → 0 breaking, 1 non-breaking (the new 403)
- `bunx eslint` + `bunx prettier --check` on the touched files → clean

## Notes for the orchestrator

- No migration, no env var, no deploy ordering constraint.
- **Behaviour change for API keys**: any external integration calling `POST /api/profiles/batch` with an API key now gets 403. No in-repo caller does; worth one line in the release notes.
- Overlap with siblings: none. #1337 (space SMTP/social) and #1341 (route ordering) touch different files; `apps/api/src/routes/profile.ts` and `apps/api/src/openapi/paths/profile.ts` are mine alone.
- `apps/web/src/api/schema.d.ts` is generated — if a sibling also regenerates it, take both hunks (mine is the `batchGetProfiles` 403 + description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
