### PR TITLE
test(module-ee): let the pure unit tests apply their own fixture env

### DIFF
--- a/packages/module-ee/test/helpers/fixture-env.ts
+++ b/packages/module-ee/test/helpers/fixture-env.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: LicenseRef-Appstrate-Commercial
+
+import requirements from "../requirements.ts";
+import { _resetEeEnvForTests } from "../../src/env.ts";
+
+/**
+ * Apply the fixture environment this module declares in `test/requirements.ts`.
+ *
+ * The module declares `postgres: true`, so under `TEST_TIER=0` the preload
+ * refuses to load it and never reaches the line that applies `requirements.env`
+ * — yet bun still collects a test file named directly on the command line. A
+ * pure schema/catalog test needs no database, only those values, so it applies
+ * them itself instead of inheriting whatever the developer's `.env` holds.
+ *
+ * Call it at the top level of such a file, BEFORE the first `getEeEnv()`: the
+ * parsed env is a lazy singleton, so this precedes every read while the
+ * `src/**` imports above it are already evaluated. Idempotent — tiers 1+ have
+ * the preload assign the very same values.
+ */
+export function applyEeFixtureEnv(): void {
+  Object.assign(process.env, requirements.env);
+  _resetEeEnvForTests();
+}

--- a/packages/module-ee/test/unit/billing-upgrades.test.ts
+++ b/packages/module-ee/test/unit/billing-upgrades.test.ts
@@ -17,6 +17,9 @@ import {
   getPlans,
   type PlanDefinition,
 } from "../../src/config.ts";
+import { applyEeFixtureEnv } from "../helpers/fixture-env.ts";
+
+applyEeFixtureEnv();
 
 function plan(id: string, tier: number, stripePriceId: string | null): PlanDefinition {
   return {

--- a/packages/module-ee/test/unit/config.test.ts
+++ b/packages/module-ee/test/unit/config.test.ts
@@ -16,6 +16,9 @@ import {
   COMPUTE_CREDITS_PER_CHAT_TURN,
   DEFAULT_QUOTE_RATES,
 } from "../../src/config.ts";
+import { applyEeFixtureEnv } from "../helpers/fixture-env.ts";
+
+applyEeFixtureEnv();
 
 describe("config", () => {
   describe("getPlans()", () => {

--- a/packages/module-ee/test/unit/env.test.ts
+++ b/packages/module-ee/test/unit/env.test.ts
@@ -2,6 +2,9 @@
 
 import { describe, expect, it } from "bun:test";
 import { describeEnvIssues, getEeEnv, _resetEeEnvForTests } from "../../src/env.ts";
+import { applyEeFixtureEnv } from "../helpers/fixture-env.ts";
+
+applyEeFixtureEnv();
 
 describe("env", () => {
   describe("getEeEnv()", () => {
@@ -13,7 +16,7 @@ describe("env", () => {
       expect(env.STRIPE_PRICE_ID_PRO).toBeString();
     });
 
-    it("returns the test values set by preload", () => {
+    it("returns the fixture values the module declares for its tests", () => {
       const env = getEeEnv();
       expect(env.STRIPE_SECRET_KEY).toBe("sk_test_fake_key_for_testing");
       expect(env.STRIPE_WEBHOOK_SECRET).toBe("whsec_test_secret_for_webhook_verification");

--- a/packages/module-ee/test/unit/init-requires-database-url.test.ts
+++ b/packages/module-ee/test/unit/init-requires-database-url.test.ts
@@ -9,6 +9,9 @@
 
 import { describe, expect, it } from "bun:test";
 import eeModule from "../../src/index.ts";
+import { applyEeFixtureEnv } from "../helpers/fixture-env.ts";
+
+applyEeFixtureEnv();
 
 describe("ee init without DATABASE_URL", () => {
   it("refuses with a message naming DATABASE_URL", async () => {


### PR DESCRIPTION
Closes #1367

## Root cause

`packages/module-ee/test/requirements.ts` declares `postgres: true`, so under `TEST_TIER=0` the preload's module loop `continue`s at `test/setup/preload.ts:317` (`skipsInTier`) — *before* `Object.assign(process.env, requirements.env ?? {})` at `:330`. `bun run test:tier0` honours that skip and excludes the module from collection, but naming a file directly (`TEST_TIER=0 bun test packages/module-ee/test/unit/env.test.ts`) still collects it, and `getEeEnv()` (`packages/module-ee/src/env.ts:152`) then parses the developer's ambient `.env` instead of the fixture.

Four pure files were red, not one: `env.test.ts` (11 of 12 cases), `config.test.ts` (4), `billing-upgrades.test.ts` (2) and `init-requires-database-url.test.ts` (1) — the last one asserting the `DATABASE_URL` refusal but receiving the Zod env error that fires first. Measured on this base: **110 pass / 18 fail** across `packages/module-ee/test/unit/`.

## Fix

Not the harness. The preload's contract — "a module this preload refuses to load is also a module whose tests bun does not collect" — is intact, and applying a *skipped* module's `requirements.env` (which by design overrides the ambient env) into a tier-0 run it was never loaded for is a footgun for any future module that declares e.g. a `DATABASE_URL`.

Instead the files that genuinely need no database stop depending on the preload's module phase: a new `test/helpers/fixture-env.ts` exports `applyEeFixtureEnv()`, which applies the values the module already declares in its own `requirements.ts` (single source, no duplicated literals) and drops the lazy env singleton. Four one-line call sites. It is idempotent — tiers 1+ have the preload assign exactly the same values — and safe by ordering because `getEeEnv()` is lazy, so a top-level call precedes every read even though the `src/**` imports above it are evaluated first.

One case renamed: `"returns the test values set by preload"` → `"returns the fixture values the module declares for its tests"`, since the preload is no longer the only source.

## Tests

No new test — the regression *is* the existing suite, which now passes in both tiers.

- `set -a && . ./.env && set +a && TEST_TIER=0 bun test packages/module-ee/test/unit/` → **128 pass / 0 fail** (was 110 pass / 18 fail)
- postgres tier, under the shared lock + docker stub: `bun test packages/module-ee/test/unit/` → **128 pass / 0 fail**
- `bun run test:tier0 packages/module-ee/test/unit/env.test.ts` → still excluded from collection (`tier0: excluding packages/module-ee …`), behaviour unchanged
- `bunx tsc --noEmit -p packages/module-ee` → clean; `bunx eslint` + `bunx prettier --check` on the 5 touched files → clean
- `bun run verify:license-boundary` → clean (2518 files, the new helper counted commercial)

## Notes for the orchestrator

- Test-only change: no `src/**`, no migration, no env var, no OpenAPI, no deploy ordering.
- Based on `fix/issue-1329` (EE chain tail) because #1328/#1370 moved `packages/module-ee/src/env.ts` and grew `test/unit/env.test.ts`; the fix lands on the current test.
- Scope note: the issue names `env.test.ts`, but the root cause is one and three sibling files in the same directory were red for it. Fixing only one would have left the module's local red — and the issue's stated cost *is* that red. No SIBLING issue territory touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
