### PR TITLE
fix(codex): keep Pro-only models out of the featured list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -621,6 +621,22 @@ INFRA_ALLOWLIST`. It had been asserted and false — at `v1.0.0-beta.53` the
 
 ### Fixed
 
+- **A Plus subscriber is no longer handed a Pro-only Codex model (#1357).**
+  `gpt-6-astra` is recommended by the vendor only from Pro plans up, but it sat
+  in the Codex `featuredModels` list — which is not merely a picker section:
+  the platform auto-seeds every featured id into `org_models` on first
+  connection and promotes the first inserted row to the org default. A Plus
+  subscriber was therefore given a model their plan refuses, and found out at
+  the first run. The two documented Pro-only ids (`gpt-6-astra`,
+  `gpt-5.3-codex-spark`) are now named in one place — `PRO_PLAN_MODEL_IDS` in
+  `@appstrate/module-codex`, with the vendor page that says so — and are kept
+  in `modelDiscoveryCandidates`, where a Pro subscriber selects them
+  deliberately, and out of `featuredModels`, which the platform applies on
+  everyone's behalf. A test pins both halves, so featuring a plan-gated id
+  fails CI rather than reaching a picker. Plan tiers appear in no vendored feed
+  and `SUBSCRIPTION_COMPLIANCE.md` forbids asking the vendor, so the
+  hand-written list is the whole mechanism.
+
 - **The hosted connect portal names the missing OAuth client instead of a
   generic "please try again" 502 (#1263).** Opening a `connect_url` for an
   oauth2 auth in a space with no registered client — and no system client or

--- a/packages/module-codex/src/index.ts
+++ b/packages/module-codex/src/index.ts
@@ -163,6 +163,34 @@ const codexHooks: ModelProviderHooks = {
 };
 
 // ---------------------------------------------------------------------------
+// Plan gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Codex model ids the vendor recommends only for **Pro plans and above**.
+ *
+ * Source: https://learn.chatgpt.com/docs/models (Codex with ChatGPT sign-in),
+ * read 2026-09-07 for `gpt-6-astra` and 2026-07-27 for `gpt-5.3-codex-spark`.
+ *
+ * Why a hand-written deny-list and not a plan-tier model: the platform cannot
+ * know which plan a credential is on. `docs/architecture/
+ * SUBSCRIPTION_COMPLIANCE.md` forbids ANY call that would enumerate a
+ * subscription, and neither vendored feed (the OpenAI pricing catalog, the
+ * `chatgpt` subscription-watch snapshot) carries plan tiers — so "Pro-only" is
+ * knowable from the vendor page and nowhere else. One id per line, with the
+ * page that says so, is the whole mechanism.
+ *
+ * What it buys: these ids stay in `modelDiscoveryCandidates` below (a Pro
+ * subscriber can still select them) but are kept OUT of `featuredModels`, which is not just a picker section — the platform
+ * auto-seeds every featured id into `org_models` on first connection and
+ * promotes the first inserted row to the org default. Featuring a Pro-only id
+ * hands a Plus subscriber a model their plan refuses, discovered at the first
+ * run. `packages/module-codex/test/unit/discovery-candidates.test.ts` enforces
+ * both halves.
+ */
+export const PRO_PLAN_MODEL_IDS = ["gpt-6-astra", "gpt-5.3-codex-spark"] as const;
+
+// ---------------------------------------------------------------------------
 // Provider definition
 // ---------------------------------------------------------------------------
 
@@ -221,12 +249,14 @@ const codexProvider: ModelProviderDefinition = {
   // serve is recorded — after checking the doc above — in
   // `apps/api/src/data/subscription-watch/reviewed.json`, never just dropped.
   //
-  // Recommended set, newest first. `gpt-6-astra` is documented for Pro plans
-  // and above — like `gpt-5.3-codex-spark`, which is also recommended but is
-  // absent from openai.json, so the boot check forbids featuring it and it
-  // lives in the candidate list only. A plan that does not serve a featured
-  // id finds out at the first run, as for every other id here.
-  featuredModels: ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
+  // Recommended set, newest first, minus `PRO_PLAN_MODEL_IDS`: every id
+  // here is recommended for ChatGPT sign-in on EVERY plan, because the
+  // platform auto-seeds all of them on first connection and defaults the org
+  // to the first one. `gpt-6-astra` and `gpt-5.3-codex-spark` are recommended
+  // too, but only from Pro up, so they are candidates and not featured — a
+  // Plus subscriber would otherwise be handed them by default and find out at
+  // the first run.
+  featuredModels: ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"],
   // OFFLINE validation: the platform issues ZERO Codex API calls to test
   // a credential or discover models. The connection test runs the
   // `validateCredential` hook below (local JWT decode) — its mere presence is
@@ -235,12 +265,13 @@ const codexProvider: ModelProviderDefinition = {
   // availability is checked at the first agent run (on the Pi engine).
   // Served as-is (∩ catalog) — what THIS account's plan actually serves is
   // discovered by the user at first run, not by the platform. Superset of
-  // `featuredModels`:
-  // the documented "recommended" set in doc order (incl. the Pro-only
-  // `gpt-5.3-codex-spark` preview), then the "other available" models — which
-  // is why the tail is not strictly newest-first. `gpt-5.2` and
-  // `gpt-5.3-codex` are deprecated for ChatGPT sign-in and were dropped from
-  // both lists.
+  // `featuredModels`: the documented "recommended" set in doc order (including
+  // both `PRO_PLAN_MODEL_IDS`), then the "other available" models —
+  // which is why the tail is not strictly newest-first. This is the right list
+  // for a plan-gated id: selecting one is a deliberate act by someone who
+  // knows their plan, unlike the featured list, which the platform seeds on
+  // everyone's behalf. `gpt-5.2` and `gpt-5.3-codex` are deprecated for
+  // ChatGPT sign-in and were dropped from both lists.
   modelDiscoveryCandidates: [
     "gpt-6-astra",
     "gpt-5.6-sol",

--- a/packages/module-codex/test/unit/codex-module.test.ts
+++ b/packages/module-codex/test/unit/codex-module.test.ts
@@ -32,12 +32,7 @@ describe("codex module", () => {
 
   it("exposes a non-empty featured catalog", () => {
     const codex = codexModule.modelProviders?.()[0];
-    expect(codex?.featuredModels).toEqual([
-      "gpt-6-astra",
-      "gpt-5.6-sol",
-      "gpt-5.6-terra",
-      "gpt-5.6-luna",
-    ]);
+    expect(codex?.featuredModels).toEqual(["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]);
   });
 });
 

--- a/packages/module-codex/test/unit/discovery-candidates.test.ts
+++ b/packages/module-codex/test/unit/discovery-candidates.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "bun:test";
-import codexModule from "../../src/index.ts";
+import codexModule, { PRO_PLAN_MODEL_IDS } from "../../src/index.ts";
 
 const def = (codexModule.modelProviders?.() ?? [])[0]!;
 
@@ -28,12 +28,30 @@ describe("codex discovery candidates", () => {
     }
   });
 
-  it("includes the Pro-only preview beyond the featured floor", () => {
-    // The run — not the static list — decides what a given plan serves, so
-    // candidates cover `gpt-5.3-codex-spark`, which is recommended for
-    // ChatGPT sign-in but absent from openai.json (hence unfeaturable).
+  it("keeps every Pro-only id selectable but never featured", () => {
+    // `featuredModels` is not just a picker section: the platform auto-seeds
+    // every featured id into `org_models` on first connection and promotes the
+    // first inserted row to the org default. So a Pro-only id in that list is
+    // handed to a Plus subscriber by the platform itself, and the plan refuses
+    // it at the first run. Candidates are the opposite: selecting one is a
+    // deliberate act by someone who knows their plan.
+    //
+    // No feed carries plan tiers (see `PRO_PLAN_MODEL_IDS`), so this is the
+    // whole enforcement — the deny-list plus these two assertions.
     expect(candidates.length).toBeGreaterThan(featured.length);
-    expect(candidates).toContain("gpt-5.3-codex-spark");
+    for (const id of PRO_PLAN_MODEL_IDS) {
+      expect(candidates).toContain(id);
+      expect(featured).not.toContain(id);
+    }
+  });
+
+  it("names both documented Pro-only ids", () => {
+    // Pins the deny-list's contents, so removing an id from it is a visible
+    // edit rather than a silent one that quietly re-opens the test above.
+    // Source: https://learn.chatgpt.com/docs/models (Codex with ChatGPT
+    // sign-in) — `gpt-5.3-codex-spark` read 2026-07-27, `gpt-6-astra`
+    // 2026-09-07.
+    expect([...PRO_PLAN_MODEL_IDS]).toEqual(["gpt-6-astra", "gpt-5.3-codex-spark"]);
   });
 
   it("drops the ids deprecated for ChatGPT sign-in", () => {


### PR DESCRIPTION
Closes #1357

## Root cause

`packages/module-codex/src/index.ts:229` listed `gpt-6-astra` — documented by the vendor as recommended for **Pro plans and above** — in `featuredModels`.

`featuredModels` is not merely a picker section. `apps/web/src/hooks/use-auto-seed-models.ts:41` seeds **every** featured id into `org_models` right after a fresh OAuth pairing, and `apps/api/src/services/org-models.ts:563` promotes the first inserted row to the org default when none is set. `apps/api/src/routes/model-provider-credentials.ts:427` also uses `featured[0]` as the credential-test probe id. So the platform hands a Plus subscriber a model their plan refuses, and the refusal surfaces at the first run.

The comment that shipped with it claimed the risk was uniform ("as for every other id here") — it is not: the other three featured ids are recommended on every plan. It also attributed `gpt-5.3-codex-spark`'s absence from the list to the boot check (featured ⊆ catalog) rather than to a plan judgement, so nothing was actually enforcing the judgement.

## Fix

- `PRO_PLAN_MODEL_IDS = ["gpt-6-astra", "gpt-5.3-codex-spark"]` — a hand-written deny-list exported from `@appstrate/module-codex`, carrying the vendor page and the read dates.
- Both ids stay in `modelDiscoveryCandidates` (a Pro subscriber still selects them deliberately; the seed gate at `apps/api/src/routes/models.ts:362` admits them through `available_model_ids`, which for a `mode: "static"` provider is `candidates ∩ catalog`) and leave `featuredModels`, which the platform applies on everyone's behalf.
- The invariant is now machine-checked instead of comment-only.

**Why a deny-list and not a plan-tier field on `ModelProviderDefinition`:** "which models are Pro-only" is knowable from the vendor page and nowhere else in this repo — neither the OpenAI pricing catalog nor the `chatgpt` subscription-watch snapshot carries plan tiers, and `docs/architecture/SUBSCRIPTION_COMPLIANCE.md` forbids any call that would enumerate a subscription. A plan-tier system would be speculative machinery through core → API → OpenAPI → web → i18n for one id in one module. No core, API, OpenAPI, or web change here.

The drift gate (`curated-model-drift.test.ts`) reads `resolveDiscoveryCandidates`, which is unchanged, so it stays green and `reviewed.json` is untouched — correctly, since that file records ids the subscription does **not** serve, and `gpt-6-astra` is served on Pro.

## Tests

`packages/module-codex/test/unit/discovery-candidates.test.ts` — the "Pro-only preview" test is widened into the invariant (`PRO_PLAN_MODEL_IDS ⊆ candidates` and `∩ featured = ∅`), plus a second test pinning the deny-list's contents so shrinking it is a visible edit. `codex-module.test.ts` featured expectation updated.

```
TEST_TIER=0 bun test packages/module-codex/test/unit                      → 27 pass / 0 fail
TEST_TIER=0 bun test apps/api/test/unit/services/{curated-model-drift,
  oauth-model-providers-registry,model-selection,credential-model-ids,
  resolve-catalog-defaults}.test.ts apps/api/test/unit/{describe-served-model,
  model-providers-registry}.test.ts                                       → 84 pass / 0 fail
bunx tsc --noEmit -p packages/module-codex                                → clean
bunx eslint + prettier on the 4 touched files                             → clean
```

Negative control: re-adding `gpt-6-astra` to `featuredModels` fails the new test with `Expected to not contain: "gpt-6-astra"`; removing it again restores green.

## Notes for the orchestrator

- No migration, no env var, no OpenAPI change. Deploy ordering irrelevant.
- **Behaviour change to state in the release notes:** orgs connecting Codex *after* this ships get three seeded models instead of four, and the org default becomes `gpt-5.6-luna` (already the case — auto-seed order follows the catalog, not the featured array). Orgs that already seeded `gpt-6-astra` keep the row and keep it selectable; nothing is removed retroactively, and no data repair is needed.
- Overlap with siblings: none. `scripts/refresh-pricing-catalog.ts` (#1327) is untouched, and this changes no discovery/search surface (#1353–1358 chain).
- Open decision for the product owner: the issue's second option — surfacing the plan requirement *in the picker* — is deliberately not implemented. It needs a plan-tier concept the platform cannot populate (compliance forbids enumerating a subscription), so it would be a static badge from the same hand-written list. Say the word if the badge is wanted; the list is already in one place to hang it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
