### PR TITLE
fix(scripts): make verify:openapi step 2 fail on an invalid document

### DIFF
--- a/scripts/lib/openapi-structure.ts
+++ b/scripts/lib/openapi-structure.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared helper: structural OpenAPI validation (§2 of `scripts/verify-openapi.ts`).
+ *
+ * Lives here rather than inline in the gate so the failure path is reachable from a
+ * test: the gate builds its document from the real source tree and has no seam for a
+ * deliberately malformed one.
+ *
+ * `@readme/openapi-parser`'s `validate()` RESOLVES with `{ valid: false, errors }` for a
+ * document that violates the OpenAPI schema — it throws only for I/O and $ref resolution
+ * failures. A caller that reacts to a throw alone therefore passes every malformed
+ * document, which is exactly what this gate did until issue #1360. Both outcomes are
+ * folded into one return value here so there is no way to consume the valid half without
+ * the invalid one.
+ */
+import { validate, compileErrors, type ParserOptions } from "@readme/openapi-parser";
+
+const OPTIONS = {
+  // Skip external $ref resolution (AFPS schema URLs) — validated separately by afps-spec repo
+  resolve: { external: false },
+} satisfies ParserOptions;
+
+/**
+ * @returns `null` when the document conforms, otherwise the human-readable error report.
+ */
+export async function validateOpenApiStructure(spec: unknown): Promise<string | null> {
+  try {
+    // Deep-clone to avoid mutation by the parser (it dereferences $refs in-place)
+    const specCopy = JSON.parse(JSON.stringify(spec));
+    const result = await validate(specCopy, OPTIONS);
+    return result.valid ? null : compileErrors(result);
+  } catch (err: unknown) {
+    // Reached when the document cannot even be cloned or read. Schema violations and
+    // unresolvable $refs do NOT land here — they arrive as `valid: false` above — so the
+    // gate must never rely on this branch alone.
+    return err instanceof Error ? err.message : String(err);
+  }
+}

--- a/scripts/test/openapi-structure.test.ts
+++ b/scripts/test/openapi-structure.test.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * §2 of `bun run verify:openapi`, the step that reported OK on every document ever handed to it
+ * (#1360). The gate builds its document from the real source tree, so the only way to hand this
+ * step a deliberately malformed one is through the helper it now delegates to.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { validate } from "@readme/openapi-parser";
+import { validateOpenApiStructure } from "../lib/openapi-structure.ts";
+
+/** Smallest document `@readme/openapi-parser` accepts: 3.1 needs a non-empty `paths`. */
+const CONFORMING = {
+  openapi: "3.1.0",
+  info: { title: "Fixture", version: "1.0.0" },
+  paths: { "/x": { get: { responses: { "200": { description: "ok" } } } } },
+};
+
+/** A structural defect the parser reports and Redocly's ruleset (§3) does not. */
+function withMissingInfoVersion(): unknown {
+  const spec = structuredClone(CONFORMING) as { info: { version?: string } };
+  delete spec.info.version;
+  return spec;
+}
+
+describe("validateOpenApiStructure", () => {
+  it("accepts a conforming document", async () => {
+    expect(await validateOpenApiStructure(CONFORMING)).toBeNull();
+  });
+
+  it("fails a document missing a required field, naming the field", async () => {
+    const failure = await validateOpenApiStructure(withMissingInfoVersion());
+    expect(failure).not.toBeNull();
+    expect(failure).toContain("version is missing here");
+  });
+
+  it("fails a document whose array schema declares no `items`", async () => {
+    const spec = structuredClone(CONFORMING);
+    spec.paths["/x"].get.responses["200"] = {
+      description: "ok",
+      content: { "application/json": { schema: { type: "array" } } },
+    } as (typeof spec.paths)["/x"]["get"]["responses"]["200"];
+    expect(await validateOpenApiStructure(spec)).toContain("`items` schema");
+  });
+
+  it("fails a document with an unresolvable internal $ref", async () => {
+    const spec = structuredClone(CONFORMING);
+    spec.paths["/x"].get.responses["200"] = {
+      description: "ok",
+      content: { "application/json": { schema: { $ref: "#/components/schemas/Absent" } } },
+    } as (typeof spec.paths)["/x"]["get"]["responses"]["200"];
+    expect(await validateOpenApiStructure(spec)).toContain("Missing $ref pointer");
+  });
+
+  it("reports a document it cannot even read as a failure rather than throwing", async () => {
+    const circular: Record<string, unknown> = { ...CONFORMING };
+    circular.self = circular;
+    const failure = await validateOpenApiStructure(circular);
+    expect(failure).not.toBeNull();
+    expect(failure!.toLowerCase()).toMatch(/cyclic|circular/);
+  });
+
+  it("does not lean on a throw: the parser RESOLVES on a malformed document", async () => {
+    // The bug this file exists for. `await validate(bad)` inside a bare try/catch printed
+    // `OK — valid OpenAPI 3.1 document.` and exited 0, because nothing was ever thrown.
+    // Pin the library semantics so a refactor back to catch-only is a red test, not a silent gate.
+    const result = await validate(withMissingInfoVersion() as Parameters<typeof validate>[0], {
+      resolve: { external: false },
+    });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -39,7 +39,6 @@
  */
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { dirname, join, normalize, relative } from "node:path";
-import { validate as validateOpenAPI } from "@readme/openapi-parser";
 import { lintFromString, createConfig } from "@redocly/openapi-core";
 import type { OpenApiSchemaEntry } from "@appstrate/core/module";
 import { buildOpenApiSpec } from "../apps/api/src/openapi/index.ts";
@@ -61,6 +60,7 @@ import {
   llmProxyUrlPath,
   type ProxiedApiShape,
 } from "../packages/runner-pi/src/llm-proxy-routes.ts";
+import { validateOpenApiStructure } from "./lib/openapi-structure.ts";
 import { collectModuleOpenApi, discoverWorkspaceModuleDirs } from "./lib/module-openapi.ts";
 import { getTypeShape, type TypeShape } from "./lib/ts-interface-required-keys.ts";
 
@@ -126,16 +126,12 @@ console.log(`  Spec endpoints: ${specEndpoints.size} (coverage asserted in §5 /
 console.log(`\n  2. Structural Validation (@readme/openapi-parser)`);
 console.log(`  --------------------------------------------------`);
 
-try {
-  // Deep-clone to avoid mutation by the parser (it dereferences $refs in-place)
-  const specCopy = JSON.parse(JSON.stringify(openApiSpec));
-  // Skip external $ref resolution (AFPS schema URLs) — validated separately by afps-spec repo
-  await validateOpenAPI(specCopy, { resolve: { external: false } });
+const structuralFailure = await validateOpenApiStructure(openApiSpec);
+if (structuralFailure === null) {
   console.log(`  OK — valid OpenAPI ${openApiSpec.openapi} document.`);
-} catch (err: unknown) {
+} else {
   exitCode = 1;
-  const msg = err instanceof Error ? err.message : String(err);
-  console.log(`  FAIL — ${msg}`);
+  console.log(`  FAIL — ${structuralFailure}`);
 }
 
 // ═══════════════════════════════════════════════════
@@ -183,7 +179,7 @@ try {
   });
 
   // Strip remote $refs (AFPS schema URLs) before linting — Redocly's lintFromString
-  // has no option equivalent to validateOpenAPI's `resolve: { external: false }`, and
+  // has no option equivalent to the parser's `resolve: { external: false }`, and
   // fetching the 4 AFPS schemas over HTTPS adds ~20s with no disk cache. The AFPS
   // schemas are validated separately by the afps-spec repo, so replacing them with a
   // stub object is safe and drops this step from ~20s to ~150ms.


### PR DESCRIPTION
Closes #1360

## Root cause

`scripts/verify-openapi.ts:129-139` wrapped `validateOpenAPI(specCopy, …)` in a `try`/`catch`
and threw the return value away. `@readme/openapi-parser`'s `validate()` **resolves** with
`{ valid: false, errors, … }` for a document that violates the OpenAPI schema — it throws only
when the document cannot be read at all (verified: a spec missing `info.version`, an array
schema without `items`, and an unresolvable internal `$ref` all resolve, none throw). So the
`catch` never ran, step 2 printed `OK — valid OpenAPI 3.1 document.` unconditionally and could
not raise `exitCode`. The package exports `compileErrors(result)` for exactly this; it was
imported nowhere in the repo.

## Fix

- New `scripts/lib/openapi-structure.ts` — `validateOpenApiStructure(spec)` returns `null` when
  the document conforms, otherwise the rendered failure (`compileErrors(result)` for a resolved
  `valid: false`, the error message for a genuine throw). Both outcomes fold into one return
  value, so there is no way to consume the pass half without the fail half.
- `scripts/verify-openapi.ts` step 2 branches on that instead of on a throw. Net −10/+6 lines
  there, plus one stale comment reference renamed.

**Why a helper rather than four lines in place:** the gate composes its document from the real
source tree via `buildOpenApiSpec()` and exposes no seam for a deliberately malformed one, so an
in-place fix is untestable. `scripts/lib/` is where this repo already keeps gate helpers
(`module-openapi.ts`, `ts-interface-required-keys.ts`), each with a `scripts/test/` unit test.

**The repository's spec passes the now-real check unchanged.** The discarded result was hiding
no defect — `bun run verify:openapi` is `ALL CHECKS PASSED`, exit 0, with step 2 reporting
`OK — valid OpenAPI 3.1.0 document.` for real. No spec edits, so no `generate:api` churn.

## Tests

`scripts/test/openapi-structure.test.ts` (new, 6 tests): a conforming document passes; a missing
required field, an array schema without `items` and an unresolvable internal `$ref` each fail
with a message naming the defect; an unreadable document is reported rather than thrown; and one
test pins the library semantics that caused the bug (`validate()` resolves on a malformed
document) so a refactor back to a bare try/catch is a red test, not a silent gate.

```
set -a && . ./.env && set +a && TEST_TIER=0 bun test scripts/test/openapi-structure.test.ts
  → 6 pass, 0 fail

bunx tsc --noEmit -p scripts/tsconfig.json      → clean
bunx eslint / prettier --check (3 files)        → clean
bun run verify:openapi                          → ALL CHECKS PASSED, exit 0
bun run verify:dead-code                        → exit 0 (knip: hints only, pre-existing)
```

Two negative controls, both run:

1. **Helper** — reverting `openapi-structure.ts` to the old catch-only shape turns 3 of the 6
   tests red (missing field, missing `items`, bad `$ref`). Restored afterwards.
2. **Gate, end to end** — temporarily deleting `version: "1.0.0"` from
   `apps/api/src/openapi/info.ts` makes `bun run verify:openapi` print
   `FAIL — OpenAPI schema validation failed.` at step 2 and exit **1** (`SOME CHECKS FAILED`).
   On `main` that same spec exits 0. Restored afterwards; `git diff` on `info.ts` is empty.

## Notes for the orchestrator

- No migration, no env var, no OpenAPI content change, no deploy ordering — this is a CI gate only.
- No overlap with siblings: the three files touched are `scripts/lib/openapi-structure.ts` (new),
  `scripts/test/openapi-structure.test.ts` (new) and `scripts/verify-openapi.ts` (step 2 only).
- **Consequence for the consolidated branch:** step 2 is now load-bearing for the first time. Any
  sibling PR that introduces a structural OpenAPI defect will fail `bun run check` here rather
  than passing silently as it would have on `main`. That is the point of the fix, but it is the
  one way this PR can turn another PR red.
- Redocly (step 3) is a different rule set and was already real; it stays untouched, as do the two
  pre-existing `no-illogical-composition-keywords` warnings it prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
