### PR TITLE
fix(cli): read keyring failures the way @napi-rs/keyring 2.x reports them

### DIFF
--- a/apps/cli/src/lib/keyring.ts
+++ b/apps/cli/src/lib/keyring.ts
@@ -7,8 +7,9 @@
  * libsecret/DBus on Linux, Credential Manager on Windows). Fallback:
  * `$XDG_CONFIG_HOME/appstrate/credentials.json` with `0600` permissions
  * when no keyring daemon is available (CI runners, stripped containers
- * — confirmed during preflight PF-1 where `@napi-rs/keyring` threw
- * `Platform secure storage failure` on a bare Debian slim image).
+ * — confirmed during preflight PF-1 where `@napi-rs/keyring` threw a
+ * `PlatformFailure` on a bare Debian slim image). Which throws take
+ * that fallback and which are refused is {@link classifyKeyringError}.
  *
  * Tokens are scoped by profile: the keyring entry key is
  * `(appstrate, <profile>)` so profiles share the service name.
@@ -33,9 +34,9 @@ import { getErrorMessage } from "@appstrate/core/errors";
  * Opt-in escape hatch for environments where the keyring daemon is
  * present but refuses to serve (SSH-attached macOS without a logged-in
  * loginwindow, frozen gnome-keyring, stripped container with a stale
- * libsecret socket). Without this env var set, a `"broken"` keyring
- * error is fatal instead of silently writing plaintext tokens to the
- * file fallback. The rationale is symmetric with the Windows refusal:
+ * libsecret socket). Without this env var set, a `"store-locked"`
+ * keyring error is fatal instead of silently writing plaintext tokens
+ * to the file fallback. The rationale is symmetric with the Windows refusal:
  * if the user's machine is configured to protect secrets via the OS
  * keyring, a broken backend is a signal, not a reason to quietly
  * downgrade.
@@ -117,35 +118,57 @@ function fallbackPath(): string {
 }
 
 /**
- * Known substrings thrown by `@napi-rs/keyring` on hosts where no
- * keyring daemon is available. These are expected fallback triggers —
- * silently route to the file store. Anything else is surfaced as a
- * one-time stderr warning so a broken daemon (corrupt libsecret,
- * locked keychain) doesn't degrade into silent plaintext storage
- * without any signal to the operator.
- *
- * The wording comes from the napi-rs/keyring error constructors we
- * observed during preflight PF-1 (Debian slim without libsecret,
- * stripped CI image). If this list drifts out of sync with upstream
- * the only cost is an extra warning line — never a wrong outcome.
- *
- * Note: `"No matching entry"` is intentionally NOT in this list.
- * `classifyKeyringError` checks for it FIRST and returns
- * `"entry-missing"` before this array is consulted, so including it
- * here would be unreachable dead code. Entry-missing is a read-path
- * concept (the user simply hasn't logged in yet), distinct from the
- * "no keyring daemon at all" fallback signal this list represents.
+ * Display prefix of `keyring-core`'s `PlatformFailure` variant — the
+ * store machinery is not functional on this host at all: no DBus
+ * session bus, no libsecret, stripped container, bare CI runner.
+ * See {@link classifyKeyringError}.
  */
-const MISSING_BACKEND_MARKERS = ["Platform secure storage failure", "No storage"];
+export const PLATFORM_FAILURE_MARKER = "Platform failure: ";
+
+/**
+ * Display prefix of `keyring-core`'s `NoStorageAccess` variant — the
+ * store exists and answered, but refused us: locked Keychain on a
+ * headless SSH session, a gnome-keyring that will not unlock, a user
+ * who denied access. See {@link classifyKeyringError}.
+ */
+export const NO_STORAGE_ACCESS_MARKER = "Couldn't access platform storage: ";
 
 /** De-dupe stderr output across calls within the same process. */
 let _backendWarningEmitted = false;
 
-function classifyKeyringError(err: unknown): "missing-backend" | "entry-missing" | "broken" {
-  const msg = getErrorMessage(err);
-  if (msg.includes("No matching entry")) return "entry-missing";
-  if (MISSING_BACKEND_MARKERS.some((marker) => msg.includes(marker))) return "missing-backend";
-  return "broken";
+/**
+ * Sort a keyring throw into the only two outcomes that change what we do.
+ *
+ * `@napi-rs/keyring` 2.x surfaces `keyring-core` errors as plain JS
+ * `Error`s, so the variant survives only as its Display prefix — the
+ * prefix IS the discriminator, and the two we care about are pinned
+ * against the shipped native binary by
+ * `test/keyring-error-markers.test.ts`, which fails on the next bump
+ * that reworded them (the failure this classification had already
+ * silently suffered once, issue #1321).
+ *
+ *   • `store-unavailable` (`PlatformFailure`) — there is no keyring
+ *     protection on this host to downgrade FROM, so the 0600 file
+ *     store is the only option: fall back silently. This is the whole
+ *     reason the file store exists.
+ *   • `store-locked` (everything else, chiefly `NoStorageAccess`) —
+ *     the machine IS configured to protect secrets and merely won't
+ *     serve us right now. Writing plaintext here would be a real
+ *     downgrade, so the write path refuses unless the operator opts in.
+ *
+ * Unknown wording therefore lands on the conservative side: refuse and
+ * say why, never a silent plaintext write.
+ *
+ * There is no third "the entry simply isn't there" class: 2.x reports
+ * a missing credential as `getPassword() === null` and
+ * `deletePassword() === false`, never as a throw (contract stated in
+ * `@napi-rs/keyring`'s own `index.d.ts`). Every throw reaching us
+ * means the store did not serve the operation.
+ */
+function classifyKeyringError(err: unknown): "store-unavailable" | "store-locked" {
+  return getErrorMessage(err).includes(PLATFORM_FAILURE_MARKER)
+    ? "store-unavailable"
+    : "store-locked";
 }
 
 /**
@@ -158,14 +181,15 @@ function classifyKeyringError(err: unknown): "missing-backend" | "entry-missing"
  * to disk. DPAPI-based encryption would fix this but is out of scope
  * for v1 (tracked as a follow-up).
  *
- * `entry-missing` is a read-path concept ("user hasn't logged in yet")
- * and never triggers a fallback, so we don't refuse on that case.
+ * Every throw from `@napi-rs/keyring` 2.x means the store did not serve
+ * the operation (a missing entry is a `null`/`false` return, not a
+ * throw), so on Windows the refusal is unconditional — there is no
+ * error class that would legitimately reach the file store here.
  * Export kept under the `_`-prefix convention for unit testability —
  * the real `process.platform` can't be faked cleanly in bun:test.
  */
-export function _shouldRefuseWindowsFallback(platform: string, err: unknown): boolean {
-  if (platform !== "win32") return false;
-  return classifyKeyringError(err) !== "entry-missing";
+export function _shouldRefuseWindowsFallback(platform: string): boolean {
+  return platform === "win32";
 }
 
 function refuseWindowsFallback(op: "read" | "write" | "delete", err: unknown): never {
@@ -192,7 +216,7 @@ function refuseWindowsFallback(op: "read" | "write" | "delete", err: unknown): n
  * — a bearer token in `~/.config/appstrate/credentials.json` equals
  * full account takeover for anyone with read access to the file.
  */
-function refuseBrokenKeyring(op: "read" | "write" | "delete", err: unknown): never {
+function refuseBrokenKeyring(op: "read" | "write", err: unknown): never {
   const cause = getErrorMessage(err);
   throw new Error(
     `Cannot ${op} Appstrate credentials: the OS keyring is installed but not serving.\n` +
@@ -208,13 +232,13 @@ function refuseBrokenKeyring(op: "read" | "write" | "delete", err: unknown): nev
       `    • Linux: ensure gnome-keyring / kwallet is running and unlocked\n` +
       `      (check with \`secret-tool store …\`).\n` +
       `    • Explicitly accept plaintext storage with:\n` +
-      `        APPSTRATE_ALLOW_PLAINTEXT_TOKENS=1 appstrate ${op === "delete" ? "logout" : "login"}\n` +
+      `        APPSTRATE_ALLOW_PLAINTEXT_TOKENS=1 appstrate login\n` +
       `      Only do this if you understand the tokens will be written\n` +
       `      to ~/.config/appstrate/credentials.json (mode 0600).`,
   );
 }
 
-function warnBackendOnce(op: "read" | "write" | "delete", err: unknown): void {
+function warnBackendOnce(op: "read" | "write", err: unknown): void {
   if (_backendWarningEmitted) return;
   _backendWarningEmitted = true;
   const msg = getErrorMessage(err);
@@ -230,24 +254,13 @@ export async function saveTokens(profile: string, tokens: Tokens): Promise<void>
     _keyringFactory(profile).setPassword(payload);
     return;
   } catch (err) {
-    if (_shouldRefuseWindowsFallback(process.platform, err)) refuseWindowsFallback("write", err);
-    // Three classes of error on write:
-    //   - `missing-backend`: no keyring daemon on this host (bare CI,
-    //     stripped container). Legitimate silent fallback to the 0600
-    //     JSON file — that's the whole point of the fallback.
-    //   - `broken`: keyring installed but not serving (locked Keychain,
-    //     frozen gnome-keyring). Refused by default. `APPSTRATE_ALLOW_
-    //     PLAINTEXT_TOKENS=1` opts in.
-    //   - `entry-missing`: napi-rs's "No matching entry" wording, which
-    //     is a read-path concept that shouldn't surface on a write.
-    //     Treat it symmetrically with `broken` — refuse by default,
-    //     because if the classification is wrong we'd rather fail loud
-    //     than silently drop plaintext tokens on disk. The same
-    //     `APPSTRATE_ALLOW_PLAINTEXT_TOKENS=1` escape hatch covers the
-    //     corner case where a future napi-rs version legitimately uses
-    //     that wording on write.
-    const kind = classifyKeyringError(err);
-    if (kind === "broken" || kind === "entry-missing") {
+    if (_shouldRefuseWindowsFallback(process.platform)) refuseWindowsFallback("write", err);
+    // The write path is the only one that can DOWNGRADE storage: it is
+    // where a plaintext file would come into existence. `store-locked`
+    // means the host does protect secrets, so refuse unless the
+    // operator opted in; `store-unavailable` means there is nothing to
+    // downgrade from and the 0600 file is the documented fallback.
+    if (classifyKeyringError(err) === "store-locked") {
       if (!plaintextFallbackAllowed()) refuseBrokenKeyring("write", err);
       warnBackendOnce("write", err);
     }
@@ -315,15 +328,13 @@ export async function loadTokens(profile: string): Promise<Tokens | null> {
       return parsed;
     }
   } catch (err) {
-    if (_shouldRefuseWindowsFallback(process.platform, err)) refuseWindowsFallback("read", err);
-    // "No matching entry" on read is normal — the user simply hasn't
-    // stored credentials for this profile yet. Missing-backend is the
-    // expected fallback trigger. A broken daemon is refused on unix
-    // unless the user opts into plaintext explicitly, otherwise we'd
-    // silently read from a plaintext file the user never consented to
-    // populate.
-    const kind = classifyKeyringError(err);
-    if (kind === "broken") {
+    if (_shouldRefuseWindowsFallback(process.platform)) refuseWindowsFallback("read", err);
+    // A host with no working store (`store-unavailable`) is the
+    // expected fallback trigger — the credentials only ever lived in
+    // the file. A locked store is refused on unix unless the user opts
+    // into plaintext explicitly, otherwise we'd silently read from a
+    // plaintext file the user never consented to populate.
+    if (classifyKeyringError(err) === "store-locked") {
       if (!plaintextFallbackAllowed()) refuseBrokenKeyring("read", err);
       warnBackendOnce("read", err);
     }
@@ -351,25 +362,43 @@ export async function loadTokens(profile: string): Promise<Tokens | null> {
   return fromFile;
 }
 
+/**
+ * Remove a profile's tokens from BOTH stores.
+ *
+ * Deletion never refuses: refusing to delete is the one failure mode
+ * that GUARANTEES the outcome we are protecting against — a live
+ * plaintext refresh token left in `credentials.json` after the user
+ * ran `logout` and was told nothing (issue #1321). So the file store is
+ * always cleared first, and only then is a keyring failure reported,
+ * loudly, because a copy of the credential may survive there.
+ */
 export async function deleteTokens(profile: string): Promise<void> {
+  let keyringError: unknown;
   try {
     _keyringFactory(profile).deletePassword();
   } catch (err) {
-    if (_shouldRefuseWindowsFallback(process.platform, err)) refuseWindowsFallback("delete", err);
-    // A missing entry is not an error; the file fallback below still
-    // runs so a partial keyring/file divergence is cleaned up. A broken
-    // daemon is still refused on unix unless the user opts into
-    // plaintext — otherwise `logout` would silently only clear half of
-    // a split-brain storage situation.
-    if (classifyKeyringError(err) === "broken") {
-      if (!plaintextFallbackAllowed()) refuseBrokenKeyring("delete", err);
-      warnBackendOnce("delete", err);
-    }
+    keyringError = err;
   }
   // Windows has no file fallback to clean up — Credential Manager is
   // the single source of truth there.
-  if (process.platform === "win32") return;
-  await deleteFromFile(profile);
+  if (process.platform !== "win32") await deleteFromFile(profile);
+  if (keyringError === undefined) return;
+  if (_shouldRefuseWindowsFallback(process.platform)) refuseWindowsFallback("delete", keyringError);
+  // A host with no working store never held a keyring entry for this
+  // profile — the file store we just cleared was the only copy.
+  if (classifyKeyringError(keyringError) === "store-unavailable") return;
+  throw new Error(
+    `Signed out of profile "${profile}" locally, but the OS keyring entry could not be removed.\n` +
+      `  Cause: ${getErrorMessage(keyringError)}\n` +
+      `  The credentials file was cleared; a copy of the token may remain in\n` +
+      `  the keyring until the store is reachable again.\n\n` +
+      `  Fixes:\n` +
+      `    • Unlock the keyring (macOS: \`security unlock-keychain\`; Linux:\n` +
+      `      start / unlock gnome-keyring) and re-run \`appstrate logout\n` +
+      `      --profile ${profile}\`.\n` +
+      `    • Or delete the "${SERVICE_NAME}" entry for "${profile}" with your\n` +
+      `      platform's credential manager.`,
+  );
 }
 
 // ─── File fallback ───────────────────────────────────────────────────────────

--- a/apps/cli/test/keyring-error-markers.test.ts
+++ b/apps/cli/test/keyring-error-markers.test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pins `lib/keyring.ts`'s error markers against the `@napi-rs/keyring`
+ * native binary this checkout actually installs.
+ *
+ * Why this test exists: the markers are the only discriminator we get.
+ * `@napi-rs/keyring` surfaces `keyring-core` errors as plain JS `Error`s
+ * — no variant, no `code`, nothing but the Display string — and that
+ * string decides whether a keyring failure means "this host has no
+ * store, use the 0600 file" or "the store is locked, refuse to write
+ * plaintext". The 2.0 bump (#1299) reworded every one of them and no
+ * call site noticed, so a store-less CI runner started hard-refusing
+ * instead of falling back (#1321). A matcher over an upstream message
+ * that nothing verifies is a silent time bomb; reading the shipped
+ * binary turns the next rewording into a red test.
+ *
+ * The binary is read as BYTES and never loaded: `new Entry(...)` on a
+ * daemon-less Linux runner segfaults the process (see the note on
+ * `_isKeyringFactoryOverriddenForTesting` in `lib/keyring.ts`), which
+ * no test can catch.
+ */
+
+import { describe, it, expect, beforeAll } from "bun:test";
+import { dirname } from "node:path";
+import { PLATFORM_FAILURE_MARKER, NO_STORAGE_ACCESS_MARKER } from "../src/lib/keyring.ts";
+
+/**
+ * Platform packages `@napi-rs/keyring` may have installed here. Linux
+ * lists both libc flavours rather than sniffing which one is running —
+ * exactly one of them is present, and trying both is cheaper than
+ * getting musl detection wrong.
+ */
+function candidatePackages(): string[] {
+  const arch = process.arch;
+  switch (process.platform) {
+    case "darwin":
+      return [`@napi-rs/keyring-darwin-${arch}`];
+    case "win32":
+      return [`@napi-rs/keyring-win32-${arch}-msvc`];
+    case "linux":
+      return [`@napi-rs/keyring-linux-${arch}-gnu`, `@napi-rs/keyring-linux-${arch}-musl`];
+    default:
+      return [`@napi-rs/keyring-${process.platform}-${arch}`];
+  }
+}
+
+/**
+ * The platform package is an optional dependency of `@napi-rs/keyring`,
+ * so under bun's isolated layout it is only reachable FROM the keyring
+ * package's own directory — not from this workspace. Resolve in two
+ * steps for that reason. Its `main` is the `.node` file itself, so the
+ * resolved path is the binary.
+ */
+function nativeBindingPath(): string {
+  const keyringDir = dirname(Bun.resolveSync("@napi-rs/keyring", import.meta.dir));
+  const tried: string[] = [];
+  for (const pkg of candidatePackages()) {
+    try {
+      return Bun.resolveSync(pkg, keyringDir);
+    } catch {
+      tried.push(pkg);
+    }
+  }
+  throw new Error(
+    `No @napi-rs/keyring native package installed for ${process.platform}-${process.arch} (tried: ${tried.join(", ")}). ` +
+      `The CLI cannot store credentials without it.`,
+  );
+}
+
+describe("@napi-rs/keyring error markers", () => {
+  let binary: Buffer;
+
+  beforeAll(async () => {
+    binary = Buffer.from(await Bun.file(nativeBindingPath()).bytes());
+  });
+
+  it("still emits the two Display prefixes the classifier splits on", () => {
+    expect(binary.includes(PLATFORM_FAILURE_MARKER, 0, "utf8")).toBe(true);
+    expect(binary.includes(NO_STORAGE_ACCESS_MARKER, 0, "utf8")).toBe(true);
+  });
+
+  it("no longer contains the 1.x wordings the classifier used to match", () => {
+    // Kept as evidence, not nostalgia: these three are what `lib/keyring.ts`
+    // matched on until #1321, and their absence is the whole bug. If a
+    // future bump brings any of them back, the classification needs
+    // re-reading rather than a silent extra branch.
+    for (const retired of ["Platform secure storage failure", "No storage", "No matching entry"]) {
+      expect(binary.includes(retired, 0, "utf8")).toBe(false);
+    }
+  });
+
+  it("carries the missing-credential wording that can never reach us", () => {
+    // `NoEntry`'s Display string is in the binary but cannot surface as
+    // a throw: 2.x returns `null` from `getPassword()` and `false` from
+    // `deletePassword()` for an absent credential. That contract is why
+    // the classifier has no "entry-missing" class any more.
+    expect(binary.includes("No matching credential found", 0, "utf8")).toBe(true);
+  });
+});

--- a/apps/cli/test/keyring.test.ts
+++ b/apps/cli/test/keyring.test.ts
@@ -53,12 +53,17 @@ function mkTokensJson(partial: {
 }
 
 // In-memory keyring backend + a toggle to simulate a failing daemon.
-// `throwMessage` defaults to the napi-rs/keyring error surfaced when no
-// backend is available — the expected silent-fallback path.
+// `throwMessage` defaults to the `keyring-core` `PlatformFailure`
+// wording — no store on this host, the expected silent-fallback path.
+// The two wordings used across this file are pinned against the shipped
+// native binary by `keyring-error-markers.test.ts`.
+const PLATFORM_FAILURE = "Platform failure: no DBus session bus";
+const STORE_LOCKED = "Couldn't access platform storage: SecKeychain error -25308";
+
 class FakeKeyring implements KeyringHandle {
   static store = new Map<string, string>();
   static shouldThrow = false;
-  static throwMessage = "Platform secure storage failure";
+  static throwMessage = PLATFORM_FAILURE;
 
   constructor(private profile: string) {}
 
@@ -111,7 +116,7 @@ beforeEach(async () => {
   process.env.XDG_CONFIG_HOME = tmpDir;
   FakeKeyring.store.clear();
   FakeKeyring.shouldThrow = false;
-  FakeKeyring.throwMessage = "Platform secure storage failure";
+  FakeKeyring.throwMessage = PLATFORM_FAILURE;
   _setKeyringFactoryForTesting((profile) => new FakeKeyring(profile));
 });
 
@@ -275,7 +280,7 @@ describe("broken-keyring fallback refusal (unix)", () => {
 
   beforeEach(() => {
     FakeKeyring.shouldThrow = true;
-    FakeKeyring.throwMessage = "gnome-keyring: DBus call timed out";
+    FakeKeyring.throwMessage = STORE_LOCKED;
     delete process.env.APPSTRATE_ALLOW_PLAINTEXT_TOKENS;
   });
 
@@ -297,8 +302,30 @@ describe("broken-keyring fallback refusal (unix)", () => {
     await expect(loadTokens("default")).rejects.toThrow(/keyring is installed but not serving/);
   });
 
-  it("refuses deleteTokens when the daemon is broken and no opt-in is set", async () => {
-    await expect(deleteTokens("default")).rejects.toThrow(/keyring is installed but not serving/);
+  it("clears the plaintext file even when the keyring delete fails", async () => {
+    // Issue #1321: refusing the delete guaranteed the outcome the
+    // refusal exists to prevent — a live 30-day refresh token left in
+    // credentials.json after `appstrate logout` said "Signed out".
+    // The file store must be cleared FIRST, and the surviving keyring
+    // entry reported afterwards.
+    process.env.APPSTRATE_ALLOW_PLAINTEXT_TOKENS = "1";
+    await saveTokens("default", mkTokens({ accessToken: "t", expiresAt: futureMs() }));
+    delete process.env.APPSTRATE_ALLOW_PLAINTEXT_TOKENS;
+    const { readFile } = await import("node:fs/promises");
+    expect(await readFile(credentialsPath(), "utf8")).toContain("rt-t");
+
+    await expect(deleteTokens("default")).rejects.toThrow(/keyring entry could not be removed/);
+
+    await expect(readFile(credentialsPath(), "utf8")).rejects.toThrow(/ENOENT/);
+  });
+
+  it("stays silent on delete when the host has no keyring store at all", async () => {
+    // Nothing was ever written to a store that does not exist, so the
+    // failed delete is a no-op — only the file store mattered.
+    FakeKeyring.throwMessage = PLATFORM_FAILURE;
+    await saveTokens("default", mkTokens({ accessToken: "t", expiresAt: futureMs() }));
+    await deleteTokens("default");
+    expect(await loadTokens("default")).toBeNull();
   });
 
   it("allows the plaintext fallback when APPSTRATE_ALLOW_PLAINTEXT_TOKENS=1", async () => {
@@ -309,7 +336,7 @@ describe("broken-keyring fallback refusal (unix)", () => {
   });
 
   it("still silent-falls-back on missing-backend (CI, stripped container)", async () => {
-    FakeKeyring.throwMessage = "Platform secure storage failure";
+    FakeKeyring.throwMessage = PLATFORM_FAILURE;
     // No opt-in env var. This is the bare-container / CI case — a
     // keyring is not expected, so falling back to 0600 file is the
     // documented behavior.
@@ -324,27 +351,17 @@ describe("Windows fallback refusal", () => {
   // `_shouldRefuseWindowsFallback` helper — stubbing
   // `process.platform` globally is racy with Bun's test runner and
   // would leak between tests.
-  it("refuses the fallback on win32 when the keyring backend is missing", () => {
-    const err = new Error("Platform secure storage failure");
-    expect(_shouldRefuseWindowsFallback("win32", err)).toBe(true);
-  });
-
-  it("refuses the fallback on win32 when the keyring backend is broken", () => {
-    const err = new Error("Credential Manager RPC call failed");
-    expect(_shouldRefuseWindowsFallback("win32", err)).toBe(true);
-  });
-
-  it("does NOT refuse on win32 when the entry simply doesn't exist yet", () => {
-    // Reads on a fresh install hit this path — no creds stored yet.
-    // The caller just returns null; no fallback needed, no refusal.
-    const err = new Error("No matching entry");
-    expect(_shouldRefuseWindowsFallback("win32", err)).toBe(false);
+  it("refuses the fallback on win32 for any keyring failure", () => {
+    // Every throw from @napi-rs/keyring 2.x means the store did not
+    // serve the call — a missing entry is a null/false RETURN, never a
+    // throw — so there is no error class that may reach a plaintext
+    // file on Windows.
+    expect(_shouldRefuseWindowsFallback("win32")).toBe(true);
   });
 
   it("never refuses on non-Windows platforms", () => {
-    const err = new Error("Platform secure storage failure");
-    expect(_shouldRefuseWindowsFallback("linux", err)).toBe(false);
-    expect(_shouldRefuseWindowsFallback("darwin", err)).toBe(false);
+    expect(_shouldRefuseWindowsFallback("linux")).toBe(false);
+    expect(_shouldRefuseWindowsFallback("darwin")).toBe(false);
   });
 });
 
@@ -522,38 +539,51 @@ describe("loadTokens expiration handling", () => {
   });
 });
 
-describe("classifyKeyringError after MISSING_BACKEND_MARKERS cleanup", () => {
-  // Regression guard: Fix 2 removed `"No matching entry"` from
-  // `MISSING_BACKEND_MARKERS` because `classifyKeyringError` checks
-  // for it FIRST and returns `"entry-missing"` before consulting the
-  // array. Verify the entry-missing classification is still preserved
-  // and the silent-fallback path on a real missing-backend marker
-  // still works.
-  it("classifies 'No matching entry' as entry-missing (read returns null, no throw)", async () => {
+describe("classifyKeyringError on @napi-rs/keyring 2.x wordings", () => {
+  // Issue #1321: the 2.0 bump reworded every error Display, and the
+  // markers this classification matched on ("Platform secure storage
+  // failure", "No storage") stopped existing in the binary — so a CI
+  // runner with no store classified as locked and hard-refused instead
+  // of using the file fallback the store-less host has no alternative
+  // to. These cases pin both sides of the split.
+  const originalPlaintextEnv = process.env.APPSTRATE_ALLOW_PLAINTEXT_TOKENS;
+
+  beforeEach(() => {
     FakeKeyring.shouldThrow = true;
-    FakeKeyring.throwMessage = "No matching entry";
-    // entry-missing on read should NOT trigger refuseBrokenKeyring —
-    // it's the normal "user hasn't logged in yet" signal. Falls
-    // through to the file fallback, which is also empty → null.
-    expect(await loadTokens("default")).toBeNull();
+    delete process.env.APPSTRATE_ALLOW_PLAINTEXT_TOKENS;
   });
 
-  it("still silent-falls-back on 'Platform secure storage failure'", async () => {
-    FakeKeyring.shouldThrow = true;
-    FakeKeyring.throwMessage = "Platform secure storage failure";
-    // No APPSTRATE_ALLOW_PLAINTEXT_TOKENS — the missing-backend path
-    // is the expected silent-fallback case (CI / stripped container).
+  afterEach(() => {
+    if (originalPlaintextEnv === undefined) {
+      delete process.env.APPSTRATE_ALLOW_PLAINTEXT_TOKENS;
+    } else {
+      process.env.APPSTRATE_ALLOW_PLAINTEXT_TOKENS = originalPlaintextEnv;
+    }
+  });
+
+  it("silent-falls-back on a PlatformFailure (no store on this host)", async () => {
+    FakeKeyring.throwMessage = PLATFORM_FAILURE;
     const toks = mkTokens({ accessToken: "ok", expiresAt: futureMs() });
     await saveTokens("default", toks);
     expect(await loadTokens("default")).toEqual(toks);
   });
 
-  it("still silent-falls-back on 'No storage' marker", async () => {
-    FakeKeyring.shouldThrow = true;
-    FakeKeyring.throwMessage = "No storage backend available";
-    await saveTokens("default", mkTokens({ accessToken: "ok2", expiresAt: futureMs() }));
-    const loaded = await loadTokens("default");
-    expect(loaded?.accessToken).toBe("ok2");
+  it("refuses a write on a NoStorageAccess (store present but locked)", async () => {
+    FakeKeyring.throwMessage = STORE_LOCKED;
+    await expect(
+      saveTokens("default", mkTokens({ accessToken: "ok2", expiresAt: futureMs() })),
+    ).rejects.toThrow(/keyring is installed but not serving/);
+  });
+
+  it("refuses rather than guesses when the wording is unknown", async () => {
+    // The conservative side of the split: an unrecognised throw never
+    // becomes a silent plaintext write. The retired 1.x markers land
+    // here, which is what makes a future rewording loud instead of
+    // silently permissive.
+    FakeKeyring.throwMessage = "Platform secure storage failure";
+    await expect(
+      saveTokens("default", mkTokens({ accessToken: "ok3", expiresAt: futureMs() })),
+    ).rejects.toThrow(/keyring is installed but not serving/);
   });
 });
 


### PR DESCRIPTION
Closes #1321

## Root cause

`@napi-rs/keyring` 2.0 (bumped in `ebb3764d2`, #1299) reworded every `keyring-core` error Display **and** made `getPassword`/`deletePassword` throw where 1.x swallowed. That armed two `catch` blocks whose markers no longer exist in the shipped binary — `apps/cli/src/lib/keyring.ts:139` matched `"Platform secure storage failure"` / `"No storage"`, and `:146` matched `"No matching entry"`; the binary emits `"Platform failure: "` and `"Couldn't access platform storage: "` (verified by reading the installed `keyring.darwin-arm64.node`). So every store failure classified as `"broken"`:

- a CI runner / stripped container with no secret-service daemon stopped falling back to the 0600 `credentials.json` and died on *"the OS keyring is installed but not serving"*;
- `deleteTokens` (`:388`) threw **before** `deleteFromFile`, so `appstrate logout` on a locked keychain left the live 30-day refresh token in plaintext on disk — the exact outcome the refusal exists to prevent.

## Fix

Classification now works off the two Display prefixes 2.x actually emits, split by what they *mean* instead of lumped as the 1.x list had them:

- `PlatformFailure` → `store-unavailable`: no store on this host, so there is no keyring protection to downgrade from — the 0600 file is the documented fallback.
- `NoStorageAccess` (and any unknown wording) → `store-locked`: the machine does protect secrets and merely will not serve us, so the **write** path still refuses unless `APPSTRATE_ALLOW_PLAINTEXT_TOKENS=1`. Unknown wording lands on the refusing side by construction: a future rewording fails loud, never into a silent plaintext write.

The `entry-missing` class is gone: 2.x reports an absent credential as `getPassword() === null` / `deletePassword() === false`, never as a throw (its own `index.d.ts` states the contract; verified against the real binding). That also makes `_shouldRefuseWindowsFallback` unconditional, so it no longer takes the error.

`deleteTokens` never refuses any more — refusing a *delete* guarantees the plaintext survives. It clears the file store first and only then reports a surviving keyring entry, with an error that says what remains and how to remove it. `lib/api.ts`'s three `deleteTokens(...).catch(() => {})` scrub paths get the same guarantee for free.

Read-path behaviour on a locked store is deliberately unchanged: it still refuses with the documented `APPSTRATE_ALLOW_PLAINTEXT_TOKENS=1` escape hatch, which is this file's stated posture (only the *classification* of which errors reach that branch was wrong).

## Tests

- `apps/cli/test/keyring-error-markers.test.ts` (new): pins both prefixes against the installed native binary and asserts the three retired 1.x wordings are absent, so the next bump that rewords them is red instead of silently mis-classifying. The `.node` is read as **bytes and never loaded** — `new Entry(...)` on a daemon-less Linux runner segfaults the process (same reason as the note on `_isKeyringFactoryOverriddenForTesting`), so no test may call the real binding.
- `apps/cli/test/keyring.test.ts`: fixtures moved to the real 2.x wordings (they were all 1.x strings, which is why the suite stayed green through the bump); the delete case now asserts the credentials file **is** cleared when the keyring delete fails; the classification block covers both sides of the split plus the refuse-on-unknown-wording case.

Commands (from `apps/cli`, per the CLI test convention):

- `TEST_TIER=0 bun test test/keyring.test.ts test/keyring-error-markers.test.ts test/logout.test.ts` → **54 pass, 0 fail**
- `TEST_TIER=0 bun test` over the auth/keyring-dependent files (keyring, keyring-error-markers, logout, auth-fixture, token, api, device-flow, whoami, org-command, jwt-identity, doctor) → **192 pass, 0 fail**
- `bunx tsc --noEmit -p apps/cli` → clean; `bunx eslint` + `bunx prettier --check` on the touched files → clean; `bunx knip --workspace apps/cli` → no findings

## Notes for the orchestrator

- No migration, no env var, no OpenAPI surface. Branch is stacked on `fix/issue-1364` as instructed.
- No overlap with #1361. `apps/cli/src/commands/logout.ts` is **not** touched: the fix belongs in the keyring seam, and logout already surfaces whatever `deleteTokens` reports.
- Linux wording is unverified by hand (the issue's open point), but it no longer needs to be: the pin reads whichever platform binary is installed, so CI on linux-x64 checks the linux strings itself.
- Behaviour change worth a release note: on a locked keychain, `appstrate logout` now exits non-zero after clearing the file store, saying the keyring copy may remain — previously it threw with the plaintext still on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
