### PR TITLE
fix(lint): extend the type-aware block to the cli, runtime-pi and scripts, and fix the defects it finds

### DIFF
--- a/apps/cli/src/lib/download.ts
+++ b/apps/cli/src/lib/download.ts
@@ -66,6 +66,19 @@ const DEFAULT_TOTAL_MS = 20 * 60_000;
 /** Never fire `onProgress` more than once per this interval (plus a final tick). */
 const PROGRESS_THROTTLE_MS = 250;
 
+/**
+ * Bytes buffered in the destination `FileSink` before it flushes to disk.
+ *
+ * Load-bearing, not a tuning knob: a `FileSink` opened WITHOUT a
+ * `highWaterMark` accumulates every written chunk in memory and flushes only
+ * on `end()` — which for a 113 MB CLI binary is the whole artifact resident,
+ * exactly the buffering this streaming helper exists to avoid (see the module
+ * doc above). With an explicit watermark, peak resident bytes are bounded by
+ * ~one watermark. Same value, and the same reason, as core's streaming upload
+ * (`packages/core/src/storage-fs.ts`).
+ */
+const SINK_FLUSH_BYTES = 1024 * 1024;
+
 /** Reason tags carried on the AbortController so the catch can explain itself. */
 const STALL = Symbol("stall");
 const TOTAL = Symbol("total");
@@ -148,7 +161,7 @@ export async function streamDownload(
       throw new Error(`GET ${url} → empty response body`);
     }
 
-    sink = Bun.file(destPath).writer();
+    sink = Bun.file(destPath).writer({ highWaterMark: SINK_FLUSH_BYTES });
     const reader = res.body.getReader();
     armStall();
     try {
@@ -158,7 +171,13 @@ export async function streamDownload(
         armStall();
         const bytes = chunk.value;
         hasher.update(bytes);
-        sink.write(bytes);
+        // AWAITED: `FileSink.write` returns `number | Promise<number>`, and
+        // returns the promise exactly when the sink has to drain — which is
+        // what `SINK_FLUSH_BYTES` above makes happen. Un-awaited it dropped
+        // both the backpressure and the rollback: a mid-write failure left the
+        // `catch` below untriggered and escaped as an unhandled rejection
+        // (fatal in Bun), so the partial file at `destPath` was never unlinked.
+        await sink.write(bytes);
         received += bytes.byteLength;
         emit(false, total);
       }

--- a/apps/cli/test/download.test.ts
+++ b/apps/cli/test/download.test.ts
@@ -54,6 +54,29 @@ describe("streamDownload", () => {
     expect(new Uint8Array(await readFile(dest))).toEqual(payload);
   });
 
+  it("round-trips a payload larger than the sink watermark", async () => {
+    // The destination `FileSink` is opened with an explicit `highWaterMark`
+    // (SINK_FLUSH_BYTES, 1 MiB) so it flushes mid-stream instead of holding
+    // the whole artifact in memory until `end()`. That watermark is the only
+    // thing that makes `FileSink.write` ever return a promise — a download
+    // smaller than it never drains, so it never exercises the awaited write.
+    // Cross it: the bytes on disk and the streamed sha256 must still match.
+    const dest = await tmpDest();
+    const payload = new Uint8Array(2 * 1024 * 1024 + 7);
+    for (let i = 0; i < payload.length; i++) payload[i] = i % 251;
+    const chunkSize = 64 * 1024;
+    const chunks: Uint8Array[] = [];
+    for (let o = 0; o < payload.length; o += chunkSize) {
+      chunks.push(payload.subarray(o, Math.min(o + chunkSize, payload.length)));
+    }
+    const res = await streamDownload("https://example/big", dest, {
+      fetchImpl: async () => streamingResponse(chunks),
+    });
+    expect(res.bytesWritten).toBe(payload.length);
+    expect(res.sha256).toBe(sha(payload));
+    expect(new Uint8Array(await readFile(dest))).toEqual(payload);
+  });
+
   it("reports progress with total from Content-Length", async () => {
     const dest = await tmpDest();
     const chunks = [new Uint8Array(10), new Uint8Array(10)];

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -790,7 +790,84 @@ export default tseslint.config(
     //
     // If this ever needs to get cheaper, narrow `files` before dropping a rule:
     // the cost is the type program, not the rule count.
-    files: ["apps/api/src/**/*.ts", "packages/*/src/**/*.ts"],
+    //
+    // ─── Why `apps/cli`, `runtime-pi` and `scripts` were added ───────────
+    //
+    // The first version of this block covered `apps/api/src` and
+    // `packages/*/src` only, which left out three trees that are backend code
+    // by every criterion the rationale above uses — while the rationale's own
+    // headline example, "an un-awaited promise in a run orchestrator", names a
+    // layer that lives in `runtime-pi/`. Run over those trees (2026-09-10) the
+    // three rules found 8 violations, four of them defects:
+    //
+    //   apps/cli/src   `download.ts` wrote to a default `FileSink` with the
+    //                  write un-awaited — a byte-for-byte twin of the
+    //                  `storage-fs.ts` defect this block's first run caught,
+    //                  in the copy that happened to be out of scope. Same two
+    //                  consequences: the whole artifact resident in memory,
+    //                  and a mid-write failure escaping the surrounding `try`
+    //                  as an unhandled rejection with the partial file left on
+    //                  disk.
+    //   runtime-pi     the sidecar's TCP connection handler dropped the
+    //                  promise of an `async` callback whose awaits (SSRF/DNS
+    //                  resolution, ClientHello reads) are not inside a `try` —
+    //                  one rejection there kills the sidecar process, and with
+    //                  it the run it proxies for. Plus a floating `FileSink`
+    //                  write in `provision.ts` and a dead truthiness test on a
+    //                  promise in `entrypoint.ts`.
+    //   scripts        no defect today (three `server.stop()` calls in a
+    //                  dev-only OAuth helper, one `Promise.all` over a
+    //                  null-mixed iterable). It is in scope for what it
+    //                  PREVENTS: `scripts/migration/**` mutates PRODUCTION
+    //                  data, which is the sharpest possible form of this
+    //                  block's first rationale — a migration that returns
+    //                  before its writes land reports a move that did not
+    //                  happen.
+    //
+    // ─── What this cost, and the ceiling it hit on the way ───────────────
+    //
+    // Widening this block is what discovered that the gate had no memory
+    // headroom left. `scripts/lint.ts` spawns `node_modules/.bin/eslint`,
+    // which is a NODE script, so the lint ran under node's default ~4 GB
+    // old-space — and this block's type programs are essentially all of that.
+    // Cold (`.eslintcache` deleted before each run), exit code captured:
+    //
+    //   before this change            exit 0
+    //   with the three trees added    exit 1  FATAL: Reached heap limit,
+    //                                         4078 MB — 2/2 runs
+    //
+    // The ceiling was ONE type program away, for any tree, for anyone. The
+    // fix belongs to the gate rather than to this block, so it lives in
+    // `scripts/lint.ts` (`--max-old-space-size`, see the note there) and the
+    // real cost of the three trees is only measurable once it is applied.
+    // Same conditions, cold, with that headroom in place:
+    //
+    //                                   user CPU   peak RSS   exit
+    //   before this change               81.0 s    3.69 GB     0
+    //   + apps/cli + runtime-pi          97.2 s    5.20 GB     0
+    //   + scripts/**                     96.3 s    4.35 GB     0 (once fixed)
+    //
+    // So the three trees together cost about +20% CPU on a COLD lint, and
+    // `scripts/**` — the one that looked expensive, since its tsconfig pulls
+    // `../apps/api/src/modules/*/index.ts` into a second program — costs
+    // nothing measurable on top of the other two. Wall clock is deliberately
+    // not quoted: the machine was running many parallel jobs and its wall
+    // numbers moved by 40% between identical runs, while user CPU did not.
+    //
+    // Warm stays warm: `--cache --cache-strategy content` rebuilds a type
+    // program only for the files that actually changed.
+    //
+    // Test trees stay out for the reason given above, and `apps/web/src` stays
+    // out because it has its own type-aware block: these three rules over JSX
+    // event handlers are a different (and much noisier) population than the
+    // backend one, and widening to the SPA is not this block's job.
+    files: [
+      "apps/api/src/**/*.ts",
+      "apps/cli/src/**/*.ts",
+      "packages/*/src/**/*.ts",
+      "runtime-pi/**/*.ts",
+      "scripts/**/*.ts",
+    ],
     ignores: ["**/test/**", "**/*.test.ts"],
     languageOptions: {
       parserOptions: {

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -749,7 +749,7 @@ const context: ExecutionContext = {
 // event). Re-awaiting the loader surfaces the ESM-cached rejection with its
 // real message, and `die()` restores the fail-fast contract: one
 // `appstrate.error` + a failed finalize instead of a lying ready signal.
-if (piSdkWarmup && (await piSdkWarmup) === null) {
+if ((await piSdkWarmup) === null) {
   try {
     await loadPiCodingAgentSdk();
   } catch (err) {

--- a/runtime-pi/provision.ts
+++ b/runtime-pi/provision.ts
@@ -274,7 +274,11 @@ export async function provisionFiles(deps: ProvisionDeps): Promise<void> {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
-        writer.write(value);
+        // AWAITED: `FileSink.write` hands back a promise whenever the sink has
+        // to drain, and dropping it sent a mid-write failure out as an
+        // unhandled rejection instead of into the `catch` below that routes it
+        // through `die()`.
+        await writer.write(value);
         // Apply backpressure so a fast upstream cannot queue unbounded chunks
         // in the sink buffer — keeps peak memory flat for large files.
         await writer.flush();

--- a/runtime-pi/sidecar/integration-mitm-listener.ts
+++ b/runtime-pi/sidecar/integration-mitm-listener.ts
@@ -261,12 +261,22 @@ export function createIntegrationMitmListener(
   // Outer TCP server: parse CONNECT, peek ClientHello for SNI, relay
   // to the per-SNI Bun.serve.
   const tcpServer = netCreateServer((rawSocket: Socket) => {
+    // `netCreateServer`'s handler is void-returning, so nothing in the runtime
+    // observes this promise. `handleInboundConnection` awaits the SSRF/DNS
+    // resolver and the ClientHello reads, none of which is inside a try — one
+    // rejection there is an unhandled rejection, which in Bun takes the whole
+    // sidecar down and with it the run it is proxying for. Route it through the
+    // same `tls-error` + destroy path the function's own failure branches use,
+    // so a bad connection kills the connection and nothing else.
     handleInboundConnection(
       rawSocket,
       async (sniHost) => getOrCreateTlsServer(sniHost),
       emit,
       options.resolveHostFn,
-    );
+    ).catch((err: unknown) => {
+      emit({ kind: "tls-error", error: `connection handler failed: ${(err as Error).message}` });
+      rawSocket.destroy();
+    });
   });
 
   let readyResolve!: () => void;

--- a/scripts/conformance/grab-token.ts
+++ b/scripts/conformance/grab-token.ts
@@ -160,7 +160,11 @@ async function main(): Promise<void> {
         const err = url.searchParams.get("error");
         if (err) {
           queueMicrotask(() => {
-            server.stop();
+            // `void` on all three `stop()` calls below: the microtask callback
+            // is void-returning, so an un-marked rejection would surface as an
+            // unhandled rejection, and the flow genuinely does not need the
+            // listening socket drained before the promise settles.
+            void server.stop();
             reject(new Error(`authorization denied: ${err}`));
           });
           return new Response(`Authorization failed: ${err}`, { status: 400 });
@@ -168,13 +172,13 @@ async function main(): Promise<void> {
         const got = url.searchParams.get("code");
         if (!got || url.searchParams.get("state") !== state) {
           queueMicrotask(() => {
-            server.stop();
+            void server.stop();
             reject(new Error("missing code or state mismatch on callback"));
           });
           return new Response("invalid callback", { status: 400 });
         }
         queueMicrotask(() => {
-          server.stop();
+          void server.stop();
           resolve(got);
         });
         return new Response(

--- a/scripts/lint.ts
+++ b/scripts/lint.ts
@@ -280,6 +280,32 @@ async function main(): Promise<number> {
   // It goes before `Bun.argv.slice(2)` so that a caller who genuinely wants a
   // budget (`bun run lint --max-warnings 20`) still wins: eslint takes the last
   // occurrence.
+  // `node_modules/.bin/eslint` is a NODE script, so a cold whole-repo lint runs
+  // under node's default old-space limit of ~4 GB — and the type-aware block in
+  // `eslint.config.mjs` builds one TypeScript program per tsconfig it reaches,
+  // which is where essentially all of that memory goes.
+  //
+  // That limit had already been reached. Measured 2026-09-10, cold
+  // (`.eslintcache` deleted before each run), exit code captured:
+  //
+  //   this config, before the type-aware block covered `apps/cli` +
+  //   `runtime-pi`               exit 0
+  //   ... with those two trees    exit 1  FATAL ERROR: Reached heap limit,
+  //                                       at 4078 MB — 2/2 runs
+  //   ... same, with this flag    exit 0  (5.2 GB peak RSS)
+  //
+  // So the ceiling was one type program away, and the next widening of that
+  // block — by anyone, for any tree — would have hit it first and reported a
+  // V8 stack trace instead of a lint result. `--max-old-space-size` is what
+  // buys the margin back. 8 GB is chosen against CI's 16 GB runner (half of
+  // it, ~3 GB above today's observed peak), not against today's number, so the
+  // gate does not need re-tuning the next time a package lands.
+  //
+  // `NODE_OPTIONS` rather than an argv flag: the flag has to reach node
+  // itself, and the child here is the eslint shim, not node. An existing
+  // NODE_OPTIONS is preserved and takes precedence — node applies the last
+  // occurrence, so a caller can still override the size.
+  const nodeOptions = `--max-old-space-size=8192 ${process.env.NODE_OPTIONS ?? ""}`.trim();
   const proc = Bun.spawnSync({
     cmd: [
       eslint,
@@ -292,6 +318,7 @@ async function main(): Promise<number> {
       ...present,
     ],
     cwd: REPO_ROOT,
+    env: { ...process.env, NODE_OPTIONS: nodeOptions },
     stdio: ["inherit", "inherit", "inherit"],
   });
   return proc.exitCode ?? 1;

--- a/scripts/migration/0010-ee-tables-into-platform-db.ts
+++ b/scripts/migration/0010-ee-tables-into-platform-db.ts
@@ -381,7 +381,7 @@ async function move(src: SQL, target: SQL, targetUrl: string, apply: boolean): P
   }
 
   const sourceCounts = await Promise.all(
-    plans.map((plan) => (plan.source === null ? null : countRows(src, plan.source))),
+    plans.map(async (plan) => (plan.source === null ? null : await countRows(src, plan.source))),
   );
 
   for (const line of planLines(prefix, plans)) out(line);


### PR DESCRIPTION
Closes #1359

## Root cause

`eslint.config.mjs`'s type-aware backend block scoped itself to
`files: ["apps/api/src/**/*.ts", "packages/*/src/**/*.ts"]`, so `apps/cli/src`,
`runtime-pi/**` and `scripts/**` got none of `no-floating-promises` /
`no-misused-promises` / `await-thenable` — while the block's own rationale names
"an un-awaited promise in a **run orchestrator**" as the motivating failure, and
that orchestrator lives in `runtime-pi/`.

Running the three rules over the excluded trees found **8 violations**, four of
them defects.

## Fix

### 1. The four defects

- **`apps/cli/src/lib/download.ts:161`** — the one the issue confirmed, and a
  byte-for-byte twin of the `packages/core/src/storage-fs.ts` defect that the
  commit which introduced this block fixed. `sink.write(bytes)` was un-awaited
  on a `Bun.file(destPath).writer()` opened with **no `highWaterMark`**; per
  core's own note (`storage-fs.ts:266-271`) such a sink accumulates every chunk
  in memory and flushes only on `end()`. So the CLI held a whole 113 MB
  artifact resident — this module's own doc comment promises "peak memory ≈ one
  chunk", which was false — and a mid-write failure escaped the surrounding
  `try` as an unhandled rejection (fatal in Bun), leaving the partial file at
  `destPath` un-unlinked. Fixed with an explicit 1 MiB watermark and an awaited
  write, matching core.
- **`runtime-pi/sidecar/integration-mitm-listener.ts:264`** — the `async`
  connection handler passed to `netCreateServer` had its promise dropped.
  `handleInboundConnection` awaits the SSRF/DNS rebind guard and the
  ClientHello reads outside any `try`, so a rejection there is an unhandled
  rejection that takes the **sidecar process** down, and with it the run it
  proxies for. Routed into the same `tls-error` + `rawSocket.destroy()` path
  the function's five other failure branches already use.
- **`runtime-pi/provision.ts:277`** — floating `writer.write(value)`; a
  mid-write failure bypassed the `catch` that routes stream errors through
  `die()`. Now awaited (the existing `flush()` still does the backpressure).
- **`runtime-pi/entrypoint.ts:752`** — `if (piSdkWarmup && …)` is a truthiness
  test on a value that is unconditionally a Promise, so the guard was dead and
  read as if the handle were optional. Removed.

The other four hits (three `server.stop()` calls in a dev-only OAuth helper,
one `Promise.all` over a null-mixed iterable in a migration) are not defects and
are fixed in place — `void` where ignoring is intended, a uniformly-async mapper
where it is not.

### 2. Heap headroom for the gate — the precondition, not scope creep

Widening the block is what discovered that `bun run lint` had **no memory
headroom left**. `scripts/lint.ts:256` spawns `node_modules/.bin/eslint`, a
NODE script, so the lint runs under node's default ~4 GB old-space, and this
block's TypeScript programs are essentially all of it. Cold, exit code
captured:

| config | cold `bun run lint` |
| ------ | ------------------- |
| `main` as-is | exit 0 |
| + the three trees | **exit 1 — `FATAL ERROR: Reached heap limit`, 4078 MB, 2/2 runs** |
| same, `--max-old-space-size=8192` | exit 0 |

The ceiling was **one type program away, for any tree, for anyone** — the next
widening of this block would have produced a V8 stack trace where a lint result
belongs, regardless of who did it or why. That is a property of the gate rather
than of this block, so the flag goes on the spawn in `scripts/lint.ts` via
`NODE_OPTIONS` (an existing value still wins, so the size stays overridable).
8 GB is sized against CI's 16 GB runner — about 3 GB above the observed peak —
rather than against today's number, so the gate does not need re-tuning the next
time a package lands.

### 3. Scope: all three trees, including `scripts/**`

With the headroom applied, the honest cost — same conditions, cold, exit codes
captured, `scripts/**`'s own four hits fixed:

| config | user CPU | peak RSS | exit |
| ------ | -------- | -------- | ---- |
| before | 81.0 s | 3.69 GB | 0 |
| + `apps/cli` + `runtime-pi` | 97.2 s | 5.20 GB | 0 |
| + `scripts/**` | 96.3 s | 4.35 GB | 0 |

About +20 % CPU on a **cold** lint for all three trees, and `scripts/**` — the
one that looked expensive, since its tsconfig deliberately pulls
`../apps/api/src/modules/*/index.ts` into a second program — costs nothing
measurable on top of the other two. It earns its place on what it prevents:
`scripts/migration/**` mutates PRODUCTION data, which is the sharpest form of
this block's own first rationale. Warm lint is unchanged (`--cache
--cache-strategy content` rebuilds a program only for files that moved).

Wall clock is deliberately not quoted anywhere above: the machine was running
many parallel jobs and its wall numbers moved ~40 % between identical runs,
while user CPU did not.

## Tests

- `cd apps/cli && TEST_TIER=0 bun test test/download.test.ts` → **10 pass, 0 fail**.
  Added one case: a payload larger than the sink watermark round-trips
  byte-exact with a matching streamed sha256. That is the discriminating test —
  the watermark is the only thing that makes `FileSink.write` ever return a
  promise, so a download smaller than it never exercises the awaited write.
- `TEST_TIER=0 bun test runtime-pi/sidecar/test/integration-mitm-listener.test.ts
  runtime-pi/sidecar/test/integration-mitm-body-cap.test.ts` → **18 pass, 0 fail**
- `TEST_TIER=0 bun test runtime-pi/test/provision.test.ts` → **22 pass, 0 fail**
- `bun test scripts/test/migration-0010-ee-tables-into-platform-db.test.ts` on
  real Postgres (via the shared lock) → **7 pass, 0 fail**
- Cold `bun run lint`, no external `NODE_OPTIONS` → **exit 0**, zero heap-limit
  lines (was 5 errors + an OOM)
- `bunx tsc --noEmit` on `apps/cli`, `runtime-pi`, `runtime-pi/sidecar`,
  `scripts` → clean
- `bunx prettier --check` on every touched file → clean

No regression test for the sidecar `.catch()`: the only reachable trigger today
is a throwing telemetry sink (`resolveAndCheckHost` swallows resolver throws by
design — `packages/afps-shared/src/ssrf-dns.ts:83-91`), and a test built around
injecting one would assert a contrived seam rather than a real failure. The
issue rated this hit "PLAUSIBLE, low" for the same reason. The guard is one line
and the failure it prevents is process-fatal, so it ships regardless.

## Notes for the orchestrator

- **No migration, no env var, no OpenAPI change.** Nothing to order at deploy.
- **This touches `scripts/lint.ts`, the gate every branch runs through.** The
  change only raises the eslint child's heap ceiling, so it is strictly more
  permissive — but it is a shared file, so it is worth knowing it is in here.
  Without it the config change in this PR cannot pass its own gate.
- **Merge overlap with #1347**: both touch `eslint.config.mjs`. #1347 works in
  the `no-restricted-imports` blocks around lines 530-640; this edit is confined
  to the type-aware block at ~793+ (its comment, and its `files` array which is
  now multi-line). No textual conflict expected.
- **Overlap with the CLI chain (#1320…#1364)**: `apps/cli/src/lib/download.ts`
  and `apps/cli/test/download.test.ts` only, and minimally — one constant, one
  `writer()` call, one `await`, one added test.
- **Watch `scripts/test/lint.test.ts` on the consolidated branch.** Its slow
  case ("fails on a warning that fires, however few") is bounded by a full
  **cold** whole-repo lint against a 300 s ceiling, and its own comment records
  CI already blowing past 120 s once. Cold lint is now ~20 % more CPU, so that
  case moves closer to its ceiling. Its comment says the ceiling "exists to
  catch a HANG, not to bound a known cost", so raising it in step is the
  sanctioned move if CI trips it; I did not pre-emptively raise it because this
  box (many parallel jobs, wall times swinging 40 %) cannot produce a
  representative CI number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
