### PR TITLE
fix(cli): resolve self-update latest across every release page

### DIFF
--- a/apps/cli/src/commands/self-update.ts
+++ b/apps/cli/src/commands/self-update.ts
@@ -137,6 +137,19 @@ export async function runSelfUpdate(opts: SelfUpdateOptions = {}): Promise<SelfU
     };
   }
 
+  if (result.status === "refused-downgrade") {
+    // Exit 0, not a failure code: `self-update` runs unattended (cron, CI
+    // images), and a box that is simply ahead of the newest release must not
+    // start failing those. The refusal is loud in the message instead, and
+    // names the flag that overrides it.
+    return {
+      exitCode: SELF_UPDATE_EXIT.OK,
+      message:
+        `Already on appstrate ${result.version}, which is NEWER than ${target}. ` +
+        `Refusing to downgrade — pass --force to install ${target} anyway.`,
+      detail: result,
+    };
+  }
   if (result.status === "already-up-to-date") {
     return {
       exitCode: SELF_UPDATE_EXIT.OK,

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -44,13 +44,20 @@ const RELEASE_URL_BASE = "https://github.com/appstrate/appstrate/releases";
  * `release.yml` can steer an update.
  */
 const RELEASES_API_URL = "https://api.github.com/repos/appstrate/appstrate/releases";
-const RELEASES_PAGE_SIZE = 30;
 /**
- * Pages scanned before giving up: 150 releases. Every platform cycle creates
- * one `v*` plus at most three npm Releases, so a `v*` sits inside the first
- * page in practice; the cap only bounds the API calls when it does not.
+ * 100 is the GitHub API maximum. Every page is walked before the highest
+ * version is picked (see `resolveTargetVersion`), so a larger page is strictly
+ * fewer requests: two calls cover the same 200 releases a 30-per-page walk
+ * would spend seven on.
  */
-const RELEASES_MAX_PAGES = 5;
+const RELEASES_PAGE_SIZE = 100;
+/**
+ * Pages scanned before giving up: 200 releases, ~50 platform cycles back (each
+ * creates one `v*` plus at most three npm Releases). The cap bounds the API
+ * calls — GitHub's unauthenticated limit is 60 req/h per IP, and every
+ * resolution now pays for the full walk rather than stopping early.
+ */
+const RELEASES_MAX_PAGES = 2;
 const PLATFORM_TAG = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 function releasesPageUrl(page: number): string {
@@ -375,18 +382,22 @@ export async function resolveTargetVersion(
     }
     return v;
   }
-  // Newest first, as the API orders them. Only a platform `v<semver>` release
-  // carries the CLI binaries; the npm workflows (`cli@`, `core@`,
-  // `afps-shared@`) publish their own Releases and are skipped by tag, the
-  // same way `releases/latest` skips drafts and prereleases. Within the newest
-  // page that holds any candidate, the HIGHEST version wins, not the newest by
-  // creation date: a hotfix for an older line published after a newer release
-  // must not become "latest".
+  // The API orders releases by creation date, newest first. Only a platform
+  // `v<semver>` release carries the CLI binaries; the npm workflows (`cli@`,
+  // `core@`, `afps-shared@`) publish their own Releases and are skipped by
+  // tag, the same way `releases/latest` skips drafts and prereleases.
+  //
+  // EVERY page is collected before the HIGHEST version wins, not the highest
+  // within the first page that holds a candidate: creation order and version
+  // order diverge whenever a hotfix is cut for an older line. `v1.1.0` ships,
+  // enough npm Releases accumulate to fill a page, then `v1.0.1` is published
+  // for the old line — it now sits alone on page 1 while `v1.1.0` sits on
+  // page 2. Stopping at the first page with a candidate hands back `v1.0.1`
+  // and downgrades every user, which is exactly what this walk prevents.
   const skipped: string[] = [];
+  const candidates: string[] = [];
   for (let page = 1; page <= RELEASES_MAX_PAGES; page++) {
     const releases = await fetchReleasesPage(deps, page);
-    if (releases.length === 0) break;
-    const candidates: string[] = [];
     for (const release of releases) {
       if (!release || typeof release !== "object") continue;
       const { tag_name, draft, prerelease } = release as {
@@ -399,10 +410,13 @@ export async function resolveTargetVersion(
       if (PLATFORM_TAG.test(tag_name)) candidates.push(tag_name);
       else skipped.push(tag_name);
     }
-    if (candidates.length > 0) {
-      candidates.sort(compareSemver);
-      return normalizeVersion(candidates[candidates.length - 1]!);
-    }
+    // GitHub fills every page but the last, so a short page is the end of the
+    // list: stop instead of spending a request on a page known to be empty.
+    if (releases.length < RELEASES_PAGE_SIZE) break;
+  }
+  if (candidates.length > 0) {
+    candidates.sort(compareSemver);
+    return normalizeVersion(candidates[candidates.length - 1]!);
   }
   throw new Error(
     `No platform v* release among the newest ${skipped.length} GitHub Releases` +
@@ -469,9 +483,13 @@ interface PerformCurlUpdateOptions {
 }
 
 export interface PerformCurlUpdateResult {
-  /** `"updated"` when a binary was written; `"already-up-to-date"` when no-op. */
-  status: "updated" | "already-up-to-date";
-  /** Final installed version. */
+  /**
+   * `"updated"` when a binary was written; `"already-up-to-date"` when the
+   * target equals the running version; `"refused-downgrade"` when the target
+   * is OLDER than it. Both no-op statuses leave the binary untouched.
+   */
+  status: "updated" | "already-up-to-date" | "refused-downgrade";
+  /** Final installed version — the running one for both no-op statuses. */
   version: string;
   /** Destination path that was atomic-replaced (only when status === "updated"). */
   destination?: string;
@@ -497,8 +515,15 @@ export async function performCurlUpdate(
     );
   }
 
-  if (!opts.force && compareSemver(current, target) === 0) {
-    return { status: "already-up-to-date", version: current };
+  // Never move backwards. The resolver picks the highest published `v*`, so a
+  // target below the running version means either a `--release` naming an older
+  // line or a release that vanished from the list — in both cases installing it
+  // strands the user on the older binary, and the next run would resolve the
+  // same target and keep them there. `--force` is the deliberate override.
+  if (!opts.force) {
+    const cmp = compareSemver(current, target);
+    if (cmp === 0) return { status: "already-up-to-date", version: current };
+    if (cmp > 0) return { status: "refused-downgrade", version: current };
   }
 
   // Require minisign on PATH. Same UX as bootstrap.sh — fail closed; a

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -176,6 +176,16 @@ describe("resolveTargetVersion", () => {
     draft: flags.draft ?? false,
     prerelease: flags.prerelease ?? false,
   });
+  /**
+   * Pad a page to `per_page` entries with filler npm-package Releases. GitHub
+   * fills every page but the last, and the resolver reads that as "keep
+   * walking" — a short page ends the walk, so a multi-page fixture needs full
+   * pages to be reached at all.
+   */
+  const fullPage = (...head: unknown[]) => [
+    ...head,
+    ...Array.from({ length: 100 - head.length }, (_, i) => release(`core@9.0.${i}`)),
+  ];
   /** Serve `pages[n-1]` for `page=n`, `[]` past the last one, like GitHub. */
   const paged = (pages: unknown[][], calls?: string[]) => async (url: string) => {
     calls?.push(url);
@@ -189,7 +199,9 @@ describe("resolveTargetVersion", () => {
       fetchText: paged([[release("v2.5.0")]], calls),
     });
     expect(out).toBe("2.5.0");
-    expect(calls).toEqual([`${RELEASES_URL}?per_page=30&page=1`]);
+    // A short page is the last one: no request is spent probing for an empty
+    // page 2.
+    expect(calls).toEqual([`${RELEASES_URL}?per_page=100&page=1`]);
   });
 
   it("skips newer npm-package releases and picks the newest platform v* release", async () => {
@@ -241,15 +253,46 @@ describe("resolveTargetVersion", () => {
     const calls: string[] = [];
     const out = await resolveTargetVersion(undefined, {
       fetchText: paged(
-        [[release("cli@1.0.0-beta.56"), release("core@9.0.0")], [release("v1.0.0-beta.56")]],
+        [fullPage(release("cli@1.0.0-beta.56")), [release("v1.0.0-beta.56")]],
         calls,
       ),
     });
     expect(out).toBe("1.0.0-beta.56");
     expect(calls).toEqual([
-      `${RELEASES_URL}?per_page=30&page=1`,
-      `${RELEASES_URL}?per_page=30&page=2`,
+      `${RELEASES_URL}?per_page=100&page=1`,
+      `${RELEASES_URL}?per_page=100&page=2`,
     ]);
+  });
+
+  it("picks the highest version ACROSS pages, not the highest on the first page holding one", async () => {
+    // Issue #1361. `v1.1.0` shipped, a full page of npm Releases accumulated,
+    // then `v1.0.1` was cut for the old line — so page 1 holds only the lower
+    // version. Returning on the first page with a candidate downgrades every
+    // user to 1.0.1 and pins them there.
+    const calls: string[] = [];
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: paged(
+        [fullPage(release("v1.0.1"), release("cli@1.0.1")), [release("v1.1.0")]],
+        calls,
+      ),
+    });
+    expect(out).toBe("1.1.0");
+    expect(calls).toHaveLength(2);
+  });
+
+  it("stops at the page cap and still returns the highest candidate seen", async () => {
+    // The cap bounds the API calls; it must not turn into an early return that
+    // reintroduces the first-page pick.
+    const calls: string[] = [];
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: async (url) => {
+        calls.push(url);
+        const page = Number(new URL(url).searchParams.get("page"));
+        return JSON.stringify(fullPage(release(page === 1 ? "v1.0.1" : "v1.1.0")));
+      },
+    });
+    expect(out).toBe("1.1.0");
+    expect(calls).toHaveLength(2);
   });
 
   it("names the releases it saw when none is a platform v* release", async () => {
@@ -261,8 +304,8 @@ describe("resolveTargetVersion", () => {
     ).rejects.toThrow(
       /No platform v\* release among the newest 2 .*cli@1\.0\.0-beta\.56, core@9\.0\.0/,
     );
-    // Stopped at the first empty page, not at the page cap.
-    expect(calls).toHaveLength(2);
+    // A short page is the last one: stopped there, not at the page cap.
+    expect(calls).toHaveLength(1);
   });
 
   it("stops at the page cap when every page holds only npm-package releases", async () => {
@@ -271,11 +314,11 @@ describe("resolveTargetVersion", () => {
       resolveTargetVersion(undefined, {
         fetchText: async (url) => {
           calls.push(url);
-          return JSON.stringify([release("cli@1.0.0-beta.56")]);
+          return JSON.stringify(fullPage(release("cli@1.0.0-beta.56")));
         },
       }),
-    ).rejects.toThrow(/No platform v\* release among the newest 5 /);
-    expect(calls).toHaveLength(5);
+    ).rejects.toThrow(/No platform v\* release among the newest 200 /);
+    expect(calls).toHaveLength(2);
   });
 
   it("throws on malformed GitHub response", async () => {
@@ -492,6 +535,44 @@ describe("runSelfUpdate — curl flow", () => {
     expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
     expect(out.message).toMatch(/Already on appstrate 1\.2\.3/);
     expect(state.replaced).toEqual([]);
+  });
+
+  it("refuses to downgrade when the target is older than the running binary", async () => {
+    // Issue #1361: the second half of the guard. Even if a resolver bug or a
+    // vanished release hands back an older tag, the binary is never replaced.
+    const state = freshState();
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.0.1",
+      currentVersion: "1.1.0",
+      deps: makeFakeDeps(state),
+    });
+    // Exit 0, not a failure code: unattended runs on a box that is ahead of
+    // the newest release must not start failing.
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
+    expect(out.message).toMatch(/NEWER than 1\.0\.1/);
+    expect(out.message).toMatch(/--force/);
+    expect(state.replaced).toEqual([]);
+    // Nothing was even downloaded.
+    expect(state.fetched).toEqual([]);
+  });
+
+  it("--force downgrades deliberately", async () => {
+    const state = freshState();
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "9.9.9",
+      force: true,
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
+    expect(out.message).toContain("Updated appstrate to 1.2.3");
+    expect(state.replaced).toHaveLength(1);
   });
 
   it("--force reinstalls even when versions match", async () => {

--- a/docs/cli/upgrades.md
+++ b/docs/cli/upgrades.md
@@ -53,11 +53,17 @@ The command:
    own upgrades.
 3. If the binary has no stamp (built from source / copied), it exits 1 with
    a diagnostic. Re-install via curl to enable in-place upgrades.
-4. Otherwise: resolves the target version (default = latest from the
-   GitHub Releases API), downloads the asset + signed checksums + minisign
-   signature, verifies the signature against the same pubkey baked into
-   `scripts/bootstrap.sh`, verifies the SHA-256, and atomically renames the
-   new binary over `process.execPath`.
+4. Otherwise: resolves the target version (default = the **highest** platform
+   `v<semver>` Release, not the most recently created one — the Releases API
+   is listed and every page is read before the maximum is taken, so a hotfix
+   cut for an older line never becomes "latest"), downloads the asset + signed
+   checksums + minisign signature, verifies the signature against the same
+   pubkey baked into `scripts/bootstrap.sh`, verifies the SHA-256, and
+   atomically renames the new binary over `process.execPath`.
+
+A target **older** than the running binary is refused: the command exits 0,
+reports that it is not downgrading, and leaves the binary alone. Pass
+`--force` to install an older version deliberately.
 
 The verification posture is identical to the curl bootstrap — `minisign`
 must be on `$PATH`. There is no `--skip-verify` flag.


### PR DESCRIPTION
Closes #1361

## Root cause

`apps/cli/src/lib/self-update.ts` — `resolveTargetVersion` `return`ed from
inside the page loop as soon as a page held any platform `v*` Release, so
`candidates.sort(compareSemver)` only ever ranked **one** page. The comment
above the loop stated the invariant ("a hotfix for an older line published
after a newer release must not become latest") that the code did not hold.

`performCurlUpdate` only skipped the install when the target **equalled** the
running version (`compareSemver(current, target) === 0`), so any lower target
silently replaced the binary — and the next run resolved the same lower target
and kept the user there.

## Fix

- **Walk every page, then take the maximum.** `candidates` is hoisted out of
  the page loop; the sort happens once, after the walk. The loop stops on a
  *short* page (GitHub fills every page but the last) instead of spending a
  request to discover an empty one.
- **Page size 30 → 100 (the API maximum), cap 5 → 2.** The walk is no longer
  early-exiting, so it must stay cheap: two requests now cover the same 200
  releases a 30-per-page walk would spend seven on. GitHub's unauthenticated
  limit is 60 req/h per IP and this code already special-cases the 403.
- **Never move backwards.** `performCurlUpdate` returns a new
  `"refused-downgrade"` status when the target is older than the running
  version; the command reports it and names `--force` as the override.
  Defence in depth — it holds even if a release vanishes from the list.
  Exit code stays `0`: `self-update` runs unattended (cron, CI images), and a
  box that is simply ahead of the newest release must not start failing. The
  refusal is loud in the message instead.

`compareSemver` was already correct (including §11.4) and is untouched.

## Tests

`apps/cli/test/self-update.test.ts` — 3 new cases plus a `fullPage` fixture
helper (a multi-page fixture needs full pages now that a short page ends the
walk); existing per-page URL and page-cap assertions updated to the new
constants.

- `picks the highest version ACROSS pages, not the highest on the first page holding one`
- `stops at the page cap and still returns the highest candidate seen`
- `refuses to downgrade when the target is older than the running binary`
- `--force downgrades deliberately`

```
cd apps/cli && TEST_TIER=0 bun test test/self-update.test.ts   → 49 pass, 0 fail
bunx tsc --noEmit -p apps/cli                                   → clean
bunx eslint <3 touched files>                                   → clean
```

Negative control: with the early `return` and the downgrade guard reverted,
the three new cases fail (46 pass / 3 fail) — they do catch the bug.

## Notes for the orchestrator

- **Deliberately out of scope: the `scripts/bootstrap.sh` half of the issue.**
  The issue's "Related" section reports three defects in
  `resolve_latest_platform_release` (creation-order pick instead of highest
  semver; `grep -oE` matching `"prerelease": true` inside a release *body*;
  `[ -z "$fields" ] && return 1` aborting the whole 5-page walk on one
  transient curl failure). Same code is duplicated in
  `scripts/bootstrap-runner.sh:87`. They are untouched here: fixing them means
  a semver comparator and a JSON scanner in POSIX `sh`/awk with no test
  harness on the critical install path, and the **published** installer never
  takes that path (`publish-installer.yml` rewrites `__APPSTRATE_VERSION__`,
  so the resolver is only reached when running the script raw from the repo).
  `Closes #1361` will close the issue on merge — **that shell half deserves
  its own issue before this merges**, or the report is lost. I did not open
  one (not authorised to create issues).
- No migration, no env var, no OpenAPI change. CLI-only.
- Base is `fix/issue-1364` (the CLI chain tail); `fix/issue-1321` was not on
  origin when this started. No overlap with the 5 commits already on that
  base — none of them touch `self-update.*`.
- Behaviour change worth a release note: `self-update` on a binary newer than
  the latest release now no-ops with a message instead of downgrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
