### PR TITLE
fix(api): prove permission before resolving the agent on eleven routes

### DIFF
--- a/apps/api/src/middleware/guards.ts
+++ b/apps/api/src/middleware/guards.ts
@@ -6,11 +6,32 @@ import { getPackage, getPackageWithAccess } from "../services/package-catalog.ts
 import { assertPackageMutationAccess } from "../lib/package-access.ts";
 import { getRunningRunsForPackage } from "../services/state/runs.ts";
 import { ApiError, forbidden, conflict, invalidRequest } from "../lib/errors.ts";
+import { hasHandlerMarker, markHandler } from "./handler-marker.ts";
+
+/**
+ * Marker stamped on every middleware that resolves an agent from the route
+ * params and 404s when it is unreachable.
+ *
+ * Such a middleware answers "does this agent exist?" before the route has
+ * proven the caller may ask. Mounted ahead of the permission guard it turns
+ * 403-vs-404 into an enumeration oracle over the space's private catalog, so
+ * the mount ORDER is a security property — and one no reviewer reliably sees.
+ * The marker lets a conformance test read the real order off Hono's route
+ * table instead (see
+ * `test/integration/middleware/agent-lookup-permission-order.test.ts`).
+ */
+const AGENT_LOOKUP = Symbol.for("appstrate.agentLookup");
+
+/** True when `handler` is a middleware produced by {@link requireAgent} or
+ *  {@link requireOrgAgent} — i.e. it can 404 on an unreachable agent. */
+export function isAgentLookup(handler: unknown): boolean {
+  return hasHandlerMarker(handler, AGENT_LOOKUP);
+}
 
 /** Middleware: load an agent by route param and set it on context, or 404.
  *  Also checks that the current space has access to the package. */
 export function requireAgent() {
-  return async (c: Context<AppEnv>, next: Next) => {
+  return markHandler(async (c: Context<AppEnv>, next: Next) => {
     const scope = c.req.param("scope");
     const name = c.req.param("name");
     const packageId = `${scope}/${name}`;
@@ -28,14 +49,14 @@ export function requireAgent() {
     }
     c.set("package", agent);
     return next();
-  };
+  }, AGENT_LOOKUP);
 }
 
 /** Middleware: load an agent by route param and set it on context, or 404.
  *  Checks org ownership only — does NOT check space-level access.
  *  Use for org-level operations (editing manifest, skills, tools). */
 export function requireOrgAgent() {
-  return async (c: Context<AppEnv>, next: Next) => {
+  return markHandler(async (c: Context<AppEnv>, next: Next) => {
     const scope = c.req.param("scope");
     const name = c.req.param("name");
     const packageId = `${scope}/${name}`;
@@ -52,7 +73,7 @@ export function requireOrgAgent() {
     }
     c.set("package", agent);
     return next();
-  };
+  }, AGENT_LOOKUP);
 }
 
 /** Extract the package ID from route params (scoped `@scope/name` or unscoped `id`). */

--- a/apps/api/src/middleware/handler-marker.ts
+++ b/apps/api/src/middleware/handler-marker.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tag a middleware so its MOUNT can be read back off Hono's route table.
+ *
+ * Several invariants in this API are properties of *where* a middleware is
+ * mounted rather than of what it does at runtime — "this route de-duplicates
+ * on `Idempotency-Key`" (`middleware/idempotency.ts`), "this route proves
+ * permission before it looks an agent up" (`middleware/guards.ts`). A
+ * hand-maintained list of such routes drifts away from the mounts silently; a
+ * marker carried by the middleware itself cannot.
+ *
+ * A symbol property rather than `handler.name`: a name survives neither
+ * wrapping nor minification. The property survives minification, and survives
+ * wrapping because {@link hasHandlerMarker} explicitly unwraps.
+ */
+
+import { findTargetHandler } from "hono/utils/handler";
+
+/** Stamp `marker` on `handler` and return it, for a factory to `return` directly. */
+export function markHandler<T extends object>(handler: T, marker: symbol): T {
+  Object.defineProperty(handler, marker, { value: true });
+  return handler;
+}
+
+/**
+ * True when `handler` carries `marker`.
+ *
+ * The marker is read *through* Hono's own handler wrapping. `app.route(path,
+ * sub)` re-wraps every handler of `sub` when the sub-app installed its own
+ * `onError()` (hono 4.12 `hono-base.js` `route()`), keeping the original only
+ * under the `COMPOSED_HANDLER` property. A naive property read on the wrapper
+ * returns `undefined`, so every marker mounted on a sub-router with an
+ * `onError()` would silently read as absent. `findTargetHandler` is Hono's own
+ * recursive unwrapper for exactly that property, so this tracks their wrapping
+ * instead of guessing at it.
+ */
+export function hasHandlerMarker(handler: unknown, marker: symbol): boolean {
+  if (typeof handler !== "function") return false;
+  const target = findTargetHandler(handler as (...args: never[]) => unknown);
+  return (target as unknown as Record<symbol, unknown>)[marker] === true;
+}

--- a/apps/api/src/middleware/idempotency.ts
+++ b/apps/api/src/middleware/idempotency.ts
@@ -8,8 +8,8 @@
  */
 
 import type { Context, Next } from "hono";
-import { findTargetHandler } from "hono/utils/handler";
 import type { AppEnv } from "../types/index.ts";
+import { hasHandlerMarker, markHandler } from "./handler-marker.ts";
 import { ApiError } from "../lib/errors.ts";
 import {
   acquireIdempotencyLock,
@@ -30,29 +30,17 @@ const MAX_KEY_LENGTH = 255;
  * handler part of this request's chain?" — instead of consulting a
  * hand-maintained list that could drift away from the mounts.
  *
- * A symbol property rather than `handler.name`: a name survives neither
- * wrapping nor minification. The property survives minification, and survives
- * wrapping only because `isIdempotencyAware` explicitly unwraps — see below.
+ * Stamped and read through `handler-marker.ts`, which owns the symbol-vs-name
+ * reasoning and the unwrapping of Hono's own handler wrapping.
  */
 const IDEMPOTENCY_AWARE = Symbol.for("appstrate.idempotencyAware");
 
 /**
  * True when `handler` is a middleware produced by `idempotency()` — i.e. the
  * route it is mounted on genuinely de-duplicates on `Idempotency-Key`.
- *
- * The marker is read *through* Hono's own handler wrapping. `app.route(path,
- * sub)` re-wraps every handler of `sub` when the sub-app installed its own
- * `onError()` (hono 4.12 `hono-base.js` `route()`), keeping the original only
- * under the `COMPOSED_HANDLER` property. A naive property read on the wrapper
- * returns `undefined`, so a sub-router with an `onError()` would silently lose
- * its idempotency support and the guard would 400 a header the route does
- * honour. `findTargetHandler` is Hono's own recursive unwrapper for exactly
- * that property, so this tracks their wrapping instead of guessing at it.
  */
 export function isIdempotencyAware(handler: unknown): boolean {
-  if (typeof handler !== "function") return false;
-  const target = findTargetHandler(handler as (...args: never[]) => unknown);
-  return (target as unknown as Record<symbol, unknown>)[IDEMPOTENCY_AWARE] === true;
+  return hasHandlerMarker(handler, IDEMPOTENCY_AWARE);
 }
 
 /**
@@ -172,6 +160,5 @@ export function idempotency() {
     });
   };
 
-  Object.defineProperty(middleware, IDEMPOTENCY_AWARE, { value: true });
-  return middleware;
+  return markHandler(middleware, IDEMPOTENCY_AWARE);
 }

--- a/apps/api/src/middleware/require-permission.ts
+++ b/apps/api/src/middleware/require-permission.ts
@@ -24,6 +24,22 @@ import type { AppEnv } from "../types/index.ts";
 import { makePermissionGuard, reportPermissionDenial } from "@appstrate/core/permissions";
 import { forbidden } from "../lib/errors.ts";
 import type { Resource, Action } from "../lib/permissions.ts";
+import { hasHandlerMarker, markHandler } from "./handler-marker.ts";
+
+/**
+ * Marker stamped on every route-level permission guard this module produces.
+ *
+ * Read by the conformance test that proves no route resolves an agent (and so
+ * 404s on an unreachable one) before it has proven the caller may ask — see
+ * `test/integration/middleware/agent-lookup-permission-order.test.ts`.
+ */
+const PERMISSION_GUARD = Symbol.for("appstrate.permissionGuard");
+
+/** True when `handler` is a route-level permission guard, i.e. it 403s a
+ *  caller lacking the permission before the handler chain continues. */
+export function isPermissionGuard(handler: unknown): boolean {
+  return hasHandlerMarker(handler, PERMISSION_GUARD);
+}
 
 /**
  * Middleware factory: require a specific permission.
@@ -32,7 +48,7 @@ import type { Resource, Action } from "../lib/permissions.ts";
  */
 export function requirePermission<R extends Resource>(resource: R, action: Action<R>) {
   const guard = makePermissionGuard(`${resource as string}:${action as string}`);
-  return (c: Context<AppEnv>, next: Next) => guard(c, next);
+  return markHandler((c: Context<AppEnv>, next: Next) => guard(c, next), PERMISSION_GUARD);
 }
 
 /**
@@ -61,12 +77,12 @@ export function assertPermission<R extends Resource>(
  */
 export function requireAnyPermission(permissions: readonly string[]) {
   const required = permissions.join("|");
-  return async (c: Context<AppEnv>, next: Next) => {
+  return markHandler(async (c: Context<AppEnv>, next: Next) => {
     const held = c.get("permissions");
     if (!permissions.some((permission) => held?.has(permission))) {
       reportPermissionDenial(c, required);
       throw forbidden(`Insufficient permissions: ${required} required`);
     }
     return next();
-  };
+  }, PERMISSION_GUARD);
 }

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -242,8 +242,8 @@ export function createAgentsRouter() {
   // input defaults + field locks (admin-only).
   router.put(
     `/${SCOPED_PACKAGE_ROUTE}/input-settings`,
-    requireAgent(),
     requirePermission("agents", "configure"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
 
@@ -319,9 +319,11 @@ export function createAgentsRouter() {
   );
 
   // GET /api/agents/:scope/:name/proxy — get agent proxy configuration.
-  // Permission BEFORE `requireAgent()`: that middleware 404s on an unknown
-  // agent, so the reverse order answers "does this agent exist?" to a caller
-  // that is not allowed to read agents at all.
+  // Permission BEFORE `requireAgent()`, as on every agent route: that
+  // middleware 404s on an unknown agent, so the reverse order answers "does
+  // this agent exist?" to a caller that is not allowed to read agents at all —
+  // 403-vs-404 enumerates the space's private catalog (#1341). The order is
+  // enforced by `test/integration/middleware/agent-lookup-permission-order.test.ts`.
   router.get(
     `/${SCOPED_PACKAGE_ROUTE}/proxy`,
     requirePermission("agents", "read"),
@@ -350,8 +352,8 @@ export function createAgentsRouter() {
   // authority; this is what the badge renders.
   router.get(
     `/${SCOPED_PACKAGE_ROUTE}/connection-readiness`,
-    requireAgent(),
     requirePermission("integrations", "read"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       return c.json(
@@ -371,8 +373,8 @@ export function createAgentsRouter() {
   // PUT /api/agents/:scope/:name/proxy — set agent proxy override (admin-only)
   router.put(
     `/${SCOPED_PACKAGE_ROUTE}/proxy`,
-    requireAgent(),
     requirePermission("agents", "configure"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const scope = getSpaceScope(c);
@@ -395,9 +397,8 @@ export function createAgentsRouter() {
   );
 
   // GET /api/agents/:scope/:name/model — get agent model configuration.
-  // Permission-first, same reason as `…/proxy` above. `agents:run` opens it
-  // too: this is where the launch form reads the model a run will resolve to,
-  // and the body carries no manifest and no prompt.
+  // `agents:run` opens it too: this is where the launch form reads the model a
+  // run will resolve to, and the body carries no manifest and no prompt.
   router.get(`/${SCOPED_PACKAGE_ROUTE}/model`, requireAgentRead, requireAgent(), async (c) => {
     const agent = c.get("package");
     const spaceId = c.get("spaceId");
@@ -409,8 +410,8 @@ export function createAgentsRouter() {
   // PUT /api/agents/:scope/:name/model — set agent model override (admin-only)
   router.put(
     `/${SCOPED_PACKAGE_ROUTE}/model`,
-    requireAgent(),
     requirePermission("agents", "configure"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const scope = getSpaceScope(c);
@@ -464,8 +465,8 @@ export function createAgentsRouter() {
   // Read the unified persistence rows visible to the caller.
   router.get(
     `/${SCOPED_PACKAGE_ROUTE}/persistence`,
-    requireAgent(),
     requirePermission("persistence", "read"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const spaceId = c.get("spaceId");
@@ -539,8 +540,8 @@ export function createAgentsRouter() {
   // DELETE /api/agents/:scope/:name/persistence/memories/:id
   router.delete(
     `/${SCOPED_PACKAGE_ROUTE}/persistence/memories/:id`,
-    requireAgent(),
     requirePermission("persistence", "delete"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const spaceId = c.get("spaceId");
@@ -565,8 +566,8 @@ export function createAgentsRouter() {
   // DELETE /api/agents/:scope/:name/persistence/pinned/:id
   router.delete(
     `/${SCOPED_PACKAGE_ROUTE}/persistence/pinned/:id`,
-    requireAgent(),
     requirePermission("persistence", "delete"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const spaceId = c.get("spaceId");
@@ -593,8 +594,8 @@ export function createAgentsRouter() {
   // in this space. Narrow with query params.
   router.delete(
     `/${SCOPED_PACKAGE_ROUTE}/persistence`,
-    requireAgent(),
     requirePermission("persistence", "delete"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const spaceId = c.get("spaceId");

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -215,8 +215,8 @@ export function createRunsRouter() {
     `/agents/${SCOPED_PACKAGE_ROUTE}/run`,
     rateLimit(20),
     idempotency(),
-    requireAgent(),
     requirePermission("agents", "run"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const orgId = c.get("orgId");
@@ -826,13 +826,13 @@ export function createRunsRouter() {
   // DELETE /api/agents/:scope/:name/runs — delete all runs for an agent
   router.delete(
     `/agents/${SCOPED_PACKAGE_ROUTE}/runs`,
-    requireAgent(),
     requirePermission("runs", "delete"),
     // The only run mutation that is not per-row: it spans every run of the
     // agent in the space, so `assertRunVisible` has no row to apply and the
     // space-wide read is what authorizes the span. Without it a principal
     // scoped `runs:delete` alone would delete runs it cannot read.
     requirePermission("runs", "read-all"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
       const scope = getSpaceScope(c);

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -303,8 +303,8 @@ export function createSchedulesRouter() {
   router.post(
     `/agents/${SCOPED_PACKAGE_ROUTE}/schedules`,
     rateLimit(10),
-    requireAgent(),
     requirePermission("schedules", "write"),
+    requireAgent(),
     async (c) => {
       const agent = c.get("package");
 

--- a/apps/api/test/integration/middleware/agent-lookup-permission-order.test.ts
+++ b/apps/api/test/integration/middleware/agent-lookup-permission-order.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-lookup ordering guard (#1341).
+ *
+ * `requireAgent()` / `requireOrgAgent()` resolve an agent from the route params
+ * and 404 when it is unreachable from the caller's space. Mounted BEFORE the
+ * route's permission guard, that 404 answers "does this agent exist?" to a
+ * caller who was never allowed to ask: 403 means the agent exists, 404 means it
+ * does not, and an API key scoped to some unrelated permission can walk the
+ * space's private agent catalog.
+ *
+ * The rule is therefore: on every route, a permission guard is mounted before
+ * any agent lookup. It is a property of the mount ORDER — invisible at runtime,
+ * invisible in a diff that adds one more route by copying its neighbour — so it
+ * is asserted here against Hono's real route table rather than trusted to
+ * review. Eleven routes had it backwards when this test was written.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { getTestApp } from "../../helpers/app.ts";
+import { isAgentLookup, requireAgent } from "../../../src/middleware/guards.ts";
+import {
+  isPermissionGuard,
+  requirePermission,
+} from "../../../src/middleware/require-permission.ts";
+
+/**
+ * Every registered route, as `"METHOD /path" -> handlers in mount order`.
+ *
+ * Hono pushes one `routes` entry per handler, in registration order, so
+ * grouping by method+path recovers each route's chain. Grouping on the EXACT
+ * path is what makes the assertion meaningful: app-wide middleware mounted on
+ * `/*` forms its own group and can never be mistaken for a permission guard
+ * standing in front of a lookup on a concrete route.
+ */
+function routeChains(): Map<string, unknown[]> {
+  const chains = new Map<string, unknown[]>();
+  for (const route of getTestApp().routes) {
+    const key = `${route.method} ${route.path}`;
+    const chain = chains.get(key);
+    if (chain) chain.push(route.handler);
+    else chains.set(key, [route.handler]);
+  }
+  return chains;
+}
+
+/** Routes that mount an agent lookup with no permission guard ahead of it. */
+function offendingRoutes(): string[] {
+  const offenders: string[] = [];
+  for (const [key, chain] of routeChains()) {
+    const lookupAt = chain.findIndex(isAgentLookup);
+    if (lookupAt === -1) continue;
+    const guardAt = chain.findIndex(isPermissionGuard);
+    if (guardAt === -1 || guardAt > lookupAt) offenders.push(key);
+  }
+  return offenders.sort();
+}
+
+describe("agent lookup never precedes the permission guard", () => {
+  it("mounts a permission guard before every agent lookup", () => {
+    // Empty list, not a count: a regression names the route it broke.
+    expect(offendingRoutes()).toEqual([]);
+  });
+
+  it("keeps both markers readable — the assertion has something to read", () => {
+    // If either marker stopped being stamped, `offendingRoutes()` would return
+    // an empty array for the wrong reason and this file would pass forever
+    // against an unguarded API. Prove both halves are actually observable.
+    const chains = [...routeChains().values()];
+    expect(chains.filter((chain) => chain.some(isAgentLookup)).length).toBeGreaterThan(0);
+    expect(chains.filter((chain) => chain.some(isPermissionGuard)).length).toBeGreaterThan(0);
+  });
+
+  it("detects a lookup mounted ahead of its guard", () => {
+    // Negative control for `offendingRoutes`: the detector must fail on the
+    // shape this issue was about, or the assertion above proves nothing.
+    const bad = [requireAgent(), requirePermission("agents", "read")];
+    const good = [requirePermission("agents", "read"), requireAgent()];
+
+    const firstLookup = (chain: unknown[]) => chain.findIndex(isAgentLookup);
+    const firstGuard = (chain: unknown[]) => chain.findIndex(isPermissionGuard);
+
+    expect(firstGuard(bad) > firstLookup(bad)).toBe(true);
+    expect(firstGuard(good) < firstLookup(good)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1341

## Root cause

`requireAgent()` (`apps/api/src/middleware/guards.ts:12`) resolves the agent named in the route params and 404s when the caller's space cannot reach it. Eleven routes mounted it **before** their permission guard, so a caller lacking the guarded permission got **403 for an agent that exists** and **404 for one that does not** — an enumeration oracle over the space's private agent catalog. An API key scoped to any unrelated permission could walk it through, for example, `PUT /api/agents/@x/y/proxy`.

Sites: `routes/agents.ts` (input-settings, connection-readiness, PUT proxy, PUT model, GET/DELETE persistence, DELETE persistence/memories/:id, DELETE persistence/pinned/:id), `routes/runs.ts:218` (POST run) and `:829` (DELETE runs), `routes/schedules.ts:306` (POST schedules). Four sibling routes already had the correct order and `agents.ts:322` already documented why.

## Fix

**Commit 1 — the ordering.** The permission guard moves ahead of the lookup on the eleven routes. Nothing else changes: both status codes were already reachable on every one of these routes (the guard was mounted, just later), so **no OpenAPI response declaration changes** — I checked all eleven, each already declares both 403 and 404, and `bun run verify:openapi` passes including its "every guaranteed 403 is documented" check. On `DELETE .../runs` the lookup moves after *both* permission guards.

I considered a combined `requireAgentWithPermission(...)` factory to make the order impossible to express. It does not fit: the permissions differ per route, two routes use the `requireAnyPermission` composites (`requireAgentRead`, `requireRunsRead`), `DELETE .../runs` stacks two guards, and two routes carry `rateLimit`/`idempotency` ahead of everything. It would have become `requireAgentAfter(...guards)` — the same ordering spelled through an indirection. The order stays explicit; a test enforces it.

**Commit 2 — so the class cannot recur.** The defect is a property of the mount **order**: invisible at runtime, invisible in a diff that adds one more route by copying its neighbour. `test/integration/middleware/agent-lookup-permission-order.test.ts` reads the real order off Hono's route table and asserts that a permission guard precedes every agent lookup, listing offending routes by name.

This needs the two middleware families to be identifiable, so each carries a symbol marker — the idiom `idempotency()` already established. The symbol-vs-name reasoning and the unwrapping of Hono's own `COMPOSED_HANDLER` wrapping (needed because `app.route()` re-wraps sub-router handlers) were already written once for idempotency; rather than copy them twice more I lifted them into `middleware/handler-marker.ts` and pointed `idempotency()` at it. `isIdempotencyAware` keeps its signature and its callers.

## Tests

New: `apps/api/test/integration/middleware/agent-lookup-permission-order.test.ts` (3 tests) — the ordering assertion, a marker-readability check so the assertion cannot pass vacuously if a marker stops being stamped, and a negative control on the detector itself.

Validated the test genuinely catches this bug, not just its own fixture: with the three route files restored to `origin/main` it fails and names **exactly the eleven routes the issue lists**, route for route.

```
TEST_TIER=0 bun test apps/api/test/integration/middleware/            → 112 pass, 0 fail (16 files)
  ...plus test/unit/guards.test.ts, test/unit/require-permission.test.ts
  (includes idempotency-contract.test.ts — covers the handler-marker refactor)
TEST_TIER=0 bun test agents.test.ts agent-connection-readiness.test.ts
  agents-space-packages-read-permissions.test.ts
  runs-schedules-read-permissions.test.ts schedules.test.ts            → 109 pass, 0 fail
TEST_TIER=0 bun test runs.test.ts runs-read-isolation.test.ts
  runs-body-validation.test.ts openapi-response-validation.test.ts
  multi-tenancy.test.ts                                                → 138 pass, 0 fail
bunx tsc --noEmit -p apps/api                                          → clean
bun run verify:openapi                                                 → ALL CHECKS PASSED
bunx eslint + prettier on the 8 touched files                          → clean
```

## Notes for the orchestrator

- **No migration, no env var, no OpenAPI change.** Nothing to sequence at deploy.
- **Overlap with siblings #1313/#1338 in `guards.ts`:** kept deliberately minimal and far from the code they move. My edit adds an import, a marker constant + `isAgentLookup()` at the top of the file, and changes the two `return async (…) => {…};` in `requireAgent`/`requireOrgAgent` into `return markHandler(async (…) => {…}, AGENT_LOOKUP);`. I did not touch `apiKeySpaceScopeGuard` (the function they rename to `pinnedSpaceScopeGuard`), so the merge should be clean.
- **Behaviour change worth naming in release notes:** these eleven routes now answer **403 instead of 404** to a caller who lacks the permission and names a nonexistent agent. Both codes were already declared and already reachable, so no client contract breaks — but a client that branched on 404 to mean "gone" will now see 403 in that one combination.
- **Pre-existing, not fixed here (out of scope):** `GET /api/agents/{scope}/{name}/schedules` is already permission-first yet still runs `requireAgent()`, so it can return 404 — but `src/openapi/paths/schedules.ts:42` declares only 200/401/403. An under-declaration unrelated to this issue; worth its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
